### PR TITLE
feature: add PrintSystemInfo() function from llama.cpp

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,7 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 - [x] `llama_max_devices`
 - [x] `llama_max_parallel_sequences`
 - [x] `llama_numa_init`
+- [x] `llama_print_system_info`
 - [x] `llama_supports_gpu_offload`
 - [x] `llama_supports_mlock`
 - [x] `llama_supports_mmap`

--- a/pkg/llama/backend.go
+++ b/pkg/llama/backend.go
@@ -38,6 +38,9 @@ var (
 
 	// LLAMA_API const char * llama_flash_attn_type_name(enum llama_flash_attn_type flash_attn_type);
 	flashAttnTypeNameFunc ffi.Fun
+
+	// LLAMA_API const char * llama_print_system_info(void);
+	printSystemInfoFunc ffi.Fun
 )
 
 func loadBackendFuncs(lib ffi.Lib) error {
@@ -84,6 +87,10 @@ func loadBackendFuncs(lib ffi.Lib) error {
 
 	if flashAttnTypeNameFunc, err = lib.Prep("llama_flash_attn_type_name", &ffi.TypePointer, &ffi.TypeSint32); err != nil {
 		return loadError("llama_flash_attn_type_name", err)
+	}
+
+	if printSystemInfoFunc, err = lib.Prep("llama_print_system_info", &ffi.TypePointer); err != nil {
+		return loadError("llama_print_system_info", err)
 	}
 
 	return nil
@@ -157,6 +164,18 @@ func TimeUs() int64 {
 func FlashAttnTypeName(flashAttnType FlashAttentionType) string {
 	var result *byte
 	flashAttnTypeNameFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&flashAttnType))
+
+	if result == nil {
+		return ""
+	}
+
+	return utils.BytePtrToString(result)
+}
+
+// PrintSystemInfo returns system information as a string.
+func PrintSystemInfo() string {
+	var result *byte
+	printSystemInfoFunc.Call(unsafe.Pointer(&result))
 
 	if result == nil {
 		return ""

--- a/pkg/llama/backend_test.go
+++ b/pkg/llama/backend_test.go
@@ -86,3 +86,14 @@ func TestNumaInit(t *testing.T) {
 	NumaInit(strategy)
 	t.Logf("NumaInit called with strategy: %d", strategy)
 }
+
+func TestPrintSystemInfo(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	info := PrintSystemInfo()
+	if info == "" {
+		t.Fatal("PrintSystemInfo returned empty string")
+	}
+	t.Logf("PrintSystemInfo returned:\n%s", info)
+}


### PR DESCRIPTION
This PR adds the `PrintSystemInfo()` function from llama.cpp that was overlooked.