### PR TITLE
feature: return errors for many functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ func main() {
 	llama.Load(libPath)
 	llama.Init()
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
-	lctx := llama.InitFromModel(model, llama.ContextDefaultParams())
+	model, _ := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	lctx, _ := llama.InitFromModel(model, llama.ContextDefaultParams())
 
 	vocab := llama.ModelGetVocab(model)
 

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -50,7 +50,12 @@ func main() {
 		mParams.SetTensorBufOverrides(overrides)
 	}
 
-	model = llama.ModelLoadFromFile(*modelFile, mParams)
+	var err error
+	model, err = llama.ModelLoadFromFile(*modelFile, mParams)
+	if err != nil {
+		fmt.Println("unable to load model from file", err.Error())
+		os.Exit(1)
+	}
 	if model == 0 {
 		fmt.Println("unable to load model from file", *modelFile)
 		os.Exit(1)
@@ -65,7 +70,11 @@ func main() {
 	ctxParams.NBatch = uint32(*batchSize)
 	ctxParams.NUbatch = uint32(*uBatchSize)
 
-	lctx = llama.InitFromModel(model, ctxParams)
+	lctx, err = llama.InitFromModel(model, ctxParams)
+	if err != nil {
+		fmt.Println("unable to initialize context from model", err.Error())
+		os.Exit(1)
+	}
 	defer llama.Free(lctx)
 
 	// pass in flags as params to samplers

--- a/examples/describe/describe.go
+++ b/examples/describe/describe.go
@@ -23,7 +23,10 @@ func describe(tmpFile string) error {
 		mtmdCtxParams.Verbosity = llama.LogLevelContinue
 	}
 
-	model := llama.ModelLoadFromFile(path.Join(*modelsDir, *modelFile), llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(path.Join(*modelsDir, *modelFile), llama.ModelDefaultParams())
+	if err != nil {
+		return fmt.Errorf("unable to load model from file %s: %v", *modelFile, err)
+	}
 	if model == 0 {
 		return fmt.Errorf("unable to load model from file %s", *modelFile)
 	}
@@ -34,13 +37,19 @@ func describe(tmpFile string) error {
 	ctxParams.NCtx = 4096
 	ctxParams.NBatch = 2048
 
-	lctx := llama.InitFromModel(model, ctxParams)
+	lctx, err := llama.InitFromModel(model, ctxParams)
+	if err != nil {
+		return fmt.Errorf("unable to initialize context from model: %v", err)
+	}
 	defer llama.Free(lctx)
 
 	vocab := llama.ModelGetVocab(model)
 	sampler := llama.NewSampler(model, llama.DefaultSamplers, llama.DefaultSamplerParams())
 
-	mtmdCtx := mtmd.InitFromFile(path.Join(*modelsDir, *projFile), model, mtmdCtxParams)
+	mtmdCtx, err := mtmd.InitFromFile(path.Join(*modelsDir, *projFile), model, mtmdCtxParams)
+	if err != nil {
+		return fmt.Errorf("unable to initialize context from file: %v", err)
+	}
 	defer mtmd.Free(mtmdCtx)
 
 	template = llama.ModelChatTemplate(model, "")

--- a/examples/embeddings/main.go
+++ b/examples/embeddings/main.go
@@ -33,7 +33,10 @@ func run() error {
 	llama.Init()
 	defer llama.BackendFree()
 
-	model := llama.ModelLoadFromFile(*modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(*modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		return fmt.Errorf("unable to load model from file %s: %v", *modelFile, err)
+	}
 	if model == 0 {
 		return fmt.Errorf("unable to load model from file %s", *modelFile)
 	}
@@ -45,7 +48,10 @@ func run() error {
 	ctxParams.PoolingType = poolingType
 	ctxParams.Embeddings = 1
 
-	lctx := llama.InitFromModel(model, ctxParams)
+	lctx, err := llama.InitFromModel(model, ctxParams)
+	if err != nil {
+		return fmt.Errorf("unable to initialize context from model: %v", err)
+	}
 	defer llama.Free(lctx)
 
 	// tokenize prompt
@@ -58,7 +64,10 @@ func run() error {
 
 	// get embeddings
 	nEmbd := llama.ModelNEmbd(model)
-	vec := llama.GetEmbeddingsSeq(lctx, 0, nEmbd)
+	vec, err := llama.GetEmbeddingsSeq(lctx, 0, nEmbd)
+	if err != nil {
+		return fmt.Errorf("unable to get embeddings: %v", err)
+	}
 
 	// normalize embeddings
 	var sum float64

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -18,8 +18,8 @@ func main() {
 	llama.Load(libPath)
 	llama.Init()
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
-	lctx := llama.InitFromModel(model, llama.ContextDefaultParams())
+	model, _ := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	lctx, _ := llama.InitFromModel(model, llama.ContextDefaultParams())
 
 	vocab := llama.ModelGetVocab(model)
 

--- a/examples/modelinfo/main.go
+++ b/examples/modelinfo/main.go
@@ -23,7 +23,16 @@ func main() {
 
 	llama.Init()
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to load model from file %s: %v\n", modelFile, err)
+		os.Exit(1)
+	}
+	if model == 0 {
+		fmt.Fprintf(os.Stderr, "unable to load model from file %s\n", modelFile)
+		os.Exit(1)
+	}
+
 	defer llama.ModelFree(model)
 
 	desc := llama.ModelDesc(model)

--- a/examples/vlm/main.go
+++ b/examples/vlm/main.go
@@ -43,7 +43,11 @@ func main() {
 	defer llama.BackendFree()
 
 	fmt.Println("Loading model", *modelFile)
-	model := llama.ModelLoadFromFile(*modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(*modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		fmt.Println("unable to load model from file", err.Error())
+		os.Exit(1)
+	}
 	if model == 0 {
 		fmt.Println("unable to load model from file", *modelFile)
 		os.Exit(1)
@@ -54,7 +58,11 @@ func main() {
 	ctxParams.NCtx = 4096
 	ctxParams.NBatch = 2048
 
-	lctx := llama.InitFromModel(model, ctxParams)
+	lctx, err := llama.InitFromModel(model, ctxParams)
+	if err != nil {
+		fmt.Println("unable to initialize context from model", err.Error())
+		os.Exit(1)
+	}
 	defer llama.Free(lctx)
 
 	vocab := llama.ModelGetVocab(model)
@@ -67,7 +75,11 @@ func main() {
 	sp.MinP = float32(*minP)
 
 	sampler := llama.NewSampler(model, llama.DefaultSamplers, sp)
-	mtmdCtx := mtmd.InitFromFile(*projFile, model, mctxParams)
+	mtmdCtx, err := mtmd.InitFromFile(*projFile, model, mctxParams)
+	if err != nil {
+		fmt.Println("unable to initialize context from file", err.Error())
+		os.Exit(1)
+	}
 	defer mtmd.Free(mtmdCtx)
 
 	if *template == "" {

--- a/pkg/llama/batch.go
+++ b/pkg/llama/batch.go
@@ -60,18 +60,23 @@ func BatchInit(nTokens int32, embd int32, nSeqMax int32) Batch {
 }
 
 // BatchFree frees a Batch of tokens allocated with BatchInit.
-func BatchFree(batch Batch) {
+func BatchFree(batch Batch) error {
 	batchFreeFunc.Call(nil, unsafe.Pointer(&batch))
+
+	return nil
 }
 
 // BatchGetOne returns Batch for single sequence of tokens.
 // The sequence ID will be fixed to 0.
 // The position of the tokens will be tracked automatically by [Decode].
 func BatchGetOne(tokens []Token) Batch {
+	var batch Batch
+	if len(tokens) == 0 {
+		return batch
+	}
 	toks := unsafe.SliceData(tokens)
 	nTokens := int32(len(tokens))
 
-	var batch Batch
 	batchGetOneFunc.Call(unsafe.Pointer(&batch), unsafe.Pointer(&toks), &nTokens)
 
 	return batch

--- a/pkg/llama/chat.go
+++ b/pkg/llama/chat.go
@@ -31,8 +31,15 @@ func loadChatFuncs(lib ffi.Lib) error {
 
 // NewChatMessage creates a new ChatMessage.
 func NewChatMessage(role, content string) ChatMessage {
-	r, _ := utils.BytePtrFromString(role)
-	c, _ := utils.BytePtrFromString(content)
+	r, err := utils.BytePtrFromString(role)
+	if err != nil {
+		return ChatMessage{}
+	}
+
+	c, err := utils.BytePtrFromString(content)
+	if err != nil {
+		return ChatMessage{}
+	}
 
 	return ChatMessage{Role: r, Content: c}
 }
@@ -40,7 +47,14 @@ func NewChatMessage(role, content string) ChatMessage {
 // ChatApplyTemplate applies a chat template to a slice of [ChatMessage], Set addAssistantPrompt to true to generate the
 // assistant prompt, for example on the first message.
 func ChatApplyTemplate(template string, chat []ChatMessage, addAssistantPrompt bool, buf []byte) int32 {
-	tmpl, _ := utils.BytePtrFromString(template)
+	tmpl, err := utils.BytePtrFromString(template)
+	if err != nil {
+		return 0
+	}
+
+	if len(chat) == 0 {
+		return 0
+	}
 
 	c := unsafe.Pointer(&chat[0])
 	nMsg := uint32(len(chat))

--- a/pkg/llama/context_test.go
+++ b/pkg/llama/context_test.go
@@ -20,17 +20,21 @@ func TestInitModel(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	params := ContextDefaultParams()
-	ctx := InitFromModel(model, params)
-	if ctx == (Context(0)) {
-		t.Fatal("Failed to initialize context")
+	ctx, err := InitFromModel(model, params)
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
 	}
 
-	Free(ctx)
-	// No direct way to verify, but ensure no panic or error occurs
+	if err := Free(ctx); err != nil {
+		t.Fatalf("Free failed: %v", err)
+	}
 }
 
 func TestWarmup(t *testing.T) {
@@ -39,13 +43,16 @@ func TestWarmup(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	params := ContextDefaultParams()
-	ctx := InitFromModel(model, params)
-	if ctx == (Context(0)) {
-		t.Fatal("Failed to initialize context")
+	ctx, err := InitFromModel(model, params)
+	if ctx == 0 || err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
 	}
 	defer Free(ctx)
 
@@ -60,10 +67,16 @@ func TestNCtx(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	nCtx := NCtx(ctx)
@@ -79,10 +92,16 @@ func TestNBatch(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	nBatch := NBatch(ctx)
@@ -98,10 +117,16 @@ func TestNUBatch(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	nUBatch := NUBatch(ctx)
@@ -117,10 +142,16 @@ func TestNSeqMax(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	nSeqMax := NSeqMax(ctx)
@@ -136,10 +167,16 @@ func TestGetModel(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	retrievedModel := GetModel(ctx)
@@ -156,10 +193,16 @@ func TestGetLogitsIth(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// tokenize prompt
@@ -172,7 +215,10 @@ func TestGetLogitsIth(t *testing.T) {
 	Decode(ctx, batch)
 
 	nVocab := int(VocabNTokens(vocab))
-	logits := GetLogitsIth(ctx, -1, nVocab)
+	logits, err := GetLogitsIth(ctx, -1, nVocab)
+	if err != nil {
+		t.Fatalf("GetLogitsIth returned an error: %v", err)
+	}
 	if logits == nil {
 		t.Fatal("GetLogitsIth returned nil")
 	}
@@ -185,14 +231,20 @@ func TestGetEmbeddingsIth(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	params := ContextDefaultParams()
 	params.PoolingType = PoolingTypeMean
 	params.Embeddings = 1
 
-	ctx := InitFromModel(model, params)
+	ctx, err := InitFromModel(model, params)
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// Tokenize a prompt
@@ -205,7 +257,10 @@ func TestGetEmbeddingsIth(t *testing.T) {
 	Decode(ctx, batch)
 
 	nEmbeddings := VocabNTokens(vocab)
-	embeddings := GetEmbeddingsIth(ctx, -1, nEmbeddings) // Get embeddings for the last token
+	embeddings, err := GetEmbeddingsIth(ctx, -1, nEmbeddings) // Get embeddings for the last token
+	if err != nil {
+		t.Fatalf("GetEmbeddingsIth returned an error: %v", err)
+	}
 	if embeddings == nil {
 		t.Fatal("GetEmbeddingsIth returned nil")
 	}
@@ -221,14 +276,20 @@ func TestGetEmbeddingsSeq(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	params := ContextDefaultParams()
 	params.PoolingType = PoolingTypeMean
 	params.Embeddings = 1
 
-	ctx := InitFromModel(model, params)
+	ctx, err := InitFromModel(model, params)
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// Tokenize a prompt
@@ -242,7 +303,10 @@ func TestGetEmbeddingsSeq(t *testing.T) {
 
 	seqID := SeqId(0)
 	nEmbeddings := int32(VocabNTokens(vocab))
-	embeddings := GetEmbeddingsSeq(ctx, seqID, nEmbeddings)
+	embeddings, err := GetEmbeddingsSeq(ctx, seqID, nEmbeddings)
+	if err != nil {
+		t.Fatalf("GetEmbeddingsSeq returned an error: %v", err)
+	}
 	if embeddings == nil {
 		t.Fatal("GetEmbeddingsSeq returned nil")
 	}
@@ -258,14 +322,20 @@ func TestGetEmbeddings(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	params := ContextDefaultParams()
 	params.PoolingType = PoolingTypeNone
 	params.Embeddings = 1
 
-	ctx := InitFromModel(model, params)
+	ctx, err := InitFromModel(model, params)
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// Tokenize a prompt
@@ -279,7 +349,10 @@ func TestGetEmbeddings(t *testing.T) {
 
 	nOutputs := len(tokens)
 	nEmbeddings := int(ModelNEmbd(model))
-	embeddings := GetEmbeddings(ctx, nOutputs, nEmbeddings)
+	embeddings, err := GetEmbeddings(ctx, nOutputs, nEmbeddings)
+	if err != nil {
+		t.Fatalf("GetEmbeddings returned an error: %v", err)
+	}
 	if embeddings == nil {
 		t.Fatal("GetEmbeddings returned nil")
 	}
@@ -295,10 +368,16 @@ func TestSetEmbeddings(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// Enable embeddings
@@ -316,10 +395,16 @@ func TestSetCausalAttn(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// Enable causal attention
@@ -337,10 +422,16 @@ func TestGetLogits(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// Tokenize a prompt
@@ -354,7 +445,10 @@ func TestGetLogits(t *testing.T) {
 
 	nTokens := len(tokens)
 	nVocab := int(VocabNTokens(vocab))
-	logits := GetLogits(ctx, nTokens, nVocab)
+	logits, err := GetLogits(ctx, nTokens, nVocab)
+	if err != nil {
+		t.Fatalf("GetLogits returned an error: %v", err)
+	}
 	if logits == nil {
 		t.Fatal("GetLogits returned nil")
 	}

--- a/pkg/llama/logs_test.go
+++ b/pkg/llama/logs_test.go
@@ -10,7 +10,10 @@ func TestLogSilent(t *testing.T) {
 
 	LogSet(LogSilent())
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("Failed to load model from file: %v", err)
+	}
 	defer ModelFree(model)
 
 	t.Log("Logs should be silent on this test")

--- a/pkg/llama/memory_test.go
+++ b/pkg/llama/memory_test.go
@@ -9,19 +9,27 @@ func TestMemoryClear(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(testModelFileName(t), params)
+	model, err := ModelLoadFromFile(testModelFileName(t), params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
-	mem := GetMemory(ctx)
-	if mem == Memory(0) {
+	mem, err := GetMemory(ctx)
+	if mem == 0 || err != nil {
 		t.Fatal("GetMemory returned an empty memory object")
 	}
 
 	// Clear memory with data = true
-	MemoryClear(mem, true)
+	if err := MemoryClear(mem, true); err != nil {
+		t.Fatalf("MemoryClear failed with data = true: %v", err)
+	}
 	// No direct way to verify, but ensure no panic or error occurs
 	t.Log("MemoryClear executed successfully with data = true")
 
@@ -35,14 +43,20 @@ func TestMemorySeqRm(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(testModelFileName(t), params)
+	model, err := ModelLoadFromFile(testModelFileName(t), params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
-	mem := GetMemory(ctx)
-	if mem == Memory(0) {
+	mem, err := GetMemory(ctx)
+	if err != nil || mem == Memory(0) {
 		t.Fatal("GetMemory returned an empty memory object")
 	}
 
@@ -51,22 +65,22 @@ func TestMemorySeqRm(t *testing.T) {
 	p0 := Pos(0)
 	p1 := Pos(10)
 
-	success := MemorySeqRm(mem, seqID, p0, p1)
-	if !success {
+	success, err := MemorySeqRm(mem, seqID, p0, p1)
+	if !success || err != nil {
 		t.Fatal("MemorySeqRm failed to remove tokens for the specified sequence and position range")
 	}
 	t.Logf("MemorySeqRm executed successfully for seqID: %d, p0: %d, p1: %d", seqID, p0, p1)
 
 	// Test with seqID < 0 (match any sequence)
-	success = MemorySeqRm(mem, -1, p0, p1)
-	if !success {
+	success, err = MemorySeqRm(mem, -1, p0, p1)
+	if !success || err != nil {
 		t.Fatal("MemorySeqRm failed to remove tokens for any sequence")
 	}
 	t.Log("MemorySeqRm executed successfully for seqID < 0 (match any sequence)")
 
 	// Test with p1 < 0 (remove tokens from p0 to infinity)
-	success = MemorySeqRm(mem, seqID, p0, -1)
-	if !success {
+	success, err = MemorySeqRm(mem, seqID, p0, -1)
+	if !success || err != nil {
 		t.Fatal("MemorySeqRm failed to remove tokens from p0 to infinity")
 	}
 	t.Log("MemorySeqRm executed successfully for p1 < 0 (remove tokens from p0 to infinity)")
@@ -77,14 +91,20 @@ func TestMemorySeqCp(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(testModelFileName(t), params)
+	model, err := ModelLoadFromFile(testModelFileName(t), params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
-	mem := GetMemory(ctx)
-	if mem == Memory(0) {
+	mem, err := GetMemory(ctx)
+	if err != nil || mem == 0 {
 		t.Fatal("GetMemory returned an empty memory object")
 	}
 
@@ -93,7 +113,9 @@ func TestMemorySeqCp(t *testing.T) {
 	p0 := Pos(0)
 	p1 := Pos(10)
 
-	MemorySeqCp(mem, seqIDSrc, seqIDDst, p0, p1)
+	if err := MemorySeqCp(mem, seqIDSrc, seqIDDst, p0, p1); err != nil {
+		t.Fatalf("MemorySeqCp failed to copy tokens from seqIDSrc to seqIDDst: %v", err)
+	}
 	t.Logf("MemorySeqCp executed successfully for seqIDSrc: %d, seqIDDst: %d, p0: %d, p1: %d", seqIDSrc, seqIDDst, p0, p1)
 }
 
@@ -102,19 +124,27 @@ func TestMemorySeqKeep(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(testModelFileName(t), params)
+	model, err := ModelLoadFromFile(testModelFileName(t), params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
-	mem := GetMemory(ctx)
-	if mem == Memory(0) {
+	mem, err := GetMemory(ctx)
+	if err != nil || mem == 0 {
 		t.Fatal("GetMemory returned an empty memory object")
 	}
 
 	seqID := SeqId(1)
-	MemorySeqKeep(mem, seqID)
+	if err := MemorySeqKeep(mem, seqID); err != nil {
+		t.Fatalf("MemorySeqKeep failed for seqID: %d: %v", seqID, err)
+	}
 	t.Logf("MemorySeqKeep executed successfully for seqID: %d", seqID)
 }
 
@@ -123,14 +153,20 @@ func TestMemorySeqAdd(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(testModelFileName(t), params)
+	model, err := ModelLoadFromFile(testModelFileName(t), params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
-	mem := GetMemory(ctx)
-	if mem == Memory(0) {
+	mem, err := GetMemory(ctx)
+	if err != nil || mem == Memory(0) {
 		t.Fatal("GetMemory returned an empty memory object")
 	}
 
@@ -139,7 +175,9 @@ func TestMemorySeqAdd(t *testing.T) {
 	p1 := Pos(10)
 	delta := Pos(5)
 
-	MemorySeqAdd(mem, seqID, p0, p1, delta)
+	if err := MemorySeqAdd(mem, seqID, p0, p1, delta); err != nil {
+		t.Fatalf("MemorySeqAdd failed for seqID: %d, p0: %d, p1: %d, delta: %d: %v", seqID, p0, p1, delta, err)
+	}
 	t.Logf("MemorySeqAdd executed successfully for seqID: %d, p0: %d, p1: %d, delta: %d", seqID, p0, p1, delta)
 }
 
@@ -148,14 +186,20 @@ func TestMemorySeqDiv(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(testModelFileName(t), params)
+	model, err := ModelLoadFromFile(testModelFileName(t), params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
-	mem := GetMemory(ctx)
-	if mem == Memory(0) {
+	mem, err := GetMemory(ctx)
+	if err != nil || mem == Memory(0) {
 		t.Fatal("GetMemory returned an empty memory object")
 	}
 
@@ -164,7 +208,9 @@ func TestMemorySeqDiv(t *testing.T) {
 	p1 := Pos(10)
 	d := 2
 
-	MemorySeqDiv(mem, seqID, p0, p1, d)
+	if err := MemorySeqDiv(mem, seqID, p0, p1, d); err != nil {
+		t.Fatalf("MemorySeqDiv failed for seqID: %d, p0: %d, p1: %d, d: %d: %v", seqID, p0, p1, d, err)
+	}
 	t.Logf("MemorySeqDiv executed successfully for seqID: %d, p0: %d, p1: %d, d: %d", seqID, p0, p1, d)
 }
 
@@ -173,19 +219,28 @@ func TestMemorySeqPosMin(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(testModelFileName(t), params)
+	model, err := ModelLoadFromFile(testModelFileName(t), params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
-	mem := GetMemory(ctx)
-	if mem == Memory(0) {
+	mem, err := GetMemory(ctx)
+	if err != nil || mem == Memory(0) {
 		t.Fatal("GetMemory returned an empty memory object")
 	}
 
 	seqID := SeqId(1)
-	posMin := MemorySeqPosMin(mem, seqID)
+	posMin, err := MemorySeqPosMin(mem, seqID)
+	if err != nil {
+		t.Fatalf("MemorySeqPosMin failed for seqID: %d: %v", seqID, err)
+	}
 	t.Logf("MemorySeqPosMin returned: %d for seqID: %d", posMin, seqID)
 }
 
@@ -194,19 +249,28 @@ func TestMemorySeqPosMax(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(testModelFileName(t), params)
+	model, err := ModelLoadFromFile(testModelFileName(t), params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
-	mem := GetMemory(ctx)
-	if mem == Memory(0) {
+	mem, err := GetMemory(ctx)
+	if err != nil || mem == 0 {
 		t.Fatal("GetMemory returned an empty memory object")
 	}
 
 	seqID := SeqId(1)
-	posMax := MemorySeqPosMax(mem, seqID)
+	posMax, err := MemorySeqPosMax(mem, seqID)
+	if err != nil {
+		t.Fatalf("MemorySeqPosMax failed for seqID: %d: %v", seqID, err)
+	}
 	t.Logf("MemorySeqPosMax returned: %d for seqID: %d", posMax, seqID)
 }
 
@@ -215,17 +279,26 @@ func TestMemoryCanShift(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(testModelFileName(t), params)
+	model, err := ModelLoadFromFile(testModelFileName(t), params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
-	mem := GetMemory(ctx)
-	if mem == Memory(0) {
+	mem, err := GetMemory(ctx)
+	if err != nil || mem == Memory(0) {
 		t.Fatal("GetMemory returned an empty memory object")
 	}
 
-	canShift := MemoryCanShift(mem)
+	canShift, err := MemoryCanShift(mem)
+	if err != nil {
+		t.Fatalf("MemoryCanShift failed: %v", err)
+	}
 	t.Logf("MemoryCanShift returned: %v", canShift)
 }

--- a/pkg/llama/model_test.go
+++ b/pkg/llama/model_test.go
@@ -23,7 +23,10 @@ func TestModelInvalidFile(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err == nil {
+		t.Fatal("ModelLoadFromFile should have failed for invalid file")
+	}
 	if model != 0 {
 		t.Fatal("ModelLoadFromFile should have failed for invalid file")
 	}
@@ -36,7 +39,10 @@ func TestModelHasDecoder(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	hasDecoder := ModelHasDecoder(model)
@@ -51,7 +57,10 @@ func TestModelNEmbdInp(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	nEmbdInp := ModelNEmbdInp(model)
@@ -67,7 +76,10 @@ func TestModelNCtxTrain(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	nCtxTrain := ModelNCtxTrain(model)
@@ -82,7 +94,10 @@ func TestModelNClsOut(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	nClsOut := ModelNClsOut(model)
@@ -95,7 +110,10 @@ func TestModelClsLabel(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	label := ModelClsLabel(model, 0)
@@ -108,7 +126,10 @@ func TestModelDesc(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	desc := ModelDesc(model)
@@ -121,7 +142,10 @@ func TestModelSize(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	size := ModelSize(model)
@@ -134,7 +158,10 @@ func TestModelIsRecurrent(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	isRecurrent := ModelIsRecurrent(model)
@@ -147,7 +174,10 @@ func TestModelIsHybrid(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	isHybrid := ModelIsHybrid(model)
@@ -160,7 +190,10 @@ func TestModelIsDiffusion(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	isDiffusion := ModelIsDiffusion(model)
@@ -171,7 +204,10 @@ func TestModelRopeFreqScaleTrain(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(testModelFileName(t), ModelDefaultParams())
+	model, err := ModelLoadFromFile(testModelFileName(t), ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	freqScale := ModelRopeFreqScaleTrain(model)
@@ -182,7 +218,10 @@ func TestModelRopeType(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(testModelFileName(t), ModelDefaultParams())
+	model, err := ModelLoadFromFile(testModelFileName(t), ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	ropeType := ModelRopeType(model)
@@ -194,7 +233,10 @@ func TestModelMetaCount(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	count := ModelMetaCount(model)
@@ -209,7 +251,10 @@ func TestModelMetaKeyByIndex(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	count := ModelMetaCount(model)
@@ -228,7 +273,10 @@ func TestModelMetaValStrByIndex(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	count := ModelMetaCount(model)
@@ -247,7 +295,10 @@ func TestModelMetaValStr(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	count := ModelMetaCount(model)
@@ -279,7 +330,10 @@ func TestModelLoadCallback(t *testing.T) {
 
 	params := ModelDefaultParams()
 	params.SetProgressCallback(callback)
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	if model == 0 {
@@ -321,7 +375,10 @@ func TestModelQuantize(t *testing.T) {
 	}
 
 	// Load the quantized model to verify it was created correctly
-	quantizedModel := ModelLoadFromFile(quantizedModelFile, ModelDefaultParams())
+	quantizedModel, err := ModelLoadFromFile(quantizedModelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(quantizedModel)
 
 	if quantizedModel == 0 {

--- a/pkg/llama/sampling_test.go
+++ b/pkg/llama/sampling_test.go
@@ -133,7 +133,10 @@ func TestNewSampler(t *testing.T) {
 	defer testCleanup(t)
 
 	modelFile := testModelFileName(t)
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	samplers := []SamplerType{

--- a/pkg/llama/state_test.go
+++ b/pkg/llama/state_test.go
@@ -11,10 +11,16 @@ func TestStateSaveFile(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// tokenize prompt
@@ -58,10 +64,16 @@ func TestStateLoadFile(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// tokenize prompt and decode, then save state
@@ -105,10 +117,16 @@ func TestStateGetSize(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	size := StateGetSize(ctx)
@@ -124,10 +142,16 @@ func TestStateGetData(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// Get the required state size
@@ -151,10 +175,16 @@ func TestStateSetData(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// Save state to buffer
@@ -181,9 +211,15 @@ func TestStateSeqGetSizeAndData(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// Tokenize and decode
@@ -215,9 +251,15 @@ func TestStateSeqSaveLoadFile(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	// Tokenize and decode
@@ -257,9 +299,15 @@ func TestStateSeqGetSizeDataExt(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
-	ctx := InitFromModel(model, ContextDefaultParams())
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer Free(ctx)
 
 	seqId := SeqId(1)

--- a/pkg/llama/vocab_test.go
+++ b/pkg/llama/vocab_test.go
@@ -11,7 +11,10 @@ func TestVocabBOS(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -27,7 +30,10 @@ func TestVocabEOS(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -44,7 +50,10 @@ func TestVocabEOT(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -60,7 +69,10 @@ func TestVocabSEP(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -76,7 +88,10 @@ func TestVocabNL(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -92,7 +107,10 @@ func TestVocabPAD(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -108,7 +126,10 @@ func TestVocabMASK(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -124,7 +145,10 @@ func TestVocabGetAddBOS(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -141,7 +165,10 @@ func TestVocabGetAddEOS(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -158,7 +185,10 @@ func TestVocabGetAddSEP(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -180,7 +210,10 @@ func TestVocabFIMPre(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -196,7 +229,10 @@ func TestVocabFIMSuf(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -212,7 +248,10 @@ func TestVocabFIMMid(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -228,7 +267,10 @@ func TestVocabFIMPad(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -244,7 +286,10 @@ func TestVocabFIMRep(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -260,7 +305,10 @@ func TestVocabFIMSep(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -276,7 +324,10 @@ func TestVocabGetAttr(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -299,7 +350,10 @@ func TestVocabGetScore(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -325,7 +379,10 @@ func TestVocabGetText(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)
@@ -351,7 +408,10 @@ func TestGetVocabType(t *testing.T) {
 	defer testCleanup(t)
 
 	params := ModelDefaultParams()
-	model := ModelLoadFromFile(modelFile, params)
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer ModelFree(model)
 
 	vocab := ModelGetVocab(model)

--- a/pkg/mtmd/chunks_test.go
+++ b/pkg/mtmd/chunks_test.go
@@ -37,11 +37,17 @@ func TestInputChunksGetType(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("Failed to load model from file: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("Failed to initialize context from file: %v", err)
+	}
 	defer Free(ctx)
 
 	chunks := InputChunksInit()
@@ -80,11 +86,17 @@ func TestInputChunkGetNTokens(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("Failed to load model from file: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("Failed to initialize context from file: %v", err)
+	}
 	defer Free(ctx)
 
 	chunks := InputChunksInit()
@@ -111,11 +123,17 @@ func TestInputChunkGetId(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("Failed to load model from file: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("Failed to initialize context from file: %v", err)
+	}
 	defer Free(ctx)
 
 	chunks := InputChunksInit()
@@ -142,11 +160,17 @@ func TestInputChunkGetNPos(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("Failed to load model from file: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("Failed to initialize context from file: %v", err)
+	}
 	defer Free(ctx)
 
 	chunks := InputChunksInit()
@@ -173,11 +197,17 @@ func TestInputChunkCopyAndFree(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("Failed to load model from file: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("Failed to initialize context from file: %v", err)
+	}
 	defer Free(ctx)
 
 	chunks := InputChunksInit()
@@ -211,11 +241,17 @@ func TestInputChunkGetTokensImage(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("Failed to load model from file: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("Failed to initialize context from file: %v", err)
+	}
 	defer Free(ctx)
 
 	chunks := InputChunksInit()

--- a/pkg/mtmd/mtmd_test.go
+++ b/pkg/mtmd/mtmd_test.go
@@ -30,12 +30,18 @@ func TestInitFromFileAndFree(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
-	if ctx == Context(0) {
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	if ctx == 0 {
 		t.Fatal("InitFromFile returned an invalid context")
 	}
 
@@ -52,11 +58,17 @@ func TestSupportVision(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
 	defer Free(ctx)
 
 	supportsVision := SupportVision(ctx)
@@ -70,11 +82,17 @@ func TestTokenize(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
 	defer Free(ctx)
 
 	chunks := InputChunksInit()
@@ -107,14 +125,23 @@ func TestHelperEvalChunks(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
 	defer Free(ctx)
 
-	lctx := llama.InitFromModel(model, llama.ContextDefaultParams())
+	lctx, err := llama.InitFromModel(model, llama.ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
 	defer llama.Free(lctx)
 
 	chunks := InputChunksInit()
@@ -141,11 +168,17 @@ func TestDecodeUseNonCausal(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
 	defer Free(ctx)
 
 	useNonCausal := DecodeUseNonCausal(ctx)
@@ -159,11 +192,17 @@ func TestDecodeUseMRope(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
 	defer Free(ctx)
 
 	useMRope := DecodeUseMRope(ctx)
@@ -177,11 +216,17 @@ func TestSupportAudio(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
 	defer Free(ctx)
 
 	supportsAudio := SupportAudio(ctx)
@@ -195,11 +240,17 @@ func TestGetAudioBitrate(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	model := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
 	defer llama.ModelFree(model)
 
 	params := ContextParamsDefault()
-	ctx := InitFromFile(mmprojFile, model, params)
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
 	defer Free(ctx)
 
 	bitrate := GetAudioBitrate(ctx)


### PR DESCRIPTION
This changes many function signature to now return an error in addition to whatever they previously were returning. It is a breaking change, but seems like needed in order to make the package more robust and so callers can more easily determine what has gone wrong if/when something does.