### PR TITLE
Use command-line flags in examples

### DIFF
--- a/examples/describe/describe.go
+++ b/examples/describe/describe.go
@@ -9,6 +9,11 @@ import (
 	"github.com/hybridgroup/yzma/pkg/mtmd"
 )
 
+const (
+	defaultContextSize = 4096
+	defaultBatchSize   = 2048
+)
+
 func describe(tmpFile string) {
 	llama.Init()
 	defer llama.BackendFree()
@@ -20,8 +25,8 @@ func describe(tmpFile string) {
 	defer llama.ModelFree(model)
 
 	ctxParams := llama.ContextDefaultParams()
-	ctxParams.NCtx = 4096
-	ctxParams.NBatch = 2048
+	ctxParams.NCtx = defaultContextSize
+	ctxParams.NBatch = defaultBatchSize
 
 	lctx := llama.InitFromModel(model, ctxParams)
 	defer llama.Free(lctx)


### PR DESCRIPTION
## Summary
- VLM example now uses temperature, topK, topP, minP, contextSize, batchSize, and predictSize flags
- Add named constants for magic numbers in describe example

## Details

### VLM Example Improvements
The VLM example defined several command-line flags but never used them:
- `temperature`, `topK`, `topP`, `minP` for sampling control
- `contextSize`, `batchSize` for model configuration
- `predictSize` for output length control

This PR replaces the default sampler with a custom sampler chain that respects these flags, giving users control over model behavior.

### Describe Example Improvements
Replaced hardcoded magic numbers (4096, 2048) with named constants for better code maintainability.

## Test plan
- [x] Code compiles successfully
- [x] No new vet warnings
- [ ] Manual testing with various flag combinations