### PR TITLE
feature: add implementations for llama.cpp state functions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -132,6 +132,13 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 ### Chat Functions
 - [x] `llama_chat_apply_template`
 
+### State Functions
+- [x] `llama_state_get_data`
+- [x] `llama_state_get_size`
+- [x] `llama_state_load_file`
+- [x] `llama_state_save_file`
+- [x] `llama_state_set_data`
+
 ### `mtmd` Functions
 
 Note that these functions are considered by `llama.cpp` to be experimental, and are subject to change.
@@ -206,10 +213,6 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 - [ ] `llama_opt_param_filter_all`
 - [ ] `llama_rm_adapter_lora`
 - [ ] `llama_set_adapter_lora`
-- [ ] `llama_state_get_data`
-- [ ] `llama_state_get_size`
-- [ ] `llama_state_load_file`
-- [ ] `llama_state_save_file`
 - [ ] `llama_state_seq_get_data_ext`
 - [ ] `llama_state_seq_get_data`
 - [ ] `llama_state_seq_get_size_ext`
@@ -218,7 +221,6 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 - [ ] `llama_state_seq_save_file`
 - [ ] `llama_state_seq_set_data_ext`
 - [ ] `llama_state_seq_set_data`
-- [ ] `llama_state_set_data`
 
 ### `mtmd` Functions still needing wrappers
 

--- a/pkg/llama/loader.go
+++ b/pkg/llama/loader.go
@@ -58,6 +58,10 @@ func Load(path string) error {
 		return err
 	}
 
+	if err := loadStateFuncs(lib); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/llama/state.go
+++ b/pkg/llama/state.go
@@ -1,0 +1,142 @@
+package llama
+
+import (
+	"unsafe"
+
+	"github.com/hybridgroup/yzma/pkg/utils"
+	"github.com/jupiterrider/ffi"
+)
+
+var (
+	// LLAMA_API bool llama_state_save_file(
+	//     struct llama_context * ctx,
+	//     const char * path_session,
+	//     const llama_token * tokens,
+	//     size_t   n_token_count);
+	stateSaveFileFunc ffi.Fun
+
+	// LLAMA_API bool llama_state_load_file(
+	//     struct llama_context * ctx,
+	//               const char * path_session,
+	//              llama_token * tokens_out,
+	//                   size_t   n_token_capacity,
+	//                   size_t * n_token_count_out);
+	stateLoadFileFunc ffi.Fun
+
+	// Returns the *actual* size in bytes of the state
+	// (logits, embedding and memory)
+	// Only use when saving the state, not when restoring it, otherwise the size may be too small.
+	// LLAMA_API size_t llama_state_get_size(struct llama_context * ctx);
+	stateGetSizeFunc ffi.Fun
+
+	// Copies the state to the specified destination address.
+	// Destination needs to have allocated enough memory.
+	// Returns the number of bytes copied
+	// LLAMA_API size_t llama_state_get_data(
+	//         struct llama_context * ctx,
+	//                      uint8_t * dst,
+	//                       size_t   size);
+	stateGetDataFunc ffi.Fun
+
+	// Set the state reading from the specified address
+	// Returns the number of bytes read
+	// LLAMA_API size_t llama_state_set_data(
+	//         struct llama_context * ctx,
+	//                const uint8_t * src,
+	//                       size_t   size);
+	stateSetDataFunc ffi.Fun
+)
+
+func loadStateFuncs(lib ffi.Lib) error {
+	var err error
+
+	if stateSaveFileFunc, err = lib.Prep("llama_state_save_file", &ffi.TypeUint8, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint32); err != nil {
+		return loadError("llama_state_save_file", err)
+	}
+
+	if stateLoadFileFunc, err = lib.Prep("llama_state_load_file", &ffi.TypeUint8, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint32, &ffi.TypePointer); err != nil {
+		return loadError("llama_state_load_file", err)
+	}
+
+	if stateGetSizeFunc, err = lib.Prep("llama_state_get_size", &ffi.TypeUint32, &ffi.TypePointer); err != nil {
+		return loadError("llama_state_get_size", err)
+	}
+
+	if stateGetDataFunc, err = lib.Prep("llama_state_get_data", &ffi.TypeUint32, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint32); err != nil {
+		return loadError("llama_state_get_data", err)
+	}
+
+	if stateSetDataFunc, err = lib.Prep("llama_state_set_data", &ffi.TypeUint32, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint32); err != nil {
+		return loadError("llama_state_set_data", err)
+	}
+
+	return err
+}
+
+// StateSaveFile saves the state to a file and returns true on success.
+func StateSaveFile(ctx Context, path string, tokens []Token) bool {
+	pathPtr, _ := utils.BytePtrFromString(path)
+	var toks *Token
+	if len(tokens) > 0 {
+		toks = unsafe.SliceData(tokens)
+	}
+	tlen := int64(len(tokens))
+
+	var result ffi.Arg
+	stateSaveFileFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), unsafe.Pointer(&pathPtr), unsafe.Pointer(&toks), &tlen)
+	return result.Bool()
+}
+
+// StateLoadFile loads the state from a file and returns true on success.
+// tokensOut should be a slice with capacity nTokenCapacity. nTokenCountOut will be set to the number of tokens loaded.
+func StateLoadFile(ctx Context, path string, tokensOut []Token, nTokenCapacity uint64, nTokenCountOut *uint64) bool {
+	pathPtr, _ := utils.BytePtrFromString(path)
+	var toks *Token
+	if len(tokensOut) > 0 {
+		toks = unsafe.SliceData(tokensOut)
+	}
+	var result ffi.Arg
+	stateLoadFileFunc.Call(
+		unsafe.Pointer(&result),
+		unsafe.Pointer(&ctx),
+		unsafe.Pointer(&pathPtr),
+		unsafe.Pointer(&toks),
+		unsafe.Pointer(&nTokenCapacity),
+		unsafe.Pointer(&nTokenCountOut),
+	)
+	return result.Bool()
+}
+
+// StateGetSize returns the actual size in bytes of the state (logits, embedding and memory).
+// Only use when saving the state, not when restoring it.
+func StateGetSize(ctx Context) uint64 {
+	var result ffi.Arg
+	stateGetSizeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx))
+	return uint64(result)
+}
+
+// StateGetData copies the state to the specified destination address.
+// Returns the number of bytes copied.
+func StateGetData(ctx Context, dst []byte) uint64 {
+	var result ffi.Arg
+	var size int64 = int64(len(dst))
+	var dstPtr *byte
+	if len(dst) > 0 {
+		dstPtr = &dst[0]
+	}
+	stateGetDataFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), unsafe.Pointer(&dstPtr), &size)
+	return uint64(result)
+}
+
+// StateSetData sets the state by reading from the specified address.
+// Returns the number of bytes read.
+func StateSetData(ctx Context, src []byte) uint64 {
+	var result ffi.Arg
+	var size int64 = int64(len(src))
+	var srcPtr *byte
+	if len(src) > 0 {
+		srcPtr = &src[0]
+	}
+	stateSetDataFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), unsafe.Pointer(&srcPtr), &size)
+	return uint64(result)
+}

--- a/pkg/llama/state_test.go
+++ b/pkg/llama/state_test.go
@@ -1,0 +1,177 @@
+package llama
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStateSaveFile(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	defer ModelFree(model)
+
+	ctx := InitFromModel(model, ContextDefaultParams())
+	defer Free(ctx)
+
+	// tokenize prompt
+	prompt := "This is a test"
+	vocab := ModelGetVocab(model)
+	count := Tokenize(vocab, prompt, nil, true, true)
+	tokens := make([]Token, count)
+	Tokenize(vocab, prompt, tokens, true, true)
+
+	// create batch and decode
+	batch := BatchGetOne(tokens)
+	Decode(ctx, batch)
+
+	// Use a temporary file for testing
+	tmp, err := os.CreateTemp("", "test_state_save.bin")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tmpFile := tmp.Name()
+	defer os.Remove(tmpFile)
+	tmp.Close()
+
+	ok := StateSaveFile(ctx, tmpFile, tokens)
+	if !ok {
+		t.Fatal("StateSaveFile failed")
+	}
+
+	// Check if file was created
+	if _, err := os.Stat(tmpFile); err != nil {
+		t.Fatalf("StateSaveFile did not create file: %v", err)
+	}
+
+	t.Logf("StateSaveFile created file: %s", tmpFile)
+}
+
+func TestStateLoadFile(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	defer ModelFree(model)
+
+	ctx := InitFromModel(model, ContextDefaultParams())
+	defer Free(ctx)
+
+	// tokenize prompt and decode, then save state
+	prompt := "This is a test"
+	vocab := ModelGetVocab(model)
+	count := Tokenize(vocab, prompt, nil, true, true)
+	tokens := make([]Token, count)
+	Tokenize(vocab, prompt, tokens, true, true)
+	batch := BatchGetOne(tokens)
+	Decode(ctx, batch)
+
+	tmp, err := os.CreateTemp("", "test_state_load.bin")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tmpFile := tmp.Name()
+	defer os.Remove(tmpFile)
+	tmp.Close()
+
+	ok := StateSaveFile(ctx, tmpFile, tokens)
+	if !ok {
+		t.Fatal("StateSaveFile failed")
+	}
+
+	// Prepare output buffer for loading
+	outTokens := make([]Token, len(tokens))
+	var nTokenCountOut uint64
+
+	ok = StateLoadFile(ctx, tmpFile, outTokens, uint64(len(outTokens)), &nTokenCountOut)
+	if !ok {
+		t.Fatal("StateLoadFile failed")
+	}
+	if nTokenCountOut == 0 || nTokenCountOut > uint64(len(outTokens)) {
+		t.Fatalf("StateLoadFile loaded unexpected number of tokens: %d", nTokenCountOut)
+	}
+
+	t.Logf("StateLoadFile loaded %d tokens from %s", nTokenCountOut, tmpFile)
+}
+
+func TestStateGetSize(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	defer ModelFree(model)
+
+	ctx := InitFromModel(model, ContextDefaultParams())
+	defer Free(ctx)
+
+	size := StateGetSize(ctx)
+	t.Logf("StateGetSize returned: %d bytes", size)
+	if size == 0 {
+		t.Fatal("StateGetSize returned 0, expected non-zero state size")
+	}
+}
+
+func TestStateGetData(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	defer ModelFree(model)
+
+	ctx := InitFromModel(model, ContextDefaultParams())
+	defer Free(ctx)
+
+	// Get the required state size
+	size := StateGetSize(ctx)
+	if size == 0 {
+		t.Fatal("StateGetSize returned 0, expected non-zero state size")
+	}
+
+	// Allocate a buffer
+	buf := make([]byte, size)
+	nCopied := StateGetData(ctx, buf)
+	t.Logf("StateGetData copied %d bytes", nCopied)
+	if nCopied == 0 || nCopied > size {
+		t.Fatalf("StateGetData copied an unexpected number of bytes: %d", nCopied)
+	}
+}
+
+func TestStateSetData(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	defer ModelFree(model)
+
+	ctx := InitFromModel(model, ContextDefaultParams())
+	defer Free(ctx)
+
+	// Save state to buffer
+	size := StateGetSize(ctx)
+	if size == 0 {
+		t.Fatal("StateGetSize returned 0, expected non-zero state size")
+	}
+	buf := make([]byte, size)
+	nCopied := StateGetData(ctx, buf)
+	if nCopied == 0 || nCopied > size {
+		t.Fatalf("StateGetData copied an unexpected number of bytes: %d", nCopied)
+	}
+
+	// Set state from buffer
+	nRead := StateSetData(ctx, buf)
+	t.Logf("StateSetData read %d bytes", nRead)
+	if nRead == 0 || nRead > size {
+		t.Fatalf("StateSetData read an unexpected number of bytes: %d", nRead)
+	}
+}


### PR DESCRIPTION
This PR adds implementations for `llama.cpp` state functions.