### PR TITLE
Fix critical sampler bugs

### DIFF
--- a/pkg/llama/sampling.go
+++ b/pkg/llama/sampling.go
@@ -158,7 +158,7 @@ func loadSamplingFuncs(lib ffi.Lib) error {
 		return err
 	}
 
-	if samplerInitMinPFunc, err = lib.Prep("llama_sampler_init_top_p", &ffi.TypePointer, &ffi.TypeFloat, &ffi.TypeUint32); err != nil {
+	if samplerInitMinPFunc, err = lib.Prep("llama_sampler_init_min_p", &ffi.TypePointer, &ffi.TypeFloat, &ffi.TypeUint32); err != nil {
 		return err
 	}
 
@@ -241,7 +241,7 @@ func SamplerInitPenalties(lastN int32, repeat float32, freq float32, present flo
 func SamplerInitDry(vocab Vocab, nCtxTrain int32, multiplier float32, base float32, allowedLength int32, penaltyLast int32,
 	seqBreakers **byte, numBreakers uint32) Sampler {
 	var p Sampler
-	samplerInitDryFunc.Call(unsafe.Pointer(&p), unsafe.Pointer(&nCtxTrain), unsafe.Pointer(&multiplier), unsafe.Pointer(&base), unsafe.Pointer(&allowedLength), unsafe.Pointer(&penaltyLast),
+	samplerInitDryFunc.Call(unsafe.Pointer(&p), unsafe.Pointer(&vocab), unsafe.Pointer(&nCtxTrain), unsafe.Pointer(&multiplier), unsafe.Pointer(&base), unsafe.Pointer(&allowedLength), unsafe.Pointer(&penaltyLast),
 		unsafe.Pointer(seqBreakers), unsafe.Pointer(&numBreakers))
 
 	return p
@@ -355,7 +355,7 @@ func NewSampler(model Model, samplers []SamplerType) Sampler {
 	bias := SamplerInitLogitBias(nTokens, int32(len(logitBiasEOG)), unsafe.SliceData(logitBiasEOG))
 	SamplerChainAdd(sampler, bias)
 
-	for samplerType := range samplers {
+	for _, samplerType := range samplers {
 		switch samplerType {
 		case SamplerTypeDry:
 			seqBreakers := []string{"\n", ":", "\"", "*"}


### PR DESCRIPTION
## Summary
- Fix MinP sampler initialization to call correct llama.cpp function
- Fix NewSampler loop to properly iterate over sampler type values
- Fix SamplerInitDry to include missing vocab parameter in FFI call

## Details

### Bug 1: Wrong function name for MinP sampler
The `samplerInitMinPFunc` was calling `llama_sampler_init_top_p` instead of `llama_sampler_init_min_p`, causing MinP sampler to behave identically to TopP sampler.

### Bug 2: Incorrect loop iteration
`NewSampler` was using `for samplerType := range samplers` which iterates over indices (0, 1, 2...) instead of the actual `SamplerType` values. This caused the wrong samplers to be added to the chain.

### Bug 3: Missing vocab parameter
`SamplerInitDry` was missing the first `vocab` parameter in its FFI call, causing potential crashes or undefined behavior when the DRY sampler is used.

## Test plan
- [x] Code compiles successfully
- [x] No new vet warnings
- [ ] Manual testing with DRY sampler
- [ ] Manual testing with MinP sampler