### PR TITLE
llama: remove llama_params_fit and llama_memory_breakdown_print bindings

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,6 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 - [x] `llama_model_rope_type`
 - [x] `llama_model_save_to_file`
 - [x] `llama_model_size`
-- [x] `llama_params_fit`
 - [x] `llama_split_path`
 - [x] `llama_split_prefix`
 

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -142,17 +142,6 @@ var (
 	//        const llama_model_quantize_params * params);
 	modelQuantizeFunc ffi.Fun
 
-	// LLAMA_API enum llama_params_fit_status llama_params_fit(
-	//                            const char   * path_model,
-	//             struct llama_model_params   * mparams,
-	//             struct llama_context_params * cparams,
-	//                                   float * tensor_split,
-	// struct llama_model_tensor_buft_override * tensor_buft_overrides,
-	//                                  size_t * margins,
-	//                                uint32_t   n_ctx_min,
-	//                     enum ggml_log_level   log_level);
-	modelParamsFitFunc ffi.Fun
-
 	// LLAMA_API void llama_model_save_to_file(
 	//         const struct llama_model * model,
 	//                     const char * path_model);
@@ -301,10 +290,6 @@ func loadModelFuncs(lib ffi.Lib) error {
 
 	if modelQuantizeFunc, err = lib.Prep("llama_model_quantize", &ffi.TypeUint32, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer); err != nil {
 		return loadError("llama_model_quantize", err)
-	}
-
-	if modelParamsFitFunc, err = lib.Prep("llama_params_fit", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint32, &ffi.TypeSint32); err != nil {
-		return loadError("llama_params_fit", err)
 	}
 
 	if modelSaveToFileFunc, err = lib.Prep("llama_model_save_to_file", &ffi.TypeVoid, &ffi.TypePointer, &ffi.TypePointer); err != nil {
@@ -918,67 +903,6 @@ func ModelQuantize(fnameInp, fnameOut string, params *ModelQuantizeParams) uint3
 	var result ffi.Arg
 	modelQuantizeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&fileInp), unsafe.Pointer(&fileOut), unsafe.Pointer(&params))
 	return uint32(result)
-}
-
-type ModelParamsFitStatus int32
-
-const (
-	ModelParamsFitStatusSuccess ModelParamsFitStatus = 0 // found allocations that are projected to fit
-	ModelParamsFitStatusFailure ModelParamsFitStatus = 1 // could not find allocations that are projected to fit
-	ModelParamsFitStatusError   ModelParamsFitStatus = 2 // a hard error occurred
-)
-
-// ModelParamsFit attempts to fit model and context parameters to available device memory.
-// It assumes system memory is unlimited and only modifies parameters that have the same
-// value as in the default model params, with the exception of context size which is
-// modified if and only if equal to 0.
-//
-// Parameters:
-//   - pathModel: path to the model file
-//   - mparams: pointer to model parameters (will be modified to fit)
-//   - cparams: pointer to context parameters (will be modified to fit)
-//   - tensorSplit: writable buffer for tensor split, needs at least MaxDevices() elements
-//   - tensorBuftOverrides: writable buffer for overrides, needs at least MaxTensorBuftOverrides() elements
-//   - margins: margins of memory to leave per device in bytes
-//   - nCtxMin: minimum context size to set when trying to reduce memory use
-//   - logLevel: minimum log level to print during fitting, lower levels go to debug log
-//
-// Note: This function is NOT thread safe because it modifies the global llama logger state.
-func ModelParamsFit(pathModel string, mparams *ModelParams, cparams *ContextParams, tensorSplit []float32, tensorBuftOverrides []TensorBuftOverride, margins []uint64, nCtxMin uint32, logLevel LogLevel) ModelParamsFitStatus {
-	pathPtr, err := utils.BytePtrFromString(pathModel)
-	if err != nil {
-		return ModelParamsFitStatusError
-	}
-
-	var tensorSplitPtr *float32
-	if len(tensorSplit) > 0 {
-		tensorSplitPtr = &tensorSplit[0]
-	}
-
-	var tensorBuftOverridesPtr *TensorBuftOverride
-	if len(tensorBuftOverrides) > 0 {
-		tensorBuftOverridesPtr = &tensorBuftOverrides[0]
-	}
-
-	var marginsPtr *uint64
-	if len(margins) > 0 {
-		marginsPtr = &margins[0]
-	}
-
-	var result ffi.Arg
-	modelParamsFitFunc.Call(
-		unsafe.Pointer(&result),
-		unsafe.Pointer(&pathPtr),
-		unsafe.Pointer(&mparams),
-		unsafe.Pointer(&cparams),
-		unsafe.Pointer(&tensorSplitPtr),
-		unsafe.Pointer(&tensorBuftOverridesPtr),
-		unsafe.Pointer(&marginsPtr),
-		&nCtxMin,
-		&logLevel,
-	)
-
-	return ModelParamsFitStatus(int32(result))
 }
 
 // ModelSaveToFile saves the model to a file.

--- a/pkg/llama/model_test.go
+++ b/pkg/llama/model_test.go
@@ -546,68 +546,6 @@ func TestModelLoadFromSplitsValid(t *testing.T) {
 	}
 }
 
-func TestModelParamsFit(t *testing.T) {
-	modelFile := testModelFileName(t)
-
-	testSetup(t)
-	defer testCleanup(t)
-
-	mparams := ModelDefaultParams()
-	cparams := ContextDefaultParams()
-	cparams.NCtx = 0 // set to 0 to allow fitting
-
-	nDevices := int(MaxDevices())
-	tensorSplit := make([]float32, nDevices)
-	tensorBuftOverrides := make([]TensorBuftOverride, MaxTensorBuftOverrides())
-	margins := make([]uint64, nDevices)
-
-	status := ModelParamsFit(
-		modelFile,
-		&mparams,
-		&cparams,
-		tensorSplit,
-		tensorBuftOverrides,
-		margins,
-		512,
-		LogLevelWarn,
-	)
-
-	if status == ModelParamsFitStatusError {
-		t.Fatal("ParamsFit returned error status")
-	}
-
-	t.Logf("ParamsFit status: %d", status)
-	t.Logf("Fitted context size: %d", cparams.NCtx)
-}
-
-func TestModelParamsFitInvalidPath(t *testing.T) {
-	testSetup(t)
-	defer testCleanup(t)
-
-	mparams := ModelDefaultParams()
-	cparams := ContextDefaultParams()
-
-	nDevices := int(MaxDevices())
-	tensorSplit := make([]float32, nDevices)
-	tensorBuftOverrides := make([]TensorBuftOverride, MaxTensorBuftOverrides())
-	margins := make([]uint64, nDevices)
-
-	status := ModelParamsFit(
-		"nonexistent_model.gguf",
-		&mparams,
-		&cparams,
-		tensorSplit,
-		tensorBuftOverrides,
-		margins,
-		512,
-		LogLevelWarn,
-	)
-
-	if status != ModelParamsFitStatusError {
-		t.Fatalf("ParamsFit should return error status for invalid path, got: %d", status)
-	}
-}
-
 func TestModelParamsSetTensorBufOverrides(t *testing.T) {
 	t.Run("empty_clears_pointer", func(t *testing.T) {
 		p := ModelDefaultParams()

--- a/pkg/llama/perf.go
+++ b/pkg/llama/perf.go
@@ -52,9 +52,6 @@ var (
 
 	// LLAMA_API void llama_perf_sampler_reset(struct llama_sampler * chain);
 	perfSamplerResetFunc ffi.Fun
-
-	// LLAMA_API void llama_memory_breakdown_print(const struct llama_context * ctx);
-	memoryBreakdownPrintFunc ffi.Fun
 )
 
 func loadPerfFuncs(lib ffi.Lib) error {
@@ -78,10 +75,6 @@ func loadPerfFuncs(lib ffi.Lib) error {
 
 	if perfSamplerResetFunc, err = lib.Prep("llama_perf_sampler_reset", &ffi.TypeVoid, &ffi.TypePointer); err != nil {
 		return loadError("llama_perf_sampler_reset", err)
-	}
-
-	if memoryBreakdownPrintFunc, err = lib.Prep("llama_memory_breakdown_print", &ffi.TypeVoid, &ffi.TypePointer); err != nil {
-		return loadError("llama_memory_breakdown_print", err)
 	}
 
 	return nil
@@ -135,12 +128,4 @@ func PerfSamplerPrint(chain Sampler) {
 		return
 	}
 	perfSamplerPrintFunc.Call(nil, unsafe.Pointer(&chain))
-}
-
-// MemoryBreakdownPrint prints a breakdown of per-device memory use.
-func MemoryBreakdownPrint(ctx Context) {
-	if ctx == 0 {
-		return
-	}
-	memoryBreakdownPrintFunc.Call(nil, unsafe.Pointer(&ctx))
 }

--- a/pkg/llama/perf_test.go
+++ b/pkg/llama/perf_test.go
@@ -63,5 +63,4 @@ func TestPerfFunctionsExist(t *testing.T) {
 
 	PerfSamplerPrint(chain)
 	PerfSamplerReset(chain)
-	MemoryBreakdownPrint(ctx)
 }


### PR DESCRIPTION
Both symbols were removed from the libllama public API in a breaking change to llama.cpp. llama_params_fit was moved to common_fit_params in libllama-common; llama_memory_breakdown_print was dropped entirely.

See https://github.com/ggml-org/llama.cpp/pull/22171