### PR TITLE
feature: add remaining unimplemented llama.cpp context functions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,6 +84,8 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 - [x] `llama_n_ubatch`
 - [x] `llama_perf_context_reset`
 - [x] `llama_pooling_type`
+- [x] `llama_set_causal_attn`
+- [x] `llama_set_embeddings`
 - [x] `llama_set_warmup`
 - [x] `llama_synchronize`
 
@@ -196,8 +198,6 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 - [ ] `llama_opt_param_filter_all`
 - [ ] `llama_rm_adapter_lora`
 - [ ] `llama_set_adapter_lora`
-- [ ] `llama_set_causal_attn`
-- [ ] `llama_set_embeddings`
 - [ ] `llama_state_get_data`
 - [ ] `llama_state_get_size`
 - [ ] `llama_state_load_file`

--- a/pkg/llama/context.go
+++ b/pkg/llama/context.go
@@ -87,6 +87,12 @@ var (
 
 	// LLAMA_API const struct llama_model * llama_get_model(const struct llama_context * ctx);
 	getModelFunc ffi.Fun
+
+	// LLAMA_API void llama_set_embeddings(struct llama_context * ctx, bool embeddings);
+	setEmbeddingsFunc ffi.Fun
+
+	// LLAMA_API void llama_set_causal_attn(struct llama_context * ctx, bool causal_attn);
+	setCausalAttnFunc ffi.Fun
 )
 
 func loadContextFuncs(lib ffi.Lib) error {
@@ -158,6 +164,14 @@ func loadContextFuncs(lib ffi.Lib) error {
 
 	if getModelFunc, err = lib.Prep("llama_get_model", &ffi.TypePointer, &ffi.TypePointer); err != nil {
 		return loadError("llama_get_model", err)
+	}
+
+	if setEmbeddingsFunc, err = lib.Prep("llama_set_embeddings", &ffi.TypeVoid, &ffi.TypePointer, &ffi.TypeUint8); err != nil {
+		return loadError("llama_set_embeddings", err)
+	}
+
+	if setCausalAttnFunc, err = lib.Prep("llama_set_causal_attn", &ffi.TypeVoid, &ffi.TypePointer, &ffi.TypeUint8); err != nil {
+		return loadError("llama_set_causal_attn", err)
 	}
 
 	return nil
@@ -294,4 +308,14 @@ func GetModel(ctx Context) Model {
 	getModelFunc.Call(unsafe.Pointer(&model), unsafe.Pointer(&ctx))
 
 	return model
+}
+
+// SetEmbeddings sets whether the context outputs embeddings or not.
+func SetEmbeddings(ctx Context, embeddings bool) {
+	setEmbeddingsFunc.Call(nil, unsafe.Pointer(&ctx), &embeddings)
+}
+
+// SetCausalAttn sets whether to use causal attention or not.
+func SetCausalAttn(ctx Context, causalAttn bool) {
+	setCausalAttnFunc.Call(nil, unsafe.Pointer(&ctx), &causalAttn)
 }

--- a/pkg/llama/context_test.go
+++ b/pkg/llama/context_test.go
@@ -257,3 +257,45 @@ func TestGetEmbeddingsSeq(t *testing.T) {
 	}
 	t.Logf("GetEmbeddingsSeq returned %d embeddings", len(embeddings))
 }
+
+func TestSetEmbeddings(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	defer ModelFree(model)
+
+	ctx := InitFromModel(model, ContextDefaultParams())
+	defer Free(ctx)
+
+	// Enable embeddings
+	SetEmbeddings(ctx, true)
+	t.Log("SetEmbeddings successfully set embeddings to true")
+
+	// Disable embeddings
+	SetEmbeddings(ctx, false)
+	t.Log("SetEmbeddings successfully set embeddings to false")
+}
+
+func TestSetCausalAttn(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	defer ModelFree(model)
+
+	ctx := InitFromModel(model, ContextDefaultParams())
+	defer Free(ctx)
+
+	// Enable causal attention
+	SetCausalAttn(ctx, true)
+	t.Log("SetCausalAttn successfully set causal attention to true")
+
+	// Disable causal attention
+	SetCausalAttn(ctx, false)
+	t.Log("SetCausalAttn successfully set causal attention to false")
+}


### PR DESCRIPTION
This PR adds the remaining unimplemented `llama.cpp` context functions.