### PR TITLE
feature: add new functions/params that were added to the llama.cpp API

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,7 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 - [x] `llama_flash_attn_type_name`
 - [x] `llama_max_devices`
 - [x] `llama_max_parallel_sequences`
+- [x] `llama_max_tensor_buft_overrides`
 - [x] `llama_numa_init`
 - [x] `llama_print_system_info`
 - [x] `llama_supports_gpu_offload`
@@ -37,6 +38,7 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 - [x] `llama_model_load_from_splits`
 - [x] `llama_model_meta_count`
 - [x] `llama_model_meta_key_by_index`
+- [x] `llama_model_meta_key_str`
 - [x] `llama_model_meta_val_str_by_index`
 - [x] `llama_model_meta_val_str`
 - [x] `llama_model_n_cls_out`
@@ -233,6 +235,7 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 - [ ] `llama_opt_epoch`
 - [ ] `llama_opt_init`
 - [ ] `llama_opt_param_filter_all`
+- [ ] `llama_params_fit`
 
 ### `mtmd` Functions still needing wrappers
 

--- a/pkg/llama/backend.go
+++ b/pkg/llama/backend.go
@@ -21,6 +21,9 @@ var (
 	// LLAMA_API size_t llama_max_parallel_sequences(void);
 	maxParallelSequencesFunc ffi.Fun
 
+	// LLAMA_API size_t llama_max_tensor_buft_overrides(void);
+	maxTensorBuftOverridesFunc ffi.Fun
+
 	// LLAMA_API bool llama_supports_mmap(void);
 	supportsMmapFunc ffi.Fun
 
@@ -63,6 +66,10 @@ func loadBackendFuncs(lib ffi.Lib) error {
 
 	if maxParallelSequencesFunc, err = lib.Prep("llama_max_parallel_sequences", &ffi.TypeUint32); err != nil {
 		return loadError("llama_max_parallel_sequences", err)
+	}
+
+	if maxTensorBuftOverridesFunc, err = lib.Prep("llama_max_tensor_buft_overrides", &ffi.TypeUint32); err != nil {
+		return loadError("llama_max_tensor_buft_overrides", err)
 	}
 
 	if supportsMmapFunc, err = lib.Prep("llama_supports_mmap", &ffi.TypeUint8); err != nil {
@@ -123,6 +130,13 @@ func MaxParallelSequences() uint64 {
 	var result ffi.Arg
 	maxParallelSequencesFunc.Call(unsafe.Pointer(&result))
 	return uint64(result)
+}
+
+// MaxTensorBuftOverrides returns the maximum number of tensor buffer overrides supported.
+func MaxTensorBuftOverrides() uint32 {
+	var result ffi.Arg
+	maxTensorBuftOverridesFunc.Call(unsafe.Pointer(&result))
+	return uint32(result)
 }
 
 // SupportsMmap checks if memory-mapped files are supported.

--- a/pkg/llama/backend_test.go
+++ b/pkg/llama/backend_test.go
@@ -26,6 +26,17 @@ func TestMaxParallelSequences(t *testing.T) {
 	t.Logf("MaxParallelSequences returned: %d", maxParallelSequences)
 }
 
+func TestMaxTensorBuftOverrides(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	max := MaxTensorBuftOverrides()
+	if max == 0 {
+		t.Fatal("MaxTensorBuftOverrides returned 0, which is invalid")
+	}
+	t.Logf("MaxTensorBuftOverrides returned: %d", max)
+}
+
 func TestSupportsMmap(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -226,6 +226,23 @@ const (
 	LogLevelContinue LogLevel = 5
 )
 
+type ModelMetaKey int32
+
+const (
+	ModelMetaKeySamplingSequence ModelMetaKey = iota
+	ModelMetaKeySamplingTopK
+	ModelMetaKeySamplingTopP
+	ModelMetaKeySamplingMinP
+	ModelMetaKeySamplingXTCProb
+	ModelMetaKeySamplingXTCThold
+	ModelMetaKeySamplingTemp
+	ModelMetaKeySamplingPenaltyLastN
+	ModelMetaKeySamplingPenaltyRepeat
+	ModelMetaKeySamplingMirostat
+	ModelMetaKeySamplingMirostatTau
+	ModelMetaKeySamplingMirostatEta
+)
+
 // Opaque types (represented as pointers)
 type (
 	Model       uintptr
@@ -288,6 +305,8 @@ type ModelParams struct {
 	UseMlock                 uint8     // force system to keep model in RAM (bool as uint8)
 	CheckTensors             uint8     // validate model tensor data (bool as uint8)
 	UseExtraBufts            uint8     // use extra buffer types (bool as uint8)
+	NoHost                   uint8     // bypass host buffer allowing extra buffers to be used (bool as uint8)
+	NoAlloc                  uint8     // only load metadata and simulate memory allocations (bool as uint8)
 }
 
 // Context parameters

--- a/pkg/llama/model_test.go
+++ b/pkg/llama/model_test.go
@@ -387,6 +387,23 @@ func TestModelMetaValStr(t *testing.T) {
 	t.Logf("ModelMetaValStr returned: %s", val)
 }
 
+func TestModelMetaKeyStr(t *testing.T) {
+	// Try a few likely valid and invalid keys
+	invalidKey := ModelMetaKey(-12345)
+
+	s := ModelMetaKeyStr(ModelMetaKeySamplingTopK)
+	if s == "" {
+		t.Log("ModelMetaKeyStr returned empty string for valid key (may be expected if no keys defined at 0)")
+	} else {
+		t.Logf("ModelMetaKeyStr(%d) returned: %q", ModelMetaKeySamplingTopK, s)
+	}
+
+	s = ModelMetaKeyStr(invalidKey)
+	if s != "" {
+		t.Fatalf("ModelMetaKeyStr should return empty string for invalid key, got: %q", s)
+	}
+}
+
 func TestModelLoadCallback(t *testing.T) {
 	modelFile := testModelFileName(t)
 	testSetup(t)


### PR DESCRIPTION
This PR adds a couple of new functions that were added to the `llama.cpp` API:

- `MaxTensorBuftOverrides()`
- `ModelMetaKeyStr()`

It also adds 2 new fields to the `ModelParams` type:

- `NoHost`
- `NoAlloc`