### PR TITLE
test: skip progress callback test on macOS

### DIFF
--- a/pkg/llama/model_test.go
+++ b/pkg/llama/model_test.go
@@ -3,6 +3,7 @@ package llama
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -388,6 +389,10 @@ func TestModelMetaValStr(t *testing.T) {
 }
 
 func TestModelLoadCallback(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping TestModelLoadCallback on macOS due to callback race issues.")
+	}
+
 	modelFile := testModelFileName(t)
 	testSetup(t)
 	defer testCleanup(t)


### PR DESCRIPTION
This PR skips the progress callback test on macOS due to periodic test fails. Probably some race condition.

See https://github.com/hybridgroup/yzma/issues/91