### PR TITLE
Add documentation and validation improvements

### DIFF
--- a/pkg/llama/chat.go
+++ b/pkg/llama/chat.go
@@ -39,6 +39,10 @@ func NewChatMessage(role, content string) ChatMessage {
 // ChatApplyTemplate applies a chat template to a slice of [ChatMessage], Set addAssistantPrompt to true to generate the
 // assistant prompt, for example on the first message.
 func ChatApplyTemplate(template string, chat []ChatMessage, addAssistantPrompt bool, buf []byte) int32 {
+	if len(chat) == 0 {
+		return 0
+	}
+
 	tmpl, _ := utils.BytePtrFromString(template)
 
 	c := unsafe.Pointer(&chat[0])

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -153,6 +153,7 @@ func ModelDecoderStartToken(model Model) Token {
 	return Token(result)
 }
 
+// ModelNCtxTrain returns the context size used during training for the Model.
 func ModelNCtxTrain(model Model) int32 {
 	var result ffi.Arg
 	modelNCtxTrainFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&model))

--- a/pkg/llama/sampling.go
+++ b/pkg/llama/sampling.go
@@ -397,7 +397,8 @@ func NewSampler(model Model, samplers []SamplerType) Sampler {
 			SamplerChainAdd(sampler, xtc)
 
 		case SamplerTypeInfill:
-			// TODO: add implementation
+			// Infill sampler not yet implemented in llama.cpp bindings
+			// See: https://github.com/ggml-org/llama.cpp/blob/master/include/llama.h
 
 		case SamplerTypePenalties:
 			penalties := SamplerInitPenalties(64, 1.0, 0, 0)


### PR DESCRIPTION
## Summary
- Add missing Go doc comment for ModelNCtxTrain
- Add validation to ChatApplyTemplate to prevent panic
- Improve SamplerTypeInfill documentation

## Details

### Documentation
Added Go doc comment for `ModelNCtxTrain` function explaining it returns the context size used during model training.

### Safety Improvement
Added validation in `ChatApplyTemplate` to check for empty chat slice before accessing `chat[0]`. Returns 0 immediately if chat is empty, preventing potential panic.

### Better TODO Comment
Replaced generic TODO in SamplerTypeInfill case with more informative comment explaining the feature is not yet implemented in the llama.cpp bindings, with reference link.

## Test plan
- [x] Code compiles successfully
- [x] No new vet warnings
- [ ] Manual testing with empty chat slice