### PR TITLE
feature: add SamplerChainGet implementation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -128,6 +128,7 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 - [x] `llama_sampler_accept`
 - [x] `llama_sampler_chain_add`
 - [x] `llama_sampler_chain_default_params`
+- [x] `llama_sampler_chain_get`
 - [x] `llama_sampler_chain_init`
 - [x] `llama_sampler_free`
 - [x] `llama_sampler_init_dist`
@@ -239,6 +240,8 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 - [ ] `llama_opt_init`
 - [ ] `llama_opt_param_filter_all`
 - [ ] `llama_params_fit`
+- [ ] `llama_sampler_init`
+- [ ] `llama_set_sampler`
 
 ### `mtmd` Functions still needing wrappers
 

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -2,10 +2,11 @@ package llama
 
 // Common types matching llama.cpp
 type (
-	Token  int32
-	Pos    int32
-	SeqId  int32
-	Memory uintptr
+	Token   int32
+	Pos     int32
+	SeqId   int32
+	Memory  uintptr
+	Sampler uintptr
 )
 
 // Constants from llama.h
@@ -377,6 +378,12 @@ type ChatMessage struct {
 // Sampler chain parameters
 type SamplerChainParams struct {
 	NoPerf uint8 // whether to measure performance timings (bool as uint8)
+}
+
+// llama_sampler_seq_config
+type SamplerSeqConfig struct {
+	SeqId   SeqId
+	Sampler Sampler
 }
 
 // Logit bias

--- a/pkg/llama/sampling_test.go
+++ b/pkg/llama/sampling_test.go
@@ -28,6 +28,43 @@ func TestSamplerChainInit(t *testing.T) {
 	SamplerFree(chain)
 }
 
+func TestSamplerChainGet(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	params := SamplerChainDefaultParams()
+	chain := SamplerChainInit(params)
+	if chain == 0 {
+		t.Fatal("SamplerChainInit failed")
+	}
+	defer SamplerFree(chain)
+
+	greedy := SamplerInitGreedy()
+	if greedy == 0 {
+		t.Fatal("SamplerInitGreedy failed")
+	}
+
+	SamplerChainAdd(chain, greedy)
+
+	// i == -1 should return the chain itself
+	got := SamplerChainGet(chain, -1)
+	if got != chain {
+		t.Errorf("SamplerChainGet(chain, -1) = %v, want %v", got, chain)
+	}
+
+	// i == 0 should return the first sampler (greedy)
+	gotSampler := SamplerChainGet(chain, 0)
+	if gotSampler == 0 {
+		t.Errorf("SamplerChainGet(chain, 0) returned 0, want non-zero sampler")
+	}
+
+	// i out of bounds should return 0
+	gotInvalid := SamplerChainGet(chain, 100)
+	if gotInvalid != 0 {
+		t.Errorf("SamplerChainGet(chain, 100) = %v, want 0", gotInvalid)
+	}
+}
+
 func TestSamplerInitGreedy(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)


### PR DESCRIPTION
This PR adds `SamplerChainGet()` implementation for the llama.cpp function `llama_sampler_chain_get`.