### PR TITLE
feature: add new mtmd_context_params::warmup param

### DIFF
--- a/pkg/mtmd/mtmd.go
+++ b/pkg/mtmd/mtmd.go
@@ -35,13 +35,15 @@ type ContextParamsType struct {
 	ImageMarker        *byte
 	MediaMarker        *byte
 	FlashAttentionType llama.FlashAttentionType
-	ImageMinTokens     int32
-	ImageMaxTokens     int32
+	// whether to run a warmup encode pass after initialization
+	Warmup         bool
+	ImageMinTokens int32
+	ImageMaxTokens int32
 }
 
 var (
 	FFITypeContextParams = ffi.NewType(&ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer,
-		&ffi.TypeUint8, &ffi.TypeSint32, &ffi.TypeSint32)
+		&ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeSint32, &ffi.TypeSint32)
 	FFITypeInputText = ffi.NewType(&ffi.TypePointer, &ffi.TypeUint8, &ffi.TypeUint8)
 )
 


### PR DESCRIPTION
This PR adds the new `mtmd_context_params::warmup` param from `llama.cpp`.

See https://github.com/ggml-org/llama.cpp/pull/17652