### PR TITLE
feature: implement mtmd.EncodeChunk() and mtmd.GetOutputEmbd()

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -197,8 +197,10 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 - [x] `mtmd_decode_use_mrope`
 - [x] `mtmd_decode_use_non_causal`
 - [x] `mtmd_default_marker`
+- [x] `mtmd_encode_chunk`
 - [x] `mtmd_free`
 - [x] `mtmd_get_audio_bitrate`
+- [x] `mtmd_get_output_embd`
 - [x] `mtmd_helper_bitmap_init_from_buf`
 - [x] `mtmd_helper_bitmap_init_from_file`
 - [x] `mtmd_helper_eval_chunks`
@@ -242,6 +244,4 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 
 Note that these functions are considered by `llama.cpp` to be experimental, and are subject to change.
 
-- [ ] `mtmd_encode_chunk`
 - [ ] `mtmd_encode`
-- [ ] `mtmd_get_output_embd`


### PR DESCRIPTION
This implements the llama.cpp functions `mtmd.EncodeChunk()` and `mtmd.GetOutputEmbd()` as requested in #173