### PR TITLE
feature: add Batch helper functions for #165

### DIFF
--- a/pkg/llama/batch.go
+++ b/pkg/llama/batch.go
@@ -82,3 +82,44 @@ func BatchGetOne(tokens []Token) Batch {
 
 	return batch
 }
+
+// Clear resets the token count of the batch to zero.
+func (b *Batch) Clear() error {
+	b.NTokens = 0
+
+	return nil
+}
+
+// SetLogit sets whether to compute logits for the token at index idx in the batch.
+func (b *Batch) SetLogit(idx int32, logits bool) {
+	logitPtr := &unsafe.Slice((*int8)(b.Logits), int(b.NTokens))[idx]
+	if logits {
+		*logitPtr = 1
+	} else {
+		*logitPtr = 0
+	}
+}
+
+// Add adds a token to the batch with the given position, sequence IDs, and logits flag.
+func (b *Batch) Add(token Token, pos Pos, seqIDs []SeqId, logits bool) {
+	i := b.NTokens
+
+	// Set token and position
+	unsafe.Slice((*Token)(b.Token), int(b.NTokens+1))[i] = token
+	unsafe.Slice((*Pos)(b.Pos), int(b.NTokens+1))[i] = pos
+
+	// Set number of sequence IDs
+	unsafe.Slice((*int32)(b.NSeqId), int(b.NTokens+1))[i] = int32(len(seqIDs))
+
+	// Set sequence IDs if present
+	seqIDPtrs := unsafe.Slice((**SeqId)(b.SeqId), int(b.NTokens+1))
+	if seqIDPtrs[i] != nil && len(seqIDs) > 0 {
+		seqSlice := unsafe.Slice((*SeqId)(seqIDPtrs[i]), len(seqIDs))
+		for j, sid := range seqIDs {
+			seqSlice[j] = sid
+		}
+	}
+
+	b.NTokens++
+	b.SetLogit(i, logits)
+}

--- a/pkg/llama/batch_test.go
+++ b/pkg/llama/batch_test.go
@@ -2,6 +2,7 @@ package llama
 
 import (
 	"testing"
+	"unsafe"
 )
 
 func TestBatchInit(t *testing.T) {
@@ -28,5 +29,80 @@ func TestBatchGetOne(t *testing.T) {
 	batch := BatchGetOne(tokens)
 	if batch == (Batch{}) {
 		t.Fatal("BatchGetOne returned an empty batch")
+	}
+}
+
+func TestBatchClear(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	batch := BatchInit(2, 0, 1)
+	batch.NTokens = 2
+	err := batch.Clear()
+	if err != nil {
+		t.Fatalf("Clear returned error: %v", err)
+	}
+	if batch.NTokens != 0 {
+		t.Errorf("Clear did not reset NTokens to 0, got %d", batch.NTokens)
+	}
+	BatchFree(batch)
+}
+
+func TestBatchSetLogit(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	batch := BatchInit(2, 0, 1)
+	batch.NTokens = 2
+
+	batch.SetLogit(0, true)
+	batch.SetLogit(1, false)
+
+	logits := unsafe.Slice((*int8)(batch.Logits), int(batch.NTokens))
+	if logits[0] != 1 {
+		t.Errorf("SetLogit did not set index 0 to 1, got %d", logits[0])
+	}
+	if logits[1] != 0 {
+		t.Errorf("SetLogit did not set index 1 to 0, got %d", logits[1])
+	}
+	BatchFree(batch)
+}
+
+func TestBatchAdd(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	batch := BatchInit(2, 0, 2)
+	defer BatchFree(batch)
+
+	token := Token(42)
+	pos := Pos(7)
+	seqIDs := []SeqId{1, 2}
+	logits := true
+
+	batch.Add(token, pos, seqIDs, logits)
+
+	if batch.NTokens != 1 {
+		t.Errorf("Add did not increment NTokens, got %d", batch.NTokens)
+	}
+
+	tokens := unsafe.Slice((*Token)(batch.Token), int(batch.NTokens))
+	if tokens[0] != token {
+		t.Errorf("Add did not set token correctly, got %v", tokens[0])
+	}
+
+	poses := unsafe.Slice((*Pos)(batch.Pos), int(batch.NTokens))
+	if poses[0] != pos {
+		t.Errorf("Add did not set pos correctly, got %v", poses[0])
+	}
+
+	nSeqIds := unsafe.Slice((*int32)(batch.NSeqId), int(batch.NTokens))
+	if nSeqIds[0] != int32(len(seqIDs)) {
+		t.Errorf("Add did not set nSeqIds correctly, got %v", nSeqIds[0])
+	}
+
+	logitVals := unsafe.Slice((*int8)(batch.Logits), int(batch.NTokens))
+	if logitVals[0] != 1 {
+		t.Errorf("Add did not set logits correctly, got %v", logitVals[0])
 	}
 }


### PR DESCRIPTION
This PR adds `Add()`, `Clear()`, and `SetLogit()` functions to the `Batch` type. Addresses the request in #165 