### PR TITLE
examples: add new example to show model info

### DIFF
--- a/examples/modelinfo/README.md
+++ b/examples/modelinfo/README.md
@@ -1,0 +1,42 @@
+# modelinfo
+
+Shows model information.
+
+## Running
+
+```shell
+go run ./examples/modelnfo/ /path/to/model.gguf
+```
+
+```shell
+$ go run ./examples/modelinfo/ ~/models/gemma-3-1b-it-q4_0.gguf 
+Model Description: gemma3 1B Q4_0
+Model Size: 997007872 tensors
+Model Has Encoder: false
+Model Has Decoder: true
+Model Is Recurrent: false
+Model Is Hybrid: false
+Model Metadata (22 entries):
+  general.file_type: 2
+  tokenizer.ggml.unknown_token_id: 3
+  tokenizer.ggml.padding_token_id: 0
+  tokenizer.ggml.bos_token_id: 2
+  general.quantization_version: 2
+  tokenizer.ggml.model: llama
+  gemma3.attention.sliding_window: 1024
+  general.architecture: gemma3
+  tokenizer.ggml.eos_token_id: 1
+  gemma3.feed_forward_length: 6912
+  gemma3.context_length: 32768
+  gemma3.block_count: 26
+  gemma3.attention.value_length: 256
+  gemma3.rope.scaling.factor: 1.000000
+  tokenizer.chat_template: {{ bos_token }} {%- if messages[0]['role'] == 'system' -%} {%- if messages[0]['content'] is string -%} {%- set first_user_prefix = messages[0]['content'] + '\n' -%} {%- else -%} {%- set first_user_prefix = messages[0]['content'][0]['text'] + '\n' -%} {%- endif -%} {%- set loop_messages = messages[1:] -%} {%- else -%} {%- set first_user_prefix = "" -%} {%- set loop_messages = messages -%} {%- endif -%} {%- for message in loop_messages -%} {%- if (message['role'] == 'user') != (loop.index0 % 2 == 0) -%} {{ raise_exception("Conversation roles must alternate user/assistant/user/assistant/...") }} {%- endif -%} {%- if (message['role'] == 'assistant') -%} {%- set role = "model" -%} {%- else -%} {%- set role = message['role'] -%} {%- endif -%} {{ '<start_of_turn>' + role + '\n' + (first_user_prefix if loop.first else "") }} {%- if message['content'] is string -%} {{ message['content'] | trim }} {%- elif message['content'] is iterable -%} {%- for item in message['content'] -%} {%- if item['type'] == 'image' -%} {{ '<start_of_image>' }} {%- elif item['type'] == 'text' -%} {{ item['text'] | trim }} {%- endif -%} {%- endfor -%} {%- else -%} {{ raise_exception("Invalid content type") }} {%- endif -%} {{ '<end_of_turn>\n' }} {%- endfor -%} {%- if add_generation_prompt -%} {{'<start_of_turn>model\n'}} {%- endif -%}
+  gemma3.attention.head_count: 4
+  gemma3.attention.head_count_kv: 1
+  gemma3.embedding_length: 1152
+  gemma3.attention.key_length: 256
+  gemma3.attention.layer_norm_rms_epsilon: 0.000001
+  gemma3.rope.scaling.type: linear
+  gemma3.rope.freq_base: 1000000.000000
+```

--- a/examples/modelinfo/main.go
+++ b/examples/modelinfo/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+var (
+	libPath = os.Getenv("YZMA_LIB")
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <modelFile>\n", os.Args[0])
+		os.Exit(1)
+	}
+	modelFile := os.Args[1]
+
+	llama.Load(libPath)
+	llama.LogSet(llama.LogSilent())
+
+	llama.Init()
+
+	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	defer llama.ModelFree(model)
+
+	desc := llama.ModelDesc(model)
+	fmt.Printf("Model Description: %s\n", desc)
+
+	size := llama.ModelSize(model)
+	fmt.Printf("Model Size: %d tensors\n", size)
+
+	encoder := llama.ModelHasEncoder(model)
+	fmt.Printf("Model Has Encoder: %v\n", encoder)
+
+	decoder := llama.ModelHasDecoder(model)
+	fmt.Printf("Model Has Decoder: %v\n", decoder)
+
+	recurrent := llama.ModelIsRecurrent(model)
+	fmt.Printf("Model Is Recurrent: %v\n", recurrent)
+
+	hybrid := llama.ModelIsHybrid(model)
+	fmt.Printf("Model Is Hybrid: %v\n", hybrid)
+
+	count := llama.ModelMetaCount(model)
+	fmt.Printf("Model Metadata (%d entries):\n", count)
+	for i := int32(0); i < count; i++ {
+		key, ok := llama.ModelMetaKeyByIndex(model, i)
+		if !ok {
+			fmt.Printf("Error getting key for index %d\n", i)
+			continue
+		}
+		value, ok := llama.ModelMetaValStrByIndex(model, i)
+		if !ok {
+			fmt.Printf("Error getting value for index %d\n", i)
+			continue
+		}
+		fmt.Printf("  %s: %s\n", key, value)
+	}
+}


### PR DESCRIPTION
This PR adds a new example to show model info.

```shell
$ go run ./examples/modelinfo/ ~/models/gemma-3-1b-it-q4_0.gguf 
Model Description: gemma3 1B Q4_0
Model Size: 997007872 tensors
Model Has Encoder: false
Model Has Decoder: true
Model Is Recurrent: false
Model Is Hybrid: false
Model Metadata (22 entries):
  general.file_type: 2
  tokenizer.ggml.unknown_token_id: 3
  tokenizer.ggml.padding_token_id: 0
  tokenizer.ggml.bos_token_id: 2
  general.quantization_version: 2
  tokenizer.ggml.model: llama
  gemma3.attention.sliding_window: 1024
  general.architecture: gemma3
  tokenizer.ggml.eos_token_id: 1
  gemma3.feed_forward_length: 6912
  gemma3.context_length: 32768
  gemma3.block_count: 26
  gemma3.attention.value_length: 256
  gemma3.rope.scaling.factor: 1.000000
  tokenizer.chat_template: {{ bos_token }} {%- if messages[0]['role'] == 'system' -%} {%- if messages[0]['content'] is string -%} {%- set first_user_prefix = messages[0]['content'] + '\n' -%} {%- else -%} {%- set first_user_prefix = messages[0]['content'][0]['text'] + '\n' -%} {%- endif -%} {%- set loop_messages = messages[1:] -%} {%- else -%} {%- set first_user_prefix = "" -%} {%- set loop_messages = messages -%} {%- endif -%} {%- for message in loop_messages -%} {%- if (message['role'] == 'user') != (loop.index0 % 2 == 0) -%} {{ raise_exception("Conversation roles must alternate user/assistant/user/assistant/...") }} {%- endif -%} {%- if (message['role'] == 'assistant') -%} {%- set role = "model" -%} {%- else -%} {%- set role = message['role'] -%} {%- endif -%} {{ '<start_of_turn>' + role + '\n' + (first_user_prefix if loop.first else "") }} {%- if message['content'] is string -%} {{ message['content'] | trim }} {%- elif message['content'] is iterable -%} {%- for item in message['content'] -%} {%- if item['type'] == 'image' -%} {{ '<start_of_image>' }} {%- elif item['type'] == 'text' -%} {{ item['text'] | trim }} {%- endif -%} {%- endfor -%} {%- else -%} {{ raise_exception("Invalid content type") }} {%- endif -%} {{ '<end_of_turn>\n' }} {%- endfor -%} {%- if add_generation_prompt -%} {{'<start_of_turn>model\n'}} {%- endif -%}
  gemma3.attention.head_count: 4
  gemma3.attention.head_count_kv: 1
  gemma3.embedding_length: 1152
  gemma3.attention.key_length: 256
  gemma3.attention.layer_norm_rms_epsilon: 0.000001
  gemma3.rope.scaling.type: linear
  gemma3.rope.freq_base: 1000000.000000
```
