### PR TITLE
fix: ensure that all previous size_t are uint64 values

### DIFF
--- a/pkg/mtmd/chunks.go
+++ b/pkg/mtmd/chunks.go
@@ -199,8 +199,9 @@ func InputChunkGetTokensText(chunk InputChunk) []llama.Token {
 		return nil
 	}
 	var tokensPtr *llama.Token
-	var nTokens uint32
-	inputChunkGetTokensTextFunc.Call(unsafe.Pointer(&tokensPtr), unsafe.Pointer(&chunk), unsafe.Pointer(&nTokens))
+	var nTokens uint64
+	nt := &nTokens
+	inputChunkGetTokensTextFunc.Call(unsafe.Pointer(&tokensPtr), unsafe.Pointer(&chunk), unsafe.Pointer(&nt))
 
 	if tokensPtr == nil || nTokens == 0 {
 		return nil
@@ -210,13 +211,13 @@ func InputChunkGetTokensText(chunk InputChunk) []llama.Token {
 }
 
 // InputChunkGetNTokens retrieves the number of tokens in the input chunk.
-func InputChunkGetNTokens(chunk InputChunk) uint32 {
+func InputChunkGetNTokens(chunk InputChunk) uint64 {
 	if chunk == 0 {
 		return 0
 	}
 	var result ffi.Arg
 	inputChunkGetNTokensFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&chunk))
-	return uint32(result)
+	return uint64(result)
 }
 
 // InputChunkGetId retrieves the ID of the input chunk.
@@ -273,33 +274,33 @@ func InputChunkGetTokensImage(chunk InputChunk) ImageTokens {
 }
 
 // ImageTokensGetNTokens returns the number of tokens in the image.
-func ImageTokensGetNTokens(imageTokens ImageTokens) uint32 {
+func ImageTokensGetNTokens(imageTokens ImageTokens) uint64 {
 	if imageTokens == 0 {
 		return 0
 	}
 	var result ffi.Arg
 	inputImageTokensGetNTokensFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&imageTokens))
-	return uint32(result)
+	return uint64(result)
 }
 
 // ImageTokensGetX returns the x size of the image tokens.
-func ImageTokensGetNX(imageTokens ImageTokens) uint32 {
+func ImageTokensGetNX(imageTokens ImageTokens) uint64 {
 	if imageTokens == 0 {
 		return 0
 	}
 	var result ffi.Arg
 	inputImageTokensGetNXFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&imageTokens))
-	return uint32(result)
+	return uint64(result)
 }
 
 // ImageTokensGetY returns the y size of the image tokens.
-func ImageTokensGetNY(imageTokens ImageTokens) uint32 {
+func ImageTokensGetNY(imageTokens ImageTokens) uint64 {
 	if imageTokens == 0 {
 		return 0
 	}
 	var result ffi.Arg
 	inputImageTokensGetNYFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&imageTokens))
-	return uint32(result)
+	return uint64(result)
 }
 
 // ImageTokensGetId returns the id of the image tokens.

--- a/pkg/mtmd/mtmd.go
+++ b/pkg/mtmd/mtmd.go
@@ -144,7 +144,7 @@ func loadFuncs(lib ffi.Lib) error {
 		return loadError("mtmd_support_vision", err)
 	}
 
-	if tokenizeFunc, err = lib.Prep("mtmd_tokenize", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint64); err != nil {
+	if tokenizeFunc, err = lib.Prep("mtmd_tokenize", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize); err != nil {
 		return loadError("mtmd_tokenize", err)
 	}
 
@@ -264,7 +264,7 @@ func Tokenize(ctx Context, out InputChunks, text *InputText, bitmaps []Bitmap) i
 	nBitmaps := uint64(len(bitmaps))
 
 	var result ffi.Arg
-	tokenizeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), unsafe.Pointer(&out), unsafe.Pointer(&text), unsafe.Pointer(&bt), unsafe.Pointer(&nBitmaps))
+	tokenizeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), unsafe.Pointer(&out), unsafe.Pointer(&text), unsafe.Pointer(&bt), &nBitmaps)
 
 	return int32(result)
 }


### PR DESCRIPTION
This is to ensure that all previous `size_t` are `uint64` values for real this time.
