### PR TITLE
Fixing Issue 95 with downloading llamacpp

### DIFF
--- a/pkg/download/install.go
+++ b/pkg/download/install.go
@@ -51,7 +51,7 @@ func InstallLibraries(libPath string, processor Processor, allowUpgrade bool) er
 func alreadyInstalled(libPath string) bool {
 	versionInfoPath := filepath.Join(libPath, versionFile)
 
-	if _, err := os.Stat(versionInfoPath); os.IsNotExist(err) {
+	if _, err := os.Stat(versionInfoPath); err != nil {
 		return false
 	}
 


### PR DESCRIPTION
This fixes the download bug based on [issue 95](https://github.com/hybridgroup/yzma/issues/95). 