### PR TITLE
build: update GH actions build to use macOS 15

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,7 +60,7 @@ jobs:
           export YZMA_TEST_ENCODER_MODEL=$GITHUB_WORKSPACE/models/t5base-encoder-q4_0.gguf
           export YZMA_TEST_LORA_MODEL=$GITHUB_WORKSPACE/models/Gemma2-Base-F32.gguf
           export YZMA_TEST_LORA_ADAPTER=$GITHUB_WORKSPACE/models/Gemma2-Lora-F32-LoRA.gguf
-          go test -v ./...
+          CGO_ENABLED=0 go test -v ./...
       - name: Run inference test
         run: go run ./examples/hello
       - name: Run embedding test


### PR DESCRIPTION
This PR updates the GH actions build to use macOS 15 to attempt address some of the recent sporadic macOS test failures. 

ALso use `CGO_ENABLED=0` for macOS test run.