### PR TITLE
ci,download: replace GitHub API with static version endpoint

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,10 +22,8 @@ jobs:
           go-version: 'stable'
       - name: Get latest llama.cpp version
         id: llama-version
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(gh api repos/hybridgroup/llama-cpp-builder/releases/latest --jq '.tag_name')
+          VERSION=$(curl -s https://hybridgroup.github.io/llama-cpp-builder/version.json | jq -r '.tag_name')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Latest llama.cpp version: $VERSION"
       - name: Install yzma command

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,10 +22,8 @@ jobs:
           go-version: 'stable'
       - name: Get latest llama.cpp version
         id: llama-version
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(gh api repos/hybridgroup/llama-cpp-builder/releases/latest --jq '.tag_name')
+          VERSION=$(curl -s https://hybridgroup.github.io/llama-cpp-builder/version.json | jq -r '.tag_name')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Latest llama.cpp version: $VERSION"
       - name: Install yzma command

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,10 +29,8 @@ jobs:
       - name: Get latest llama.cpp version
         id: llama-version
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(gh api repos/hybridgroup/llama-cpp-builder/releases/latest --jq '.tag_name')
+          VERSION=$(curl -s https://hybridgroup.github.io/llama-cpp-builder/version.json | jq -r '.tag_name')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Latest llama.cpp version: $VERSION"
       - name: Install yzma command

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -30,7 +30,7 @@ var (
 	RetryCount = 3
 	// RetryDelay is the delay between retries when obtaining the latest llama.cpp version.
 	RetryDelay = 3 * time.Second
-	// apiURL is the GitHub API URL for fetching the latest llama.cpp version.
+	// versionURL is the URL for fetching the latest llama.cpp version.
 	// We use the llama-cpp-builder repo instead of the original llama.cpp repo because
 	// we need the precompiled binaries for certain platforms, and the build server might be
 	// up to 1 hour out of sync with the latest commits to the original llama.cpp repo.
@@ -38,10 +38,10 @@ var (
 	// Actual downloads will be from the llama.cpp repo for any builds that are available there,
 	// and from the llama-cpp-builder repo for builds that are not available in the original repo
 	// (e.g. ARM64 CUDA builds). This is handled in the getDownloadLocationAndFilename function.
-	apiURL = "https://api.github.com/repos/hybridgroup/llama-cpp-builder/releases/latest"
+	versionURL = "https://hybridgroup.github.io/llama-cpp-builder/version.json"
 )
 
-// LlamaLatestVersion fetches the latest release tag of llama.cpp from the GitHub API.
+// LlamaLatestVersion fetches the latest release tag of llama.cpp from the version URL.
 func LlamaLatestVersion() (string, error) {
 	var version string
 	var err error
@@ -57,14 +57,10 @@ func LlamaLatestVersion() (string, error) {
 }
 
 func getLatestVersion() (string, error) {
-	req, err := http.NewRequest("GET", apiURL, nil)
+	req, err := http.NewRequest("GET", versionURL, nil)
 	if err != nil {
 		return "", err
 	}
-
-	// Set required headers for GitHub API
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
 	client := &http.Client{
 		Timeout: 30 * time.Second,
@@ -77,7 +73,7 @@ func getLatestVersion() (string, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("received status code %d from GitHub API: %s", resp.StatusCode, string(body))
+		return "", fmt.Errorf("received status code %d from version URL: %s", resp.StatusCode, string(body))
 	}
 
 	var result struct {

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -20,7 +20,7 @@ func TestLlamaLatestVersion(t *testing.T) {
 	// Create a mock server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify the request
-		if r.URL.Path != "/repos/hybridgroup/llama-cpp-builder/releases/latest" {
+		if r.URL.Path != "/llama-cpp-builder/version.json" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -38,10 +38,10 @@ func TestLlamaLatestVersion(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Override the API URL for testing
-	originalURL := apiURL
-	apiURL = server.URL + "/repos/hybridgroup/llama-cpp-builder/releases/latest"
-	defer func() { apiURL = originalURL }()
+	// Override the version URL for testing
+	originalURL := versionURL
+	versionURL = server.URL + "/llama-cpp-builder/version.json"
+	defer func() { versionURL = originalURL }()
 
 	version, err := LlamaLatestVersion()
 	if err != nil {
@@ -67,10 +67,10 @@ func TestLlamaLatestVersion_Error(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Override the API URL for testing
-	originalURL := apiURL
-	apiURL = server.URL + "/repos/hybridgroup/llama-cpp-builder/releases/latest"
-	defer func() { apiURL = originalURL }()
+	// Override the version URL for testing
+	originalURL := versionURL
+	versionURL = server.URL + "/llama-cpp-builder/version.json"
+	defer func() { versionURL = originalURL }()
 
 	// Reduce retry count for faster test
 	originalRetryCount := RetryCount

--- a/pkg/download/install.go
+++ b/pkg/download/install.go
@@ -10,11 +10,6 @@ import (
 	"runtime"
 )
 
-var (
-	llamaCppVersionDocURL = "https://api.github.com/repos/hybridgroup/llama-cpp-builder/releases/latest"
-	versionFile           = "version.json"
-)
-
 type tag struct {
 	TagName string `json:"tag_name"`
 }


### PR DESCRIPTION
Replace `gh api` calls and GitHub API requests with a curl/jq-based fetch from the static `hybridgroup.github.io/llama-cpp-builder/version.json` endpoint across CI workflows and the download package.