### PR TITLE
fix: use singleton for model progress loader callback

### DIFF
--- a/pkg/llama/model_test.go
+++ b/pkg/llama/model_test.go
@@ -3,7 +3,6 @@ package llama
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 )
 
@@ -389,10 +388,6 @@ func TestModelMetaValStr(t *testing.T) {
 }
 
 func TestModelLoadCallback(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("Skipping TestModelLoadCallback on macOS due to callback race issues.")
-	}
-
 	modelFile := testModelFileName(t)
 	testSetup(t)
 	defer testCleanup(t)


### PR DESCRIPTION
This PR uses a singleton for the model progress loader callback, and checks the params passed in to the callback at runtime to avoid segfault.