### PR TITLE
feature: use go-getter for all downloads with available progress tracking

### DIFF
--- a/pkg/download/models.go
+++ b/pkg/download/models.go
@@ -2,20 +2,16 @@ package download
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"os"
-	"time"
 
 	getter "github.com/hashicorp/go-getter"
 )
 
 // GetModel downloads a model from the specified URL to the destination path.
-func GetModel(url, dest string, showProgress bool) error {
-	return getModel(url, dest, showProgress)
+func GetModel(url, dest string) error {
+	return getModel(url, dest)
 }
 
-func getModel(url, dest string, showProgress bool) error {
+func getModel(url, dest string) error {
 	client := &getter.Client{
 		Ctx:  context.Background(),
 		Src:  url,
@@ -23,20 +19,8 @@ func getModel(url, dest string, showProgress bool) error {
 		Mode: getter.ClientModeAny,
 	}
 
-	if showProgress {
-		progFunc := func(src string, currentSize int64, totalSize int64, mibPerSec float64, complete bool) {
-			fmt.Printf("\r\x1b[KDownloading %s... %d MiB of %d MiB (%.2f MiB/s)", src, currentSize/(1024*1024), totalSize/(1024*1024), mibPerSec)
-			if complete {
-				fmt.Println()
-			}
-		}
-
-		pr := progressReader{
-			dst:      dest,
-			progress: progFunc,
-		}
-
-		client.ProgressListener = getter.ProgressTracker(&pr)
+	if ShowProgress {
+		client.ProgressListener = progressTracker(dest)
 	}
 
 	if err := client.Get(); err != nil {
@@ -44,69 +28,4 @@ func getModel(url, dest string, showProgress bool) error {
 	}
 
 	return nil
-}
-
-type progressFunc func(src string, currentSize int64, totalSize int64, mibPerSec float64, complete bool)
-
-type progressReader struct {
-	src          string
-	dst          string
-	currentSize  int64
-	totalSize    int64
-	lastReported int64
-	startTime    time.Time
-	reader       io.ReadCloser
-	progress     progressFunc
-}
-
-func (pr *progressReader) TrackProgress(src string, currentSize, totalSize int64, stream io.ReadCloser) io.ReadCloser {
-	if currentSize == totalSize {
-		return nil
-	}
-
-	if currentSize != totalSize {
-		os.Remove(pr.dst)
-	}
-
-	pr.src = src
-	pr.currentSize = currentSize
-	pr.totalSize = totalSize
-	pr.startTime = time.Now()
-	pr.reader = stream
-
-	return pr
-}
-
-const (
-	mib    = 1024 * 1024
-	mib100 = mib * 100
-)
-
-func (pr *progressReader) Read(p []byte) (int, error) {
-	n, err := pr.reader.Read(p)
-	pr.currentSize += int64(n)
-
-	if pr.progress != nil && pr.currentSize-pr.lastReported >= mib100 {
-		pr.lastReported = pr.currentSize
-		pr.progress(pr.src, pr.currentSize, pr.totalSize, pr.mibPerSec(), false)
-	}
-
-	return n, err
-}
-
-func (pr *progressReader) Close() error {
-	if pr.progress != nil {
-		pr.progress(pr.src, pr.currentSize, pr.totalSize, pr.mibPerSec(), true)
-	}
-
-	return pr.reader.Close()
-}
-
-func (pr *progressReader) mibPerSec() float64 {
-	elapsed := time.Since(pr.startTime).Seconds()
-	if elapsed == 0 {
-		return 0
-	}
-
-	return float64(pr.currentSize) / mib / elapsed
 }

--- a/pkg/download/models_test.go
+++ b/pkg/download/models_test.go
@@ -10,7 +10,8 @@ func TestGetModel(t *testing.T) {
 	url := "https://huggingface.co/ggml-org/models-moved/resolve/main/tinyllamas/stories260K.gguf"
 	dest := filepath.Join(t.TempDir(), "stories260K.gguf")
 
-	err := GetModel(url, dest, false)
+	ShowProgress = false
+	err := GetModel(url, dest)
 	if err != nil {
 		t.Fatalf("GetModel() failed: %v", err)
 	}
@@ -26,7 +27,8 @@ func TestGetModelProgress(t *testing.T) {
 	url := "https://huggingface.co/ggml-org/models-moved/resolve/main/tinyllamas/stories260K.gguf"
 	dest := filepath.Join(t.TempDir(), "stories260K.gguf")
 
-	err := GetModel(url, dest, true)
+	ShowProgress = true
+	err := GetModel(url, dest)
 	if err != nil {
 		t.Fatalf("GetModel() failed: %v", err)
 	}

--- a/pkg/download/progress.go
+++ b/pkg/download/progress.go
@@ -1,0 +1,94 @@
+package download
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/hashicorp/go-getter"
+)
+
+// ShowProgress indicates whether to show download progress.
+var ShowProgress = true
+
+func progressTracker(dest string) getter.ProgressTracker {
+	progFunc := func(src string, currentSize int64, totalSize int64, mibPerSec float64, complete bool) {
+		fmt.Printf("\r\x1b[Kdownloading %s... %d MiB of %d MiB (%.2f MiB/s)", src, currentSize/(1024*1024), totalSize/(1024*1024), mibPerSec)
+		if complete {
+			fmt.Println()
+		}
+	}
+
+	pr := progressReader{
+		dst:      dest,
+		progress: progFunc,
+	}
+
+	return getter.ProgressTracker(&pr)
+}
+
+type progressFunc func(src string, currentSize int64, totalSize int64, mibPerSec float64, complete bool)
+
+type progressReader struct {
+	src          string
+	dst          string
+	currentSize  int64
+	totalSize    int64
+	lastReported int64
+	startTime    time.Time
+	reader       io.ReadCloser
+	progress     progressFunc
+}
+
+func (pr *progressReader) TrackProgress(src string, currentSize, totalSize int64, stream io.ReadCloser) io.ReadCloser {
+	if currentSize == totalSize {
+		return nil
+	}
+
+	if currentSize != totalSize {
+		os.Remove(pr.dst)
+	}
+
+	pr.src = src
+	pr.currentSize = currentSize
+	pr.totalSize = totalSize
+	pr.startTime = time.Now()
+	pr.reader = stream
+
+	return pr
+}
+
+const (
+	mib    = 1024 * 1024
+	mib100 = mib * 100
+)
+
+func (pr *progressReader) Read(p []byte) (int, error) {
+	n, err := pr.reader.Read(p)
+	pr.currentSize += int64(n)
+
+	if pr.progress != nil && pr.currentSize-pr.lastReported >= mib100 {
+		pr.lastReported = pr.currentSize
+		pr.progress(pr.src, pr.currentSize, pr.totalSize, pr.mibPerSec(), false)
+	}
+
+	return n, err
+}
+
+func (pr *progressReader) Close() error {
+	if pr.progress != nil {
+		pr.progress(pr.src, pr.currentSize, pr.totalSize, pr.mibPerSec(), true)
+	}
+
+	return pr.reader.Close()
+}
+
+func (pr *progressReader) mibPerSec() float64 {
+	elapsed := time.Since(pr.startTime).Seconds()
+	if elapsed == 0 {
+		return 0
+	}
+
+	return float64(pr.currentSize) / mib / elapsed
+}


### PR DESCRIPTION
This PR uses go-getter for all downloads with available progress tracking. Still have to extract the tar.gz files ourselves during our install, but we get the download recovery and tracking part back.