### PR TITLE
Introduce a mechanism to notify downstream projects of a new YZMA release

### DIFF
--- a/.github/workflows/notify-release.yaml.yml
+++ b/.github/workflows/notify-release.yaml.yml
@@ -1,0 +1,17 @@
+name: Notify on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-downstream:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger downstream repository (KRONK)
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.KRONK_REPO_TOKEN }}" \
+            https://api.github.com/repos/ardanlabs/kronk/dispatches \
+            -d '{"event_type":"external-release","client_payload":{"version":"${{ github.event.release.tag_name }}","release_name":"${{ github.event.release.name }}","release_url":"${{ github.event.release.html_url }}"}}'


### PR DESCRIPTION
This PR introduces the capability of notifying third-party repositories of a new release.

You will need to add a new secret to the repository named `KRONK_REPO_TOKEN` so the workflow can be triggered automatically. @ardan-bkennedy will be able to provide that outside of Github channels :)

Fixes #109

P.S. This depends on https://github.com/ardanlabs/kronk/pull/16 being merged, instead of just the `KRONK_REPO_TOKEN` secret configuration.
