### PR TITLE
docs: add info about Fantasy provider via Kronk

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -7,7 +7,7 @@ Hera are some projects that are using `yzma`. Also some tools/frameworks and blo
 ### Kronk
 
 <a href="https://github.com/ardanlabs/kronk" target="_blank">
-<img src="https://github.com/ardanlabs/kronk/blob/main/images/project/kronk_logo1.png?raw=true" width="150" alt="Kronk logo">
+<img src="https://github.com/ardanlabs/kronk/blob/main/images/project/kronk_logo1.png?raw=true" width="300" alt="Kronk logo">
 </a>
 
 Kronk provides a high-level API that feels similar to using an OpenAI compatible API.
@@ -19,7 +19,7 @@ https://github.com/ardanlabs/kronk
 ### wasmVision
 
 <a href="https://wasmvision.com" target="_blank">
-<img src="https://github.com/wasmvision/wasmvision/blob/main/images/wasmvision-logo.png?raw=true" width="150" alt="wasmVision logo">
+<img src="https://github.com/wasmvision/wasmvision/blob/main/images/wasmvision-logo.png?raw=true" width="300" alt="wasmVision logo">
 </a>
 
 wasmVision is a high-performance computer vision processing engine that includes advanced algorithms and vision models for machine learning.
@@ -29,12 +29,22 @@ https://github.com/wasmvision/wasmvision
 ### NornicDB
 
 <a href="https://github.com/orneryd/NornicDB" target="_blank">
-<img src="https://raw.githubusercontent.com/orneryd/NornicDB/refs/heads/main/docs/assets/logos/nornicdb-logo.svg" width="150" alt="NornicDB logo">
+<img src="https://raw.githubusercontent.com/orneryd/NornicDB/refs/heads/main/docs/assets/logos/nornicdb-logo.svg" width="300" alt="NornicDB logo">
 </a>
 
 NornicDB is a high-performance graph database designed for AI agents and knowledge systems.
 
 https://github.com/orneryd/NornicDB
+
+### Fantasy
+
+<a href="https://github.com/charmbracelet/fantasy" target="_blank">
+<img src="https://github.com/user-attachments/assets/b22c5862-792a-44c1-bc98-55a2e46c8fb9" width="300" alt="Fantasy logo">
+</a>
+
+Fantasy lets you build AI agents with Go. Multi-provider, multi-model, one API. It supports [Kronk](https://github.com/ardanlabs/kronk), which in turn is built on yzma.
+
+https://github.com/charmbracelet/fantasy
 
 ## Examples and Tutorials
 


### PR DESCRIPTION
This PR adds docs about the new Fantasy provider via Kronk.