### PR TITLE
chore: change media marker location to start of prompt to match behavior in llama.cpp

### DIFF
--- a/examples/describe/describe.go
+++ b/examples/describe/describe.go
@@ -53,7 +53,7 @@ func describe(tmpFile string) error {
 	defer mtmd.Free(mtmdCtx)
 
 	template = llama.ModelChatTemplate(model, "")
-	messages = []llama.ChatMessage{llama.NewChatMessage("user", *prompt+mtmd.DefaultMarker())}
+	messages = []llama.ChatMessage{llama.NewChatMessage("user", mtmd.DefaultMarker()+*prompt)}
 	output := mtmd.InputChunksInit()
 	input := mtmd.NewInputText(chatTemplate(true), true, true)
 

--- a/examples/vlm/main.go
+++ b/examples/vlm/main.go
@@ -92,7 +92,7 @@ func main() {
 	if *systemPrompt != "" {
 		messages = append(messages, llama.NewChatMessage("system", *systemPrompt))
 	}
-	messages = append(messages, llama.NewChatMessage("user", *prompt+mtmd.DefaultMarker()))
+	messages = append(messages, llama.NewChatMessage("user", mtmd.DefaultMarker()+*prompt))
 
 	output := mtmd.InputChunksInit()
 	input := mtmd.NewInputText(chatTemplate(true), true, true)

--- a/pkg/mtmd/benchmark_test.go
+++ b/pkg/mtmd/benchmark_test.go
@@ -82,7 +82,7 @@ func benchmarkMultimodalInference(b *testing.B, mctx Context, ctx llama.Context,
 	vocab := llama.ModelGetVocab(model)
 
 	messages := make([]llama.ChatMessage, 0)
-	messages = append(messages, llama.NewChatMessage("user", text+DefaultMarker()))
+	messages = append(messages, llama.NewChatMessage("user", DefaultMarker()+text))
 	input := NewInputText(chatTemplate(template, messages, true), true, true)
 
 	output := InputChunksInit()


### PR DESCRIPTION
This PR is to change media marker location to start of prompt to match behavior in `llama.cpp`.

Seems like many new models expect this. See https://github.com/ggml-org/llama.cpp/pull/17909