### PR TITLE
fix: correct file name for DLL on Windows

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -18,7 +18,7 @@ func LoadLibrary(path string) (ffi.Lib, error) {
 	case "linux", "freebsd":
 		filename = filepath.Join(path, "libmtmd.so")
 	case "windows":
-		filename = filepath.Join(path, "libmtmd.dll")
+		filename = filepath.Join(path, "mtmd.dll")
 	case "darwin":
 		filename = filepath.Join(path, "libmtmd.dylib")
 	}


### PR DESCRIPTION
This PR corrects the file name for DLL on Windows.