### PR TITLE
fix: increase size of return buffer for metadata calls

### DIFF
--- a/pkg/llama/lora.go
+++ b/pkg/llama/lora.go
@@ -145,7 +145,7 @@ func AdapterMetaValStr(adapter AdapterLora, key string) (string, bool) {
 	if adapter == 0 {
 		return "", false
 	}
-	buf := make([]byte, 8192)
+	buf := make([]byte, 32768)
 	b := unsafe.SliceData(buf)
 	bLen := int32(len(buf))
 
@@ -211,7 +211,7 @@ func AdapterMetaValStrByIndex(adapter AdapterLora, i int32) (string, bool) {
 	if adapter == 0 {
 		return "", false
 	}
-	buf := make([]byte, 8192)
+	buf := make([]byte, 32768)
 	b := unsafe.SliceData(buf)
 	bLen := int32(len(buf))
 

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -586,7 +586,7 @@ func ModelMetaValStr(model Model, key string) (string, bool) {
 	if model == 0 {
 		return "", false
 	}
-	buf := make([]byte, 8192)
+	buf := make([]byte, 32768)
 	b := unsafe.SliceData(buf)
 	bLen := int32(len(buf))
 
@@ -654,7 +654,7 @@ func ModelMetaValStrByIndex(model Model, i int32) (string, bool) {
 	if model == 0 {
 		return "", false
 	}
-	buf := make([]byte, 8192)
+	buf := make([]byte, 32768)
 	b := unsafe.SliceData(buf)
 	bLen := int32(len(buf))
 


### PR DESCRIPTION
This PR increase size of return buffer for metadata calls, since they are also used for prompt templates.

Fixes #114 