### PR TITLE
feature: update to use new mtmd_log_set function

### DIFF
--- a/examples/describe/describe.go
+++ b/examples/describe/describe.go
@@ -20,7 +20,7 @@ func describe(tmpFile string) error {
 		fmt.Println("Using model", path.Join(*modelsDir, *modelFile))
 	default:
 		llama.LogSet(llama.LogSilent())
-		mtmdCtxParams.Verbosity = llama.LogLevelContinue
+		mtmd.LogSet(llama.LogSilent())
 	}
 
 	model, err := llama.ModelLoadFromFile(path.Join(*modelsDir, *modelFile), llama.ModelDefaultParams())

--- a/examples/vlm/main.go
+++ b/examples/vlm/main.go
@@ -36,7 +36,7 @@ func main() {
 	mctxParams := mtmd.ContextParamsDefault()
 	if !*verbose {
 		llama.LogSet(llama.LogSilent())
-		mctxParams.Verbosity = llama.LogLevelContinue
+		mtmd.LogSet(llama.LogSilent())
 	}
 
 	llama.Init()

--- a/pkg/llama/logs.go
+++ b/pkg/llama/logs.go
@@ -27,14 +27,13 @@ func loadLogFuncs(lib ffi.Lib) error {
 	return nil
 }
 
-// LogSet sets the logging mode. Pass [LogSilent()] to turn logging off. Pass nil to use stdout.
-// Note that if you turn logging off when using the [mtmd] package, you must also set Verbosity = llama.LogLevelContinue.
+// LogSet sets the logging mode. Pass llama.LogSilent() to turn logging off. Pass nil to use stdout.
 func LogSet(cb uintptr) {
 	nada := uintptr(0)
 	logSetFunc.Call(nil, unsafe.Pointer(&cb), unsafe.Pointer(&nada))
 }
 
-// LogSilent is a callback function that you can pass into the [LogSet] function to turn logging off.
+// LogSilent is a callback function that you can pass into the LogSet function to turn logging off.
 func LogSilent() uintptr {
 	return purego.NewCallback(func(level int32, text, data uintptr) uintptr {
 		return 0


### PR DESCRIPTION
This PR adds the new `mtmd_log_set function` and removes `Verbosity` from the config params to match `llama.cpp` recent changes in https://github.com/ggml-org/llama.cpp/pull/17268