### PR TITLE
mtmd: load benchmark model once via TestMain to prevent GPU memory ex…

### DIFF
--- a/pkg/mtmd/testmain_test.go
+++ b/pkg/mtmd/testmain_test.go
@@ -1,0 +1,124 @@
+package mtmd
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+var (
+	benchModel    llama.Model
+	benchCtx      llama.Context
+	benchMtmdCtx  Context
+	benchTemplate string
+	benchBitmap   Bitmap
+	benchImgData  []byte
+	benchReady    bool
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	if benchReady {
+		benchmarkTeardown()
+	}
+
+	os.Exit(code)
+}
+
+func benchmarkSetupOnce(b *testing.B) {
+	if benchReady {
+		return
+	}
+
+	modelFile := benchmarkModelFileName(b)
+	projectFile := benchmarkProjectorFileName(b)
+
+	benchmarkSetup(b)
+
+	mparams := llama.ModelDefaultParams()
+	bd := os.Getenv("YZMA_BENCHMARK_DEVICE")
+	if bd != "" {
+		devs := []llama.GGMLBackendDevice{}
+		devices := strings.Split(bd, ",")
+		for _, d := range devices {
+			dev := llama.GGMLBackendDeviceByName(d)
+			if dev == 0 {
+				b.Fatalf("unknown device: %s", d)
+			}
+			devs = append(devs, dev)
+		}
+
+		mparams.SetDevices(devs)
+	}
+
+	params := llama.ContextDefaultParams()
+
+	switch {
+	case strings.Contains(bd, "CUDA"), strings.Contains(bd, "VULKAN"):
+		mparams.UseMmap = 0
+		mparams.UseDirectIO = 1
+		params.NCtx = 32000
+		params.NBatch = 4096
+
+	case runtime.GOOS == "darwin":
+		params.NCtx = 16000
+		params.NBatch = 4096
+		mparams.UseMmap = 0
+
+	default:
+		mparams.UseMmap = 1
+		mparams.UseDirectIO = 0
+		params.NCtx = 8192
+		params.NBatch = 4096
+	}
+
+	model, err := llama.ModelLoadFromFile(modelFile, mparams)
+	if err != nil {
+		b.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	benchModel = model
+
+	ctx, err := llama.InitFromModel(model, params)
+	if err != nil {
+		b.Fatalf("InitFromModel failed: %v", err)
+	}
+	benchCtx = ctx
+
+	mprms := ContextParamsDefault()
+	mprms.ImageMinTokens = 1024
+
+	mtmdCtx, err := InitFromFile(projectFile, model, mprms)
+	if err != nil {
+		fmt.Println("unable to initialize context from file", err.Error())
+		os.Exit(1)
+	}
+	benchMtmdCtx = mtmdCtx
+
+	benchTemplate = llama.ModelChatTemplate(model, "")
+
+	data, x, y, err := openImageFile("../../images/domestic_llama.jpg")
+	if err != nil {
+		b.Fatal("could not open file")
+	}
+	benchImgData = data
+	benchBitmap = BitmapInit(x, y, uintptr(unsafe.Pointer(&benchImgData[0])))
+
+	benchReady = true
+}
+
+func benchmarkTeardown() {
+	BitmapFree(benchBitmap)
+	Free(benchMtmdCtx)
+	llama.Free(benchCtx)
+	llama.ModelFree(benchModel)
+
+	llama.LogSet(llama.LogNormal)
+	LogSet(llama.LogNormal)
+	llama.Close()
+}


### PR DESCRIPTION
…haustion

The Go benchmark framework can invoke BenchmarkMultimodalInference multiple times. Each invocation was loading the model from scratch, and GPU memory was not fully reclaimed before the next load, causing 'failed to load model' errors by the 4th run.

Move model, context, and bitmap setup into a benchmarkSetupOnce function backed by package-level variables, with teardown handled in TestMain. The model is now loaded exactly once per test binary execution.

Amp-Thread-ID: https://ampcode.com/threads/T-019c38b9-ed6b-72ca-bb4c-df4301fcec28