### PR TITLE
feature: use runtime.GOARCH for download to support arm64 on Linux/Windows

### DIFF
--- a/examples/installer/main.go
+++ b/examples/installer/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	fmt.Println("installing llama.cpp version", *version, "to", *libPath)
-	if err := download.Get(runtime.GOOS, *processor, *version, *libPath); err != nil {
+	if err := download.Get(runtime.GOARCH, runtime.GOOS, *processor, *version, *libPath); err != nil {
 		fmt.Println("failed to download llama.cpp:", err.Error())
 		return
 	}

--- a/pkg/download/arch.go
+++ b/pkg/download/arch.go
@@ -1,0 +1,63 @@
+package download
+
+import "fmt"
+
+// The set of architectures that can be used.
+var (
+	AMD64 = newArch("amd64")
+	ARM64 = newArch("arm64")
+)
+
+// =============================================================================
+
+// Set of known architectures.
+var archs = make(map[string]Arch)
+
+// Arch represents a architecture option.
+type Arch struct {
+	value string
+}
+
+func newArch(arch string) Arch {
+	a := Arch{arch}
+	archs[arch] = a
+	return a
+}
+
+// String returns the name of the architecture.
+func (a Arch) String() string {
+	return a.value
+}
+
+// Equal provides support for the go-cmp package and testing.
+func (a Arch) Equal(a2 Arch) bool {
+	return a.value == a2.value
+}
+
+// MarshalText provides support for logging and any marshal needs.
+func (a Arch) MarshalText() ([]byte, error) {
+	return []byte(a.value), nil
+}
+
+// =============================================================================
+
+// ParseArch parses the string value and returns an Arch if one exists.
+func ParseArch(value string) (Arch, error) {
+	arch, exists := archs[value]
+	if !exists {
+		return Arch{}, fmt.Errorf("invalid architecture %q", value)
+	}
+
+	return arch, nil
+}
+
+// MustParseArch parses the string value and returns an Arch if one exists. If
+// an error occurs the function panics.
+func MustParseArch(value string) Arch {
+	arch, err := ParseArch(value)
+	if err != nil {
+		panic(err)
+	}
+
+	return arch
+}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -13,6 +13,7 @@ import (
 )
 
 var (
+	ErrUnknownArch      = errors.New("unknown architecture")
 	ErrUnknownOS        = errors.New("unknown OS")
 	ErrUnknownProcessor = errors.New("unknown processor")
 	ErrInvalidVersion   = errors.New("invalid version")
@@ -60,13 +61,99 @@ func getLatestVersion() (string, error) {
 	return result.TagName, nil
 }
 
-// Get downloads the llama.cpp precompiled binaries for the desired OS/processor.
+// getDownloadLocationAndFilename returns the download location and filename for the given parameters.
+func getDownloadLocationAndFilename(arch Arch, os OS, prcssr Processor, version string, dest string) (location, filename string, err error) {
+	location = fmt.Sprintf("https://github.com/ggml-org/llama.cpp/releases/download/%s", version)
+
+	switch os {
+	case Linux:
+		switch prcssr {
+		case CPU:
+			if arch == ARM64 {
+				return "", "", errors.New("precompiled binaries for Linux ARM64 CPU are not available")
+			}
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-x64.zip//build/bin", version)
+		case CUDA:
+			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+			if arch == ARM64 {
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-arm64.zip", version)
+			} else {
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-x64.zip", version)
+			}
+		case Vulkan:
+			if arch == ARM64 {
+				return "", "", errors.New("precompiled binaries for Linux ARM64 Vulkan are not available")
+			}
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.zip//build/bin", version)
+		default:
+			return "", "", ErrUnknownProcessor
+		}
+
+	case Darwin:
+		switch prcssr {
+		case Metal:
+			if arch != ARM64 {
+				return "", "", errors.New("precompiled binaries for macOS non-ARM64 CPU/Metal are not available")
+			}
+			filename = fmt.Sprintf("llama-%s-bin-macos-arm64.zip//build/bin", version)
+		case CPU:
+			if arch == ARM64 {
+				filename = fmt.Sprintf("llama-%s-bin-macos-arm64-cpu.zip//build/bin", version)
+			} else {
+				filename = fmt.Sprintf("llama-%s-bin-macos-x64-cpu.zip//build/bin", version)
+			}
+		default:
+			return "", "", ErrUnknownProcessor
+		}
+
+	case Windows:
+		switch prcssr {
+		case CPU:
+			if arch == ARM64 {
+				filename = fmt.Sprintf("llama-%s-bin-win-cpu-arm64.zip", version)
+			} else {
+				filename = fmt.Sprintf("llama-%s-bin-win-cpu-x64.zip", version)
+			}
+		case CUDA:
+			if arch == ARM64 {
+				return "", "", errors.New("precompiled binaries for Windows ARM64 CUDA are not available")
+			}
+			// also requires the CUDA RT files
+			cudart := "cudart-llama-bin-win-cuda-12.4-x64.zip"
+			url := fmt.Sprintf("%s/%s", location, cudart)
+			if err := get(url, dest); err != nil {
+				return "", "", err
+			}
+			filename = fmt.Sprintf("llama-%s-bin-win-cuda-12.4-x64.zip", version)
+		case Vulkan:
+			if arch == ARM64 {
+				return "", "", errors.New("precompiled binaries for Windows ARM64 Vulkan are not available")
+			}
+			filename = fmt.Sprintf("llama-%s-bin-win-vulkan-x64.zip", version)
+		default:
+			return "", "", ErrUnknownProcessor
+		}
+
+	default:
+		return "", "", ErrUnknownOS
+	}
+
+	return location, filename, nil
+}
+
+// Get downloads the llama.cpp precompiled binaries for the desired arch/OS/processor.
+// arch can be one of the following values: "amd64", "arm64".
 // os can be one of the following values: "linux", "darwin", "windows".
 // processor can be one of the following values: "cpu", "cuda", "vulkan", "metal".
 // version should be the desired `b1234` formatted llama.cpp version. You can use the
 // [LlamaLatestVersion] function to obtain the latest release.
 // dest in the destination directory for the downloaded binaries.
-func Get(operatingSystem string, processor string, version string, dest string) error {
+func Get(architecture string, operatingSystem string, processor string, version string, dest string) error {
+	arch, err := ParseArch(architecture)
+	if err != nil {
+		return ErrUnknownArch
+	}
+
 	os, err := ParseOS(operatingSystem)
 	if err != nil {
 		return ErrUnknownOS
@@ -78,55 +165,12 @@ func Get(operatingSystem string, processor string, version string, dest string) 
 	}
 
 	if err := VersionIsValid(version); err != nil {
-		return err
+		return ErrInvalidVersion
 	}
 
-	var location, filename string
-	location = fmt.Sprintf("https://github.com/ggml-org/llama.cpp/releases/download/%s", version)
-
-	switch os {
-	case Linux:
-		switch prcssr {
-		case CPU:
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-x64.zip//build/bin", version)
-		case CUDA:
-			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-x64.zip", version)
-		case Vulkan:
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.zip//build/bin", version)
-		default:
-			return ErrUnknownProcessor
-		}
-
-	case Darwin:
-		switch prcssr {
-		case CPU, Metal:
-			filename = fmt.Sprintf("llama-%s-bin-macos-arm64.zip//build/bin", version)
-		default:
-			return ErrUnknownProcessor
-		}
-
-	case Windows:
-		switch prcssr {
-		case CPU:
-			filename = fmt.Sprintf("llama-%s-bin-win-cpu-x64.zip", version)
-		case CUDA:
-			// also requires the CUDA RT files
-			cudart := "cudart-llama-bin-win-cuda-12.4-x64.zip"
-			url := fmt.Sprintf("%s/%s", location, cudart)
-			if err := get(url, dest); err != nil {
-				return err
-			}
-
-			filename = fmt.Sprintf("llama-%s-bin-win-cuda-12.4-x64.zip", version)
-		case Vulkan:
-			filename = fmt.Sprintf("llama-%s-bin-win-vulkan-x64.zip", version)
-		default:
-			return ErrUnknownProcessor
-		}
-
-	default:
-		return ErrUnknownOS
+	location, filename, err := getDownloadLocationAndFilename(arch, os, prcssr, version, dest)
+	if err != nil {
+		return err
 	}
 
 	url := fmt.Sprintf("%s/%s", location, filename)

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -27,11 +27,12 @@ func TestLlamaLatestVersion(t *testing.T) {
 
 func TestGetLinuxCPU(t *testing.T) {
 	version := "b6795"
+	arch := "amd64"
 	osVer := "linux"
 	processor := "cpu"
 	dest := t.TempDir()
 
-	err := Get(osVer, processor, version, dest)
+	err := Get(arch, osVer, processor, version, dest)
 	if err != nil {
 		t.Fatalf("Get() failed: %v", err)
 	}
@@ -46,11 +47,12 @@ func TestGetLinuxCPU(t *testing.T) {
 
 func TestGetInvalidOS(t *testing.T) {
 	version := "b6795"
+	arch := "amd64"
 	osVer := "cpm"
 	processor := "cpu"
 	dest := t.TempDir()
 
-	err := Get(osVer, processor, version, dest)
+	err := Get(arch, osVer, processor, version, dest)
 	if err != ErrUnknownOS {
 		t.Fatalf("Get() should have failed: %v", err)
 	}
@@ -58,11 +60,12 @@ func TestGetInvalidOS(t *testing.T) {
 
 func TestGetInvalidProcessor(t *testing.T) {
 	version := "b6795"
+	arch := "amd64"
 	osVer := "windows"
 	processor := "flux"
 	dest := t.TempDir()
 
-	err := Get(osVer, processor, version, dest)
+	err := Get(arch, osVer, processor, version, dest)
 	if err != ErrUnknownProcessor {
 		t.Fatalf("Get() should have failed: %v", err)
 	}
@@ -70,11 +73,12 @@ func TestGetInvalidProcessor(t *testing.T) {
 
 func TestGetInvalidVersion(t *testing.T) {
 	version := "nogood"
+	arch := "amd64"
 	osVer := "linux"
 	processor := "cpu"
 	dest := t.TempDir()
 
-	err := Get(osVer, processor, version, dest)
+	err := Get(arch, osVer, processor, version, dest)
 	if err != ErrInvalidVersion {
 		t.Fatalf("Get() should have failed: %v", err)
 	}

--- a/pkg/download/install.go
+++ b/pkg/download/install.go
@@ -120,7 +120,7 @@ func installLlamaCpp(libPath string, processor Processor, version string) error 
 		os.RemoveAll(libPath)
 	}
 
-	if err := Get(runtime.GOOS, processor.String(), version, libPath); err != nil {
+	if err := Get(runtime.GOARCH, runtime.GOOS, processor.String(), version, libPath); err != nil {
 		return fmt.Errorf("error downloading llama.cpp: %w", err)
 	}
 


### PR DESCRIPTION
This PR is to use `runtime.GOARCH` for downloads to support `arm64` on Linux/Windows for certain configurations, most importantly CUDA arm64 devices such as Nvidia Jetson.

Unfortunately this requires a small breaking change to accommodate this in the `download.Get()` function.

I probably should have added it sooner just to future proof it, but here we are now.