### PR TITLE
fix: use the returned length from converting token to piece in the result buffer

### DIFF
--- a/examples/describe/describe.go
+++ b/examples/describe/describe.go
@@ -70,9 +70,9 @@ func describe(tmpFile string) {
 		}
 
 		buf := make([]byte, 128)
-		llama.TokenToPiece(vocab, token, buf, 0, true)
+		l := llama.TokenToPiece(vocab, token, buf, 0, true)
 
-		fmt.Print(string(buf))
+		fmt.Print(string(buf[:l]))
 
 		batch.Token = &token
 		batch.Pos = &n

--- a/examples/vlm/main.go
+++ b/examples/vlm/main.go
@@ -97,9 +97,9 @@ func main() {
 		}
 
 		buf := make([]byte, 128)
-		llama.TokenToPiece(vocab, token, buf, 0, true)
+		l := llama.TokenToPiece(vocab, token, buf, 0, true)
 
-		fmt.Print(string(buf))
+		fmt.Print(string(buf[:l]))
 
 		batch.Token = &token
 		batch.Pos = &n


### PR DESCRIPTION
This PR fixes a bug in a couple of the examples by using the returned length from converting token to piece in the result buffer.

Thanks to @ardan-bkennedy for pointing out the problem.
