### PR TITLE
feature: add LogNormal constant for turning llama.cpp logs on

### DIFF
--- a/pkg/llama/logs.go
+++ b/pkg/llama/logs.go
@@ -39,3 +39,6 @@ func LogSilent() uintptr {
 		return 0
 	})
 }
+
+// LogNormal is a value you can pass into the LogSet function to turn standard logging on.
+const LogNormal uintptr = 0

--- a/pkg/llama/logs_test.go
+++ b/pkg/llama/logs_test.go
@@ -18,3 +18,20 @@ func TestLogSilent(t *testing.T) {
 
 	t.Log("Logs should be silent on this test")
 }
+
+func TestLogNormal(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	LogSet(LogNormal)
+
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("Failed to load model from file: %v", err)
+	}
+	defer ModelFree(model)
+
+	t.Log("Logs should be normal on this test")
+}


### PR DESCRIPTION
This PR adds a `llama.LogNormal` constant for turning llama.cpp logs on, if they have been turned off.