### PR TITLE
feature: implement GGML device types

### DIFF
--- a/pkg/llama/ggml.go
+++ b/pkg/llama/ggml.go
@@ -3,7 +3,24 @@ package llama
 import (
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
+)
+
+type (
+	GGMLBackendDeviceType int32
+	GGMLBackendDevice     uintptr
+)
+
+const (
+	// CPU device using system memory
+	GGMLBackendDeviceTypeCPU GGMLBackendDeviceType = iota
+	// GPU device using dedicated memory
+	GGMLBackendDeviceTypeGPU
+	// integrated GPU device using host memory
+	GGMLBackendDeviceTypeIGPU
+	// accelerator devices intended to be used together with the CPU backend (e.g. BLAS or AMX)
+	GGMLBackendDeviceTypeACCEL
 )
 
 var (
@@ -12,6 +29,19 @@ var (
 
 	// GGML_API void ggml_backend_load_all(void);
 	ggmlBackendLoadAllFromPath ffi.Fun
+
+	// Device enumeration
+	// GGML_API size_t             ggml_backend_dev_count(void);
+	ggmlBackendDevCountFunc ffi.Fun
+
+	// GGML_API ggml_backend_dev_t ggml_backend_dev_get(size_t index);
+	ggmlBackendDevGetFunc ffi.Fun
+
+	// GGML_API ggml_backend_dev_t ggml_backend_dev_by_name(const char * name);
+	ggmlBackendDevByNameFunc ffi.Fun
+
+	// GGML_API ggml_backend_dev_t ggml_backend_dev_by_type(enum ggml_backend_dev_type type);
+	ggmlBackendDevByTypeFunc ffi.Fun
 )
 
 func loadGGML(lib ffi.Lib) error {
@@ -23,6 +53,22 @@ func loadGGML(lib ffi.Lib) error {
 
 	if ggmlBackendLoadAllFromPath, err = lib.Prep("ggml_backend_load_all_from_path", &ffi.TypeVoid, &ffi.TypePointer); err != nil {
 		return loadError("ggml_backend_load_all_from_path", err)
+	}
+
+	if ggmlBackendDevCountFunc, err = lib.Prep("ggml_backend_dev_count", &ffi.TypeUint64); err != nil {
+		return loadError("ggml_backend_dev_count", err)
+	}
+
+	if ggmlBackendDevGetFunc, err = lib.Prep("ggml_backend_dev_get", &ffi.TypePointer, &ffi.TypeUint64); err != nil {
+		return loadError("ggml_backend_dev_get", err)
+	}
+
+	if ggmlBackendDevByNameFunc, err = lib.Prep("ggml_backend_dev_by_name", &ffi.TypePointer, &ffi.TypePointer); err != nil {
+		return loadError("ggml_backend_dev_by_name", err)
+	}
+
+	if ggmlBackendDevByTypeFunc, err = lib.Prep("ggml_backend_dev_by_type", &ffi.TypePointer, &ffi.TypeSint32); err != nil {
+		return loadError("ggml_backend_dev_by_type", err)
 	}
 
 	return nil
@@ -37,4 +83,33 @@ func GGMLBackendLoadAll() {
 func GGMLBackendLoadAllFromPath(path string) {
 	p := &[]byte(path + "\x00")[0]
 	ggmlBackendLoadAllFromPath.Call(nil, unsafe.Pointer(&p))
+}
+
+// GGMLBackendDeviceCount returns the number of backend devices.
+func GGMLBackendDeviceCount() uint64 {
+	var ret ffi.Arg
+	ggmlBackendDevCountFunc.Call(unsafe.Pointer(&ret))
+	return uint64(ret)
+}
+
+// GGMLBackendDeviceGet returns the backend device at the given index.
+func GGMLBackendDeviceGet(index uint64) GGMLBackendDevice {
+	var ret GGMLBackendDevice
+	ggmlBackendDevGetFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&index))
+	return ret
+}
+
+// GGMLBackendDeviceByName returns the backend device by its name.
+func GGMLBackendDeviceByName(name string) GGMLBackendDevice {
+	namePtr, _ := utils.BytePtrFromString(name)
+	var ret GGMLBackendDevice
+	ggmlBackendDevByNameFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&namePtr))
+	return ret
+}
+
+// GGMLBackendDeviceByType returns the backend device by its type.
+func GGMLBackendDeviceByType(devType GGMLBackendDeviceType) GGMLBackendDevice {
+	var ret GGMLBackendDevice
+	ggmlBackendDevByTypeFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&devType))
+	return ret
 }

--- a/pkg/llama/ggml_test.go
+++ b/pkg/llama/ggml_test.go
@@ -1,0 +1,81 @@
+package llama
+
+import "testing"
+
+func TestGGMLBackendDevCount(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	count := GGMLBackendDeviceCount()
+	t.Logf("GGMLBackendDeviceCount returned: %d", count)
+	if count == 0 {
+		t.Skip("No backend devices found")
+	}
+}
+
+func TestGGMLBackendDeviceGet(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	count := GGMLBackendDeviceCount()
+	if count == 0 {
+		t.Skip("No backend devices to get")
+	}
+	dev := GGMLBackendDeviceGet(0)
+	if dev == 0 {
+		t.Fatal("GGMLBackendDeviceGet returned 0 for index 0")
+	}
+	t.Logf("GGMLBackendDeviceGet(0) returned: %v", dev)
+}
+
+func TestGGMLBackendDeviceByType(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	// Try CPU device type
+	dev := GGMLBackendDeviceByType(GGMLBackendDeviceTypeCPU)
+	if dev == 0 {
+		t.Fatal("GGMLBackendDeviceByType(GGMLBackendDeviceTypeCPU) returned 0")
+	} else {
+		t.Logf("GGMLBackendDeviceByType(GGMLBackendDeviceTypeCPU) returned: %v", dev)
+	}
+}
+
+func TestGGMLBackendDeviceByName(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	count := GGMLBackendDeviceCount()
+	if count == 0 {
+		t.Skip("No backend devices to get name from")
+	}
+
+	dev := GGMLBackendDeviceByName("CPU")
+	if dev == 0 {
+		t.Fatal("GGMLBackendDeviceByName(\"CPU\") returned 0")
+	} else {
+		t.Logf("GGMLBackendDeviceByName(\"CPU\") returned: %v", dev)
+	}
+}
+
+func TestGGMLBackendDeviceName(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	count := GGMLBackendDeviceCount()
+	if count == 0 {
+		t.Skip("No backend devices to get name from")
+	}
+
+	dev := GGMLBackendDeviceGet(0)
+	if dev == 0 {
+		t.Fatal("GGMLBackendDeviceGet(0) returned 0")
+	}
+
+	name := GGMLBackendDeviceName(dev)
+	if name == "" {
+		t.Fatal("GGMLBackendDeviceName returned empty string")
+	} else {
+		t.Logf("GGMLBackendDeviceName returned: %s", name)
+	}
+}

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -722,6 +722,18 @@ func (p *ModelParams) SetProgressCallback(cb ProgressCallback) {
 	p.ProgressCallback = uintptr(callback)
 }
 
+// SetDevices sets the devices to be used for model execution.
+// An empty slice indicates that no specific devices are set, meaning
+// that the default device selection will be used.
+func (p *ModelParams) SetDevices(devices []GGMLBackendDevice) {
+	if len(devices) == 0 {
+		p.Devices = uintptr(0)
+		return
+	}
+
+	p.Devices = uintptr(unsafe.Pointer(&devices[0]))
+}
+
 // ModelQuantizeDefaultParams returns default parameters for model quantization.
 func ModelQuantizeDefaultParams() ModelQuantizeParams {
 	var p ModelQuantizeParams


### PR DESCRIPTION
This PR is to implement GGML device types for selection of specific hardware devices for model inference.

Needed for things like benchmarking a specific device, or finer granularity of choice for inference on multiple models with multiple GPUs.