### PR TITLE
feature: add new SamplerParams type and require it as param to call NewSampler()

### DIFF
--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -63,18 +63,15 @@ func main() {
 	lctx = llama.InitFromModel(model, ctxParams)
 	defer llama.Free(lctx)
 
-	sampler = llama.SamplerChainInit(llama.SamplerChainDefaultParams())
-	if *topK != 0 {
-		llama.SamplerChainAdd(sampler, llama.SamplerInitTopK(int32(*topK)))
-	}
-	if *topP < 1.0 {
-		llama.SamplerChainAdd(sampler, llama.SamplerInitTopP(float32(*topP), 1))
-	}
-	if *minP > 0 {
-		llama.SamplerChainAdd(sampler, llama.SamplerInitMinP(float32(*minP), 1))
-	}
-	llama.SamplerChainAdd(sampler, llama.SamplerInitTempExt(float32(*temperature), 0, 1.0))
-	llama.SamplerChainAdd(sampler, llama.SamplerInitDist(llama.DefaultSeed))
+	// pass in flags as params to samplers
+	sp := llama.DefaultSamplerParams()
+	sp.Temp = float32(*temperature)
+	sp.TopK = int32(*topK)
+	sp.TopP = float32(*topP)
+	sp.MinP = float32(*minP)
+
+	samplers := []llama.SamplerType{llama.SamplerTypeTopK, llama.SamplerTypeTopP, llama.SamplerTypeMinP, llama.SamplerTypeTemperature}
+	sampler = llama.NewSampler(model, samplers, sp)
 
 	if *template == "" {
 		*template = llama.ModelChatTemplate(model, "")

--- a/examples/describe/describe.go
+++ b/examples/describe/describe.go
@@ -34,7 +34,7 @@ func describe(tmpFile string) {
 	defer llama.Free(lctx)
 
 	vocab := llama.ModelGetVocab(model)
-	sampler := llama.NewSampler(model, llama.DefaultSamplers)
+	sampler := llama.NewSampler(model, llama.DefaultSamplers, llama.DefaultSamplerParams())
 
 	mtmdCtx := mtmd.InitFromFile(path.Join(*modelsDir, *projFile), model, mtmdCtxParams)
 	defer mtmd.Free(mtmdCtx)

--- a/examples/vlm/main.go
+++ b/examples/vlm/main.go
@@ -54,8 +54,15 @@ func main() {
 	defer llama.Free(lctx)
 
 	vocab := llama.ModelGetVocab(model)
-	// TODO: pass in flags as params to samplers
-	sampler := llama.NewSampler(model, llama.DefaultSamplers)
+
+	// pass in flags as params to samplers
+	sp := llama.DefaultSamplerParams()
+	sp.Temp = float32(*temperature)
+	sp.TopK = int32(*topK)
+	sp.TopP = float32(*topP)
+	sp.MinP = float32(*minP)
+
+	sampler := llama.NewSampler(model, llama.DefaultSamplers, sp)
 	mtmdCtx := mtmd.InitFromFile(*projFile, model, mctxParams)
 	defer mtmd.Free(mtmdCtx)
 

--- a/pkg/llama/sampling_test.go
+++ b/pkg/llama/sampling_test.go
@@ -141,7 +141,7 @@ func TestNewSampler(t *testing.T) {
 		SamplerTypeTopP,
 	}
 
-	sampler := NewSampler(model, samplers)
+	sampler := NewSampler(model, samplers, DefaultSamplerParams())
 	if sampler == (Sampler(0)) {
 		t.Fatal("NewSampler failed to create a new sampler chain")
 	}


### PR DESCRIPTION
This is to make it possible to pass sampling params in to the NewSampler() function which streamlines use of samplers which still allowing for customization.

**NOTE: this is a breaking change to the `NewSampler()` function.**

The benefit is now you can do this:

```go
	// pass in flags as params to samplers
	sp := llama.DefaultSamplerParams()
	sp.Temp = float32(*temperature)
	sp.TopK = int32(*topK)
	sp.TopP = float32(*topP)
	sp.MinP = float32(*minP)

	sampler := llama.NewSampler(model, llama.DefaultSamplers, sp)
```