### PR TITLE
embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lib/
 *.so
 *.dylib
 *.dll
+/models

--- a/examples/embeddings/main.go
+++ b/examples/embeddings/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v", err)
+		os.Exit(1)
+	}
+}
+
+const usage = `
+  -model string
+    	path to the GGUF model
+  -prompt string
+    	prompt to embed
+  -pooling string
+    	pooling type for embeddings (mean, cls, none)
+`
+
+func run() error {
+	var modelFlag, prompt, pooling string
+	flag.StringVar(&modelFlag, "model", "", "path to the GGUF model")
+	flag.StringVar(&prompt, "prompt", "", "prompt to embed")
+	flag.StringVar(&pooling, "pooling", "mean", "pooling type for embeddings (mean, cls, none)")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: embeddings %s\n", usage)
+	}
+	flag.Parse()
+	if modelFlag == "" || prompt == "" {
+		flag.Usage()
+		return nil
+	}
+	var poolingType llama.PoolingType
+	switch pooling {
+	case "mean":
+		poolingType = llama.PoolingTypeMean
+	case "cls":
+		poolingType = llama.PoolingTypeCLS
+	case "rank":
+		poolingType = llama.PoolingTypeRank
+	case "last":
+		poolingType = llama.PoolingTypeLast
+	case "none":
+		poolingType = llama.PoolingTypeNone
+	default:
+		poolingType = llama.PoolingTypeUnspecified
+	}
+
+	// load library and init
+	llama.Load(os.Getenv("YZMA_LIB"))
+	llama.Init()
+	defer llama.BackendFree()
+
+	// load model
+	model := llama.ModelLoadFromFile(modelFlag, llama.ModelDefaultParams())
+	defer llama.ModelFree(model)
+
+	// create context
+	params := llama.ContextDefaultParams()
+	params.PoolingType = poolingType
+	params.Embeddings = 1
+	lctx := llama.InitFromModel(model, params)
+	defer llama.Free(lctx)
+
+	// tokenize prompt
+	vocab := llama.ModelGetVocab(model)
+	count := llama.Tokenize(vocab, prompt, nil, true, true)
+	tokens := make([]llama.Token, count)
+	llama.Tokenize(vocab, prompt, tokens, true, true)
+
+	// create batch and decode
+	batch := llama.BatchGetOne(tokens)
+	llama.Decode(lctx, batch)
+
+	// get embeddings
+	nEmbd := llama.ModelNEmbd(model)
+	vec := llama.GetEmbeddingsSeq(lctx, 0, nEmbd)
+
+	// normalize embeddings
+	var sum float64
+	for _, v := range vec {
+		sum += float64(v * v)
+	}
+	sum = math.Sqrt(sum)
+	norm := float32(1.0 / sum)
+
+	var b strings.Builder
+	for i, v := range vec {
+		if i > 0 {
+			b.WriteString(" ")
+		}
+		b.WriteString(fmt.Sprintf("%f", v*norm))
+	}
+	fmt.Println(b.String())
+
+	return nil
+}

--- a/pkg/llama/context.go
+++ b/pkg/llama/context.go
@@ -6,17 +6,22 @@ import (
 	"github.com/jupiterrider/ffi"
 )
 
-var (
-	FFITypeContextParams = ffi.NewType(&ffi.TypeUint32, &ffi.TypeUint32, &ffi.TypeUint32, &ffi.TypeUint32,
-		&ffi.TypeSint32, &ffi.TypeSint32,
-		&ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypeSint32,
-		&ffi.TypeFloat, &ffi.TypeFloat, &ffi.TypeFloat, &ffi.TypeFloat, &ffi.TypeFloat, &ffi.TypeFloat,
-		&ffi.TypeUint32, &ffi.TypeFloat,
-		&ffi.TypePointer, &ffi.TypePointer,
-		&ffi.TypeSint32, &ffi.TypeSint32,
-		&ffi.TypePointer, &ffi.TypePointer,
-		&ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8)
-)
+var FFITypeContextParams = ffi.NewType(
+	&ffi.TypeUint32, &ffi.TypeUint32,
+	&ffi.TypeUint32, &ffi.TypeUint32,
+	&ffi.TypeSint32, &ffi.TypeSint32,
+	&ffi.TypeSint32, &ffi.TypeSint32,
+	&ffi.TypeSint32, &ffi.TypeSint32,
+	&ffi.TypeFloat, &ffi.TypeFloat,
+	&ffi.TypeFloat, &ffi.TypeFloat,
+	&ffi.TypeFloat, &ffi.TypeFloat,
+	&ffi.TypeUint32, &ffi.TypeFloat,
+	&ffi.TypePointer, &ffi.TypePointer,
+	&ffi.TypeSint32, &ffi.TypeSint32,
+	&ffi.TypePointer, &ffi.TypePointer,
+	&ffi.TypeUint8, &ffi.TypeUint8,
+	&ffi.TypeUint8, &ffi.TypeUint8,
+	&ffi.TypeUint8, &ffi.TypeUint8)
 
 var (
 	// LLAMA_API struct llama_context_params        llama_context_default_params(void);
@@ -220,7 +225,7 @@ func GetEmbeddingsIth(ctx Context, i int32) []float32 {
 	var result ffi.Arg
 	getEmbeddingsIthFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), &i)
 
-	return unsafe.Slice(((*float32)(unsafe.Pointer(&result))), i)
+	return unsafe.Slice(((*float32)(unsafe.Pointer(uintptr(result)))), i)
 }
 
 // GetEmbeddingsSeq gets the embeddings for this sequence ID.
@@ -228,5 +233,5 @@ func GetEmbeddingsSeq(ctx Context, seqID SeqId, i int32) []float32 {
 	var result ffi.Arg
 	getEmbeddingsSeqFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), &seqID)
 
-	return unsafe.Slice(((*float32)(unsafe.Pointer(&result))), i)
+	return unsafe.Slice(((*float32)(unsafe.Pointer(uintptr(result)))), i)
 }

--- a/pkg/llama/helpers_test.go
+++ b/pkg/llama/helpers_test.go
@@ -14,7 +14,7 @@ func testSetup(t *testing.T) {
 	Init()
 }
 
-func testCleanup(t *testing.T) {
+func testCleanup(_ *testing.T) {
 	BackendFree()
 }
 

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -185,10 +185,12 @@ const (
 )
 
 // Opaque types (represented as pointers)
-type Model uintptr
-type Context uintptr
-type Vocab uintptr
-type AdapterLora uintptr
+type (
+	Model       uintptr
+	Context     uintptr
+	Vocab       uintptr
+	AdapterLora uintptr
+)
 
 // Structs
 type TokenData struct {

--- a/pkg/llama/loader.go
+++ b/pkg/llama/loader.go
@@ -71,5 +71,5 @@ func Init() {
 }
 
 func loadError(name string, err error) error {
-	return fmt.Errorf("could not load '': %w", err)
+	return fmt.Errorf("could not load %q: %w", name, err)
 }

--- a/pkg/llama/vocab.go
+++ b/pkg/llama/vocab.go
@@ -69,12 +69,12 @@ var (
 	vocabNTokensFunc ffi.Fun
 
 	// LLAMA_API int32_t llama_token_to_piece(
-	// 		const struct llama_vocab * vocab,
-	// 					llama_token   token,
-	// 							char * buf,
-	// 						int32_t   length,
-	// 						int32_t   lstrip,
-	// 							bool   special);
+	//              const struct llama_vocab * vocab,
+	//                           llama_token   token,
+	//                                  char * buf,
+	//                               int32_t   length,
+	//                               int32_t   lstrip,
+	//                               bool   special);
 	tokenToPieceFunc ffi.Fun
 
 	// LLAMA_API int32_t llama_tokenize(
@@ -173,13 +173,11 @@ func loadVocabFuncs(lib ffi.Lib) error {
 
 	if tokenToPieceFunc, err = lib.Prep("llama_token_to_piece", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypeSint32,
 		&ffi.TypePointer, &ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypeUint8); err != nil {
-
 		return loadError("llama_token_to_piece", err)
 	}
 
 	if tokenizeFunc, err = lib.Prep("llama_tokenize", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeSint32,
 		&ffi.TypePointer, &ffi.TypeSint32, &ffi.TypeUint8, &ffi.TypeUint8); err != nil {
-
 		return loadError("llama_tokenize", err)
 	}
 
@@ -192,12 +190,14 @@ func ModelGetVocab(model Model) Vocab {
 
 	return vocab
 }
+
 func VocabBOS(vocab Vocab) Token {
 	var token ffi.Arg
 	vocabBOSFunc.Call(unsafe.Pointer(&token), unsafe.Pointer(&vocab))
 
 	return Token(token)
 }
+
 func VocabEOS(vocab Vocab) Token {
 	var token ffi.Arg
 	vocabEOSFunc.Call(unsafe.Pointer(&token), unsafe.Pointer(&vocab))
@@ -328,13 +328,15 @@ func Tokenize(vocab Vocab, text string, tokens []Token, addSpecial bool, parseSp
 	txt, _ := utils.BytePtrFromString(text)
 	txtLen := int32(len(text))
 
-	toks := unsafe.SliceData(tokens)
-	nTokensMax := len(tokens)
+	var toks *Token
+	if len(tokens) > 0 {
+		toks = unsafe.SliceData(tokens)
+	}
+	nTokensMax := int32(len(tokens))
 
 	var result ffi.Arg
 	tokenizeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&vocab), unsafe.Pointer(&txt), &txtLen,
 		unsafe.Pointer(&toks), &nTokensMax, &addSpecial, &parseSpecial)
 
-	// for whatever reason, llama.cpp returns a negative number.
 	return -int32(result)
 }

--- a/pkg/llama/vocab_test.go
+++ b/pkg/llama/vocab_test.go
@@ -18,7 +18,7 @@ func TestVocabBOS(t *testing.T) {
 
 	bos := VocabBOS(vocab)
 	if bos == TokenNull {
-		t.Fatal("VocabBOS returned TokenNull")
+		t.Skip("skipping test, model does not have BOS token")
 	}
 }
 
@@ -36,7 +36,7 @@ func TestVocabEOS(t *testing.T) {
 
 	eos := VocabEOS(vocab)
 	if eos == TokenNull {
-		t.Fatal("VocabEOS returned TokenNull")
+		t.Skip("skipping test, model does not have EOS token")
 	}
 }
 
@@ -54,13 +54,11 @@ func TestVocabEOT(t *testing.T) {
 
 	eot := VocabEOT(vocab)
 	if eot == TokenNull {
-		t.Fatal("VocabEOT returned TokenNull")
+		t.Skip("skipping test, model does not have EOT token")
 	}
 }
 
 func TestVocabSEP(t *testing.T) {
-	t.Skip("TODO: test this function for model with vocab that has this")
-
 	modelFile := testModelFileName(t)
 
 	testSetup(t)
@@ -74,7 +72,7 @@ func TestVocabSEP(t *testing.T) {
 
 	sep := VocabSEP(vocab)
 	if sep == TokenNull {
-		t.Fatal("VocabSEP returned TokenNull")
+		t.Skip("skipping test, model does not have SEP token")
 	}
 }
 
@@ -97,8 +95,6 @@ func TestVocabNL(t *testing.T) {
 }
 
 func TestVocabPAD(t *testing.T) {
-	t.Skip("TODO: test this function for model with vocab that has this")
-
 	modelFile := testModelFileName(t)
 
 	testSetup(t)
@@ -112,13 +108,11 @@ func TestVocabPAD(t *testing.T) {
 
 	pad := VocabPAD(vocab)
 	if pad == TokenNull {
-		t.Fatal("VocabPAD returned TokenNull")
+		t.Skip("skipping test, model does not have PAD token")
 	}
 }
 
 func TestVocabMASK(t *testing.T) {
-	t.Skip("TODO: test this function for model with vocab that has this")
-
 	modelFile := testModelFileName(t)
 
 	testSetup(t)
@@ -132,7 +126,7 @@ func TestVocabMASK(t *testing.T) {
 
 	mask := VocabMASK(vocab)
 	if mask == TokenNull {
-		t.Fatal("VocabMASK returned TokenNull")
+		t.Skip("skipping test, model does not have MASK token")
 	}
 }
 
@@ -171,8 +165,6 @@ func TestVocabGetAddEOS(t *testing.T) {
 }
 
 func TestVocabGetAddSEP(t *testing.T) {
-	t.Skip("TODO: test this function for model with vocab that has this")
-
 	modelFile := testModelFileName(t)
 
 	testSetup(t)
@@ -184,14 +176,17 @@ func TestVocabGetAddSEP(t *testing.T) {
 
 	vocab := ModelGetVocab(model)
 
+	sep := VocabSEP(vocab)
+	if sep == TokenNull {
+		t.Skip("skipping test, model does not have SEP token")
+	}
+
 	addSEP := VocabGetAddSEP(vocab)
 	// No specific expected value, just ensure it doesn't fail
 	_ = addSEP
 }
 
 func TestVocabFIMPre(t *testing.T) {
-	t.Skip("TODO: test this function for model with vocab that has this")
-
 	modelFile := testModelFileName(t)
 
 	testSetup(t)
@@ -205,13 +200,11 @@ func TestVocabFIMPre(t *testing.T) {
 
 	fimPre := VocabFIMPre(vocab)
 	if fimPre == TokenNull {
-		t.Fatal("VocabFIMPre returned TokenNull")
+		t.Skip("skipping test, model does not have FIMPre token")
 	}
 }
 
 func TestVocabFIMSuf(t *testing.T) {
-	t.Skip("TODO: test this function for model with vocab that has this")
-
 	modelFile := testModelFileName(t)
 
 	testSetup(t)
@@ -225,13 +218,11 @@ func TestVocabFIMSuf(t *testing.T) {
 
 	fimSuf := VocabFIMSuf(vocab)
 	if fimSuf == TokenNull {
-		t.Fatal("VocabFIMSuf returned TokenNull")
+		t.Skip("skipping test, model does not have FIMSuf token")
 	}
 }
 
 func TestVocabFIMMid(t *testing.T) {
-	t.Skip("TODO: test this function for model with vocab that has this")
-
 	modelFile := testModelFileName(t)
 
 	testSetup(t)
@@ -245,13 +236,11 @@ func TestVocabFIMMid(t *testing.T) {
 
 	fimMid := VocabFIMMid(vocab)
 	if fimMid == TokenNull {
-		t.Fatal("VocabFIMMid returned TokenNull")
+		t.Skip("skipping test, model does not have FIMMid token")
 	}
 }
 
 func TestVocabFIMPad(t *testing.T) {
-	t.Skip("TODO: test this function for model with vocab that has this")
-
 	modelFile := testModelFileName(t)
 
 	testSetup(t)
@@ -265,7 +254,7 @@ func TestVocabFIMPad(t *testing.T) {
 
 	fimPad := VocabFIMPad(vocab)
 	if fimPad == TokenNull {
-		t.Fatal("VocabFIMPad returned TokenNull")
+		t.Skip("skipping test, model does not have FIMPad token")
 	}
 }
 
@@ -283,13 +272,11 @@ func TestVocabFIMRep(t *testing.T) {
 
 	fimRep := VocabFIMRep(vocab)
 	if fimRep == TokenNull {
-		t.Fatal("VocabFIMRep returned TokenNull")
+		t.Skip("skipping test, model does not have FIMRep token")
 	}
 }
 
 func TestVocabFIMSep(t *testing.T) {
-	t.Skip("TODO: test this function for model with vocab that has this")
-
 	modelFile := testModelFileName(t)
 
 	testSetup(t)
@@ -303,6 +290,6 @@ func TestVocabFIMSep(t *testing.T) {
 
 	fimSep := VocabFIMSep(vocab)
 	if fimSep == TokenNull {
-		t.Fatal("VocabFIMSep returned TokenNull")
+		t.Skip("skipping test, model does not have FIMSep token")
 	}
 }

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jupiterrider/ffi"
 )
 
-// The path can be an empty string to use the location as set by the YZMA_LIB env variable.
+// LoadLibrary The path can be an empty string to use the location as set by the YZMA_LIB env variable.
 // The lib should be the "short name" for the library, for example:
 // gguf, llama, mtmd
 func LoadLibrary(path, lib string) (ffi.Lib, error) {


### PR DESCRIPTION
added example with vector normalization

I confirmed the exact same results as [llama-embedding](https://github.com/ggml-org/llama.cpp/tree/master/examples/embedding)

```sh
llama-embedding -m ./models/SmolLM-135M.Q2_K.gguf --pooling mean -p "Hello World" 2>/dev/null

go run ./examples/embeddings/ -model ./models/SmolLM-135M.Q2_K.gguf -prompt "Hello World" 2>/dev/null
```

I couldn't find a model that satisfies all the vocab_test.
I tried with

1) [codellama-7b-instruct.Q2_K.gguf](https://huggingface.co/TheBloke/CodeLlama-7B-Instruct-GGUF)

```
YZMA_LIB=./lib YZMA_TEST_MODEL=.models/codellama-7b-instruct.Q2_K.gguf go test -v ./... | grep skip
    vocab_test.go:75: skipping test, model does not have SEP token
    vocab_test.go:111: skipping test, model does not have PAD token
    vocab_test.go:129: skipping test, model does not have MASK token
    vocab_test.go:181: skipping test, model does not have SEP token
    vocab_test.go:257: skipping test, model does not have FIMPad token
    vocab_test.go:275: skipping test, model does not have FIMRep token
    vocab_test.go:293: skipping test, model does not have FIMSep token
```

2) [SmolLM-135M.Q2_K.gguf](https://huggingface.co/QuantFactory/SmolLM-135M-GGUF)

```
YZMA_LIB=./lib YZMA_TEST_MODEL=.models/SmolLM-135M.Q2_K.gguf go test -v ./... | grep skip
    vocab_test.go:57: skipping test, model does not have EOT token
    vocab_test.go:75: skipping test, model does not have SEP token
    vocab_test.go:111: skipping test, model does not have PAD token
    vocab_test.go:129: skipping test, model does not have MASK token
    vocab_test.go:181: skipping test, model does not have SEP token
    vocab_test.go:257: skipping test, model does not have FIMPad token
    vocab_test.go:275: skipping test, model does not have FIMRep token
    vocab_test.go:293: skipping test, model does not have FIMSep token
```

3) [embeddinggemma-300M-F32.gguf](https://huggingface.co/unsloth/embeddinggemma-300m-GGUF)

```
YZMA_LIB=./lib YZMA_TEST_MODEL=./models/embeddinggemma-300M-F32.gguf go test -v ./... | grep skip
    vocab_test.go:75: skipping test, model does not have SEP token
    vocab_test.go:129: skipping test, model does not have MASK token
    vocab_test.go:181: skipping test, model does not have SEP token
    vocab_test.go:203: skipping test, model does not have FIMPre token
    vocab_test.go:221: skipping test, model does not have FIMSuf token
    vocab_test.go:239: skipping test, model does not have FIMMid token
    vocab_test.go:257: skipping test, model does not have FIMPad token
    vocab_test.go:275: skipping test, model does not have FIMRep token
    vocab_test.go:293: skipping test, model does not have FIMSep token
```