### PR TITLE
Improve error handling and buffer safety in vocab functions

### DIFF
--- a/pkg/llama/vocab.go
+++ b/pkg/llama/vocab.go
@@ -135,9 +135,12 @@ func TokenToPiece(vocab Vocab, token Token, buf []byte, lstrip int32, special bo
 	tokenToPieceFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&vocab), &token, unsafe.Pointer(&b),
 		&bLen, &lstrip, &special)
 
-	copy(buf, piece)
+	resLen := int32(result)
+	if resLen > 0 && resLen <= int32(len(piece)) {
+		copy(buf, piece[:resLen])
+	}
 
-	return int32(result)
+	return resLen
 }
 
 func Tokenize(vocab Vocab, text string, tokens []Token, addSpecial bool, parseSpecial bool) int32 {
@@ -151,6 +154,5 @@ func Tokenize(vocab Vocab, text string, tokens []Token, addSpecial bool, parseSp
 	tokenizeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&vocab), unsafe.Pointer(&txt), &txtLen,
 		unsafe.Pointer(&toks), &nTokensMax, &addSpecial, &parseSpecial)
 
-	// for whatever reason, llama.cpp returns a negative number.
-	return -int32(result)
+	return int32(result)
 }


### PR DESCRIPTION
## Summary
- Fix Tokenize return value sign convention
- Add bounds checking to TokenToPiece to prevent buffer overflow

## Details

### Bug: Incorrect Tokenize return value
The comment claimed llama.cpp returns a negative number, but this is incorrect. The llama.cpp tokenize function returns:
- Positive value: number of tokens successfully tokenized
- Negative value: error condition

The code was negating the result, which would turn errors into positive numbers and success counts into negative numbers. This fix removes the negation to match llama.cpp's actual behavior.

### Improvement: Buffer overflow prevention in TokenToPiece
Added bounds checking before copying data to the output buffer. Now only copies data if:
1. Result length is positive
2. Result length doesn't exceed buffer size

This prevents potential panics from out-of-bounds slice access.

## Test plan
- [x] Code compiles successfully
- [x] No new vet warnings
- [ ] Manual testing with tokenization