### PR TITLE
download: use CUDA 13 builds for Windows and Linux amd64/arm64

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -98,9 +98,9 @@ func getDownloadLocationAndFilename(arch Arch, os OS, prcssr Processor, version 
 		case CUDA:
 			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
 			if arch == ARM64 {
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-arm64.tar.gz", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-13-arm64.tar.gz", version)
 			} else {
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-x64.tar.gz", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-13-x64.tar.gz", version)
 			}
 		case Vulkan:
 			if arch == ARM64 {
@@ -143,12 +143,12 @@ func getDownloadLocationAndFilename(arch Arch, os OS, prcssr Processor, version 
 				return "", "", errors.New("precompiled binaries for Windows ARM64 CUDA are not available")
 			}
 			// also requires the CUDA RT files
-			cudart := "cudart-llama-bin-win-cuda-12.4-x64.zip"
+			cudart := "cudart-llama-bin-win-cuda-13.1-x64.zip"
 			url := fmt.Sprintf("%s/%s", location, cudart)
 			if err := get(url, dest, ProgressTracker); err != nil {
 				return "", "", err
 			}
-			filename = fmt.Sprintf("llama-%s-bin-win-cuda-12.4-x64.zip", version)
+			filename = fmt.Sprintf("llama-%s-bin-win-cuda-13.1-x64.zip", version)
 		case Vulkan:
 			if arch == ARM64 {
 				return "", "", errors.New("precompiled binaries for Windows ARM64 Vulkan are not available")

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -289,7 +289,7 @@ func TestGetDownloadLocationAndFilename_LinuxCUDA_AMD64(t *testing.T) {
 	}
 
 	expectedLocation := "https://github.com/hybridgroup/llama-cpp-builder/releases/download/b7225"
-	expectedFilename := "llama-b7225-bin-ubuntu-cuda-x64.tar.gz"
+	expectedFilename := "llama-b7225-bin-ubuntu-cuda-13-x64.tar.gz"
 
 	if location != expectedLocation {
 		t.Errorf("location = %q, want %q", location, expectedLocation)
@@ -309,7 +309,7 @@ func TestGetDownloadLocationAndFilename_LinuxCUDA_ARM64(t *testing.T) {
 	}
 
 	expectedLocation := "https://github.com/hybridgroup/llama-cpp-builder/releases/download/b7225"
-	expectedFilename := "llama-b7225-bin-ubuntu-cuda-arm64.tar.gz"
+	expectedFilename := "llama-b7225-bin-ubuntu-cuda-13-arm64.tar.gz"
 
 	if location != expectedLocation {
 		t.Errorf("location = %q, want %q", location, expectedLocation)


### PR DESCRIPTION
This PR updates the `download` package to use the new CUDA 13 builds for Windows and Linux amd64/arm64.

See https://github.com/ggml-org/llama.cpp/pull/17839 and https://github.com/hybridgroup/llama-cpp-builder/pull/14