### PR TITLE
logs: use purego callback for simplicity

### DIFF
--- a/pkg/llama/logs.go
+++ b/pkg/llama/logs.go
@@ -1,21 +1,20 @@
 package llama
 
 import (
-	"runtime"
 	"unsafe"
 
+	"github.com/ebitengine/purego"
 	"github.com/jupiterrider/ffi"
 )
 
-type LogCallback *ffi.Closure
+type LogCallback uintptr // *ffi.Closure
 
 var (
 	// LLAMA_API void llama_log_set(ggml_log_callback log_callback, void * user_data);
-	logSet     func(cb LogCallback, data uintptr)
 	logSetFunc ffi.Fun
 
 	// static void llama_log_callback_null(ggml_log_level level, const char * text, void * user_data) { (void) level; (void) text; (void) user_data; }
-	logSilent *ffi.Closure
+	// logSilent uintptr
 )
 
 func loadLogFuncs(lib ffi.Lib) error {
@@ -24,43 +23,20 @@ func loadLogFuncs(lib ffi.Lib) error {
 	if logSetFunc, err = lib.Prep("llama_log_set", &ffi.TypeVoid, &ffi.TypePointer, &ffi.TypePointer); err != nil {
 		return loadError("llama_log_set", err)
 	}
-	logSet = func(cb LogCallback, data uintptr) {
-		logSetFunc.Call(nil, unsafe.Pointer(&cb), unsafe.Pointer(&data))
-	}
-
-	var callback unsafe.Pointer
-	logSilent = ffi.ClosureAlloc(unsafe.Sizeof(ffi.Closure{}), &callback)
-
-	var cifCallback ffi.Cif
-	if status := ffi.PrepCif(&cifCallback, ffi.DefaultAbi, 0, &ffi.TypeVoid, &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer); status != ffi.OK {
-		panic(status)
-	}
-
-	fn := ffi.NewCallback(func(cif *ffi.Cif, ret unsafe.Pointer, args *unsafe.Pointer, userData unsafe.Pointer) uintptr {
-		return 0
-	})
-
-	if logSilent != nil {
-		if status := ffi.PrepClosureLoc(logSilent, &cifCallback, fn, nil, callback); status != ffi.OK {
-			panic(status)
-		}
-	}
 
 	return nil
 }
 
 // LogSet sets the logging mode. Pass [LogSilent()] to turn logging off. Pass nil to use stdout.
 // Note that if you turn logging off when using the [mtmd] package, you must also set Verbosity = llama.LogLevelContinue.
-func LogSet(cb LogCallback) {
-	// calling LogSet on macOS currently results in a SIGBUS error.
-	// TODO: solve this. For now, you cannot disable logging on macOS.
-	if runtime.GOOS == "darwin" {
-		return
-	}
-	logSet(cb, uintptr(0))
+func LogSet(cb uintptr) {
+	nada := uintptr(0)
+	logSetFunc.Call(nil, unsafe.Pointer(&cb), unsafe.Pointer(&nada))
 }
 
 // LogSilent is a callback function that you can pass into the [LogSet] function to turn logging off.
-func LogSilent() *ffi.Closure {
-	return logSilent
+func LogSilent() uintptr {
+	return purego.NewCallback(func(level int32, text, data uintptr) uintptr {
+		return 0
+	})
 }


### PR DESCRIPTION
This PR is to use `purego` callback for simplicity. Also hopefully works on macOS.