### PR TITLE
feature: add download location for llama.cpp prebuilt binaries for Linux arm64 Vulkan

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -82,7 +82,9 @@ func getDownloadLocationAndFilename(arch Arch, os OS, prcssr Processor, version 
 			}
 		case Vulkan:
 			if arch == ARM64 {
-				return "", "", errors.New("precompiled binaries for Linux ARM64 Vulkan are not available")
+				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-arm64.zip", version)
+				break
 			}
 			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.zip//build/bin", version)
 		default:


### PR DESCRIPTION
This PR adds the download location for `llama.cpp` prebuilt binaries for Linux arm64 Vulkan.