### PR TITLE
Add ROCm backend support

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -29,7 +29,7 @@ var InstallCmd = &cli.Command{
 		&cli.StringFlag{
 			Name:    "processor",
 			Aliases: []string{"p"},
-			Usage:   "processor to use (cpu, cuda, metal, vulkan)",
+			Usage:   "processor to use (cpu, cuda, metal, rocm, vulkan)",
 			Value:   "",
 		},
 		&cli.StringFlag{
@@ -96,6 +96,11 @@ func runInstall(c *cli.Context) error {
 				fmt.Printf("CUDA detected (version %s), using CUDA build\n", cudaVersion)
 			}
 			processor = "cuda"
+		} else if rocmInstalled, rocmVersion := download.HasROCm(); rocmInstalled {
+			if !quiet {
+				fmt.Printf("ROCm detected (version %s), using ROCm build\n", rocmVersion)
+			}
+			processor = "rocm"
 		}
 	}
 

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -113,6 +113,11 @@ func getDownloadLocationAndFilename(arch Arch, os OS, prcssr Processor, version 
 				break
 			}
 			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.tar.gz", version)
+		case ROCm:
+			if arch != AMD64 {
+				return "", "", errors.New("precompiled binaries for Linux ARM64 ROCm are not available")
+			}
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-rocm-7.2-x64.tar.gz", version)
 		default:
 			return "", "", ErrUnknownProcessor
 		}
@@ -220,6 +225,11 @@ func getDownloadLocationAndFilename(arch Arch, os OS, prcssr Processor, version 
 				return "", "", errors.New("precompiled binaries for Windows ARM64 Vulkan are not available")
 			}
 			filename = fmt.Sprintf("llama-%s-bin-win-vulkan-x64.zip", version)
+		case ROCm:
+			if arch != AMD64 {
+				return "", "", errors.New("precompiled binaries for Windows ARM64 ROCm are not available")
+			}
+			filename = fmt.Sprintf("llama-%s-bin-win-hip-radeon-x64.zip", version)
 		default:
 			return "", "", ErrUnknownProcessor
 		}
@@ -237,7 +247,7 @@ var getFunc = get
 // Get downloads the llama.cpp precompiled binaries for the desired arch/OS/processor.
 // arch can be one of the following values: "amd64", "arm64".
 // os can be one of the following values: "linux", "darwin", "windows", "bookworm", "trixie".
-// processor can be one of the following values: "cpu", "cuda", "vulkan", "metal".
+// processor can be one of the following values: "cpu", "cuda", "metal", "rocm", "vulkan".
 // version should be the desired `b1234` formatted llama.cpp version. You can use the
 // [LlamaLatestVersion] function to obtain the latest release.
 // dest in the destination directory for the downloaded binaries.
@@ -249,7 +259,7 @@ func Get(architecture string, operatingSystem string, processor string, version 
 // using the provided progress tracker.
 // arch can be one of the following values: "amd64", "arm64".
 // os can be one of the following values: "linux", "darwin", "windows", "bookworm", "trixie".
-// processor can be one of the following values: "cpu", "cuda", "vulkan", "metal".
+// processor can be one of the following values: "cpu", "cuda", "metal", "rocm", "vulkan".
 // version should be the desired `b1234` formatted llama.cpp version. You can use the
 // [LlamaLatestVersion] function to obtain the latest release.
 // dest in the destination directory for the downloaded binaries.
@@ -261,7 +271,7 @@ func GetWithProgress(architecture string, operatingSystem string, processor stri
 // using the provided context and progress tracker.
 // arch can be one of the following values: "amd64", "arm64".
 // os can be one of the following values: "linux", "darwin", "windows", "bookworm", "trixie".
-// processor can be one of the following values: "cpu", "cuda", "vulkan", "metal".
+// processor can be one of the following values: "cpu", "cuda", "metal", "rocm", "vulkan".
 // version should be the desired `b1234` formatted llama.cpp version. You can use the
 // [LlamaLatestVersion] function to obtain the latest release.
 // dest in the destination directory for the downloaded binaries.

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -721,6 +721,76 @@ func TestGetDownloadLocationAndFilename_WindowsVulkan_ARM64(t *testing.T) {
 	}
 }
 
+func TestGetDownloadLocationAndFilename_LinuxROCm_AMD64(t *testing.T) {
+	version := "b7974"
+	dest := t.TempDir()
+
+	location, filename, err := getDownloadLocationAndFilename(AMD64, Linux, ROCm, version, dest)
+	if err != nil {
+		t.Fatalf("getDownloadLocationAndFilename() failed: %v", err)
+	}
+
+	expectedLocation := "https://github.com/ggml-org/llama.cpp/releases/download/b7974"
+	expectedFilename := "llama-b7974-bin-ubuntu-rocm-7.2-x64.tar.gz"
+
+	if location != expectedLocation {
+		t.Errorf("location = %q, want %q", location, expectedLocation)
+	}
+	if filename != expectedFilename {
+		t.Errorf("filename = %q, want %q", filename, expectedFilename)
+	}
+}
+
+func TestGetDownloadLocationAndFilename_LinuxROCm_ARM64(t *testing.T) {
+	version := "b7974"
+	dest := t.TempDir()
+
+	_, _, err := getDownloadLocationAndFilename(ARM64, Linux, ROCm, version, dest)
+	if err == nil {
+		t.Fatal("getDownloadLocationAndFilename() should have failed for Linux ARM64 ROCm")
+	}
+}
+
+func TestGetDownloadLocationAndFilename_WindowsROCm_AMD64(t *testing.T) {
+	version := "b7974"
+	dest := t.TempDir()
+
+	location, filename, err := getDownloadLocationAndFilename(AMD64, Windows, ROCm, version, dest)
+	if err != nil {
+		t.Fatalf("getDownloadLocationAndFilename() failed: %v", err)
+	}
+
+	expectedLocation := "https://github.com/ggml-org/llama.cpp/releases/download/b7974"
+	expectedFilename := "llama-b7974-bin-win-hip-radeon-x64.zip"
+
+	if location != expectedLocation {
+		t.Errorf("location = %q, want %q", location, expectedLocation)
+	}
+	if filename != expectedFilename {
+		t.Errorf("filename = %q, want %q", filename, expectedFilename)
+	}
+}
+
+func TestGetDownloadLocationAndFilename_WindowsROCm_ARM64(t *testing.T) {
+	version := "b7974"
+	dest := t.TempDir()
+
+	_, _, err := getDownloadLocationAndFilename(ARM64, Windows, ROCm, version, dest)
+	if err == nil {
+		t.Fatal("getDownloadLocationAndFilename() should have failed for Windows ARM64 ROCm")
+	}
+}
+
+func TestGetDownloadLocationAndFilename_DarwinROCm(t *testing.T) {
+	version := "b7974"
+	dest := t.TempDir()
+
+	_, _, err := getDownloadLocationAndFilename(AMD64, Darwin, ROCm, version, dest)
+	if err == nil {
+		t.Fatal("getDownloadLocationAndFilename() should have failed for Darwin ROCm")
+	}
+}
+
 func TestGet404Error(t *testing.T) {
 	version := "b7974"
 

--- a/pkg/download/install.go
+++ b/pkg/download/install.go
@@ -58,3 +58,25 @@ func HasCUDA() (bool, string) {
 	}
 	return true, ""
 }
+
+// HasROCm checks if ROCm is available and returns (available, rocmVersion).
+func HasROCm() (bool, string) {
+	if runtime.GOOS != "linux" {
+		return false, ""
+	}
+
+	cmd := execCommand("rocminfo")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return false, ""
+	}
+	re := regexp.MustCompile(`Runtime Version:\s*([0-9.]+)`)
+	matches := re.FindStringSubmatch(out.String())
+	if len(matches) >= 2 {
+		return true, matches[1]
+	}
+	return true, ""
+}

--- a/pkg/download/processor.go
+++ b/pkg/download/processor.go
@@ -7,6 +7,7 @@ var (
 	CPU    = newProcessor("cpu")
 	CUDA   = newProcessor("cuda")
 	Metal  = newProcessor("metal")
+	ROCm   = newProcessor("rocm")
 	Vulkan = newProcessor("vulkan")
 )
 


### PR DESCRIPTION
This adds support for the ROCm device type.
It allows the libraries to be installed and the device type to be then set to ROCm.