### PR TITLE
ci: switch to use 'stable' version of Go for testing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.1'
+          go-version: 'stable'
       - name: Download llama.cpp
         uses: robinraju/release-downloader@v1
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.1'
+          go-version: 'stable'
       - name: Download llama.cpp
         uses: robinraju/release-downloader@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.1'
+          go-version: 'stable'
       - name: Install vcredist
         shell: pwsh
         run: |


### PR DESCRIPTION
This PR switches the GH actions to use the 'stable' version of Go for testing.