### PR TITLE
fix: parse Gemma tool calls with missing commas between arguments

### DIFF
--- a/pkg/message/parser_gemma.go
+++ b/pkg/message/parser_gemma.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 )
 
+// gemmaKeyStartRE matches the start of a bare Gemma argument key: a word
+// immediately followed by a colon, with no preceding separator. Used to
+// detect when a closing quote token is immediately followed by the next
+// key in a comma-less argument list.
+var gemmaKeyStartRE = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*:`)
+
 // gemmaQuoteToken is the canonical Gemma 4 string delimiter.
 const gemmaQuoteToken = "<|\"|>"
 
@@ -271,6 +277,13 @@ func findClosingGemmaQuote(s, token string) int {
 		// model may mix Gemma format with standard JSON mid-output.
 		switch s[afterQuote] {
 		case ',', '}', ']', '"':
+			return pos
+		}
+
+		// Also accept when followed by a bare word+colon: Gemma sometimes omits
+		// the comma separator between arguments, e.g.
+		//   command:<|"|>slowlook<|"|>angle:135
+		if gemmaKeyStartRE.MatchString(s[afterQuote:]) {
 			return pos
 		}
 

--- a/pkg/message/parser_gemma_test.go
+++ b/pkg/message/parser_gemma_test.go
@@ -255,3 +255,53 @@ func TestParseGemmaToolCalls_EmptyArgsMixedWithValid(t *testing.T) {
 		t.Errorf("command: got %q, want %q", calls[0].Function.Arguments["command"], "speak")
 	}
 }
+func TestParseGemmaToolCalls_NoCommaBetweenArgs_PipeToken(t *testing.T) {
+	// Gemma sometimes omits the comma between arguments, emitting:
+	//   command:<|"|>slowlook<|"|>angle:135
+	// instead of the canonical:
+	//   command:<|"|>slowlook<|"|>,angle:135
+	response := `call:tool_movement{command:<|"|>slowlook<|"|>angle:135}`
+	calls := ParseToolCalls(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].Function.Arguments["command"] != "slowlook" {
+		t.Errorf("command: got %q, want %q", calls[0].Function.Arguments["command"], "slowlook")
+	}
+	if calls[0].Function.Arguments["angle"] != "135" {
+		t.Errorf("angle: got %q, want %q", calls[0].Function.Arguments["angle"], "135")
+	}
+}
+
+func TestParseGemmaToolCalls_NoCommaBetweenArgs_ShortToken(t *testing.T) {
+	// Same as above but with the short <"> quote token variant.
+	response := `call:tool_movement{command:<">look<">angle:90}`
+	calls := ParseToolCalls(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].Function.Arguments["command"] != "look" {
+		t.Errorf("command: got %q, want %q", calls[0].Function.Arguments["command"], "look")
+	}
+	if calls[0].Function.Arguments["angle"] != "90" {
+		t.Errorf("angle: got %q, want %q", calls[0].Function.Arguments["angle"], "90")
+	}
+}
+
+func TestParseGemmaToolCalls_NoComma_MultipleCallsInGeneration(t *testing.T) {
+	// Real-world Gemma output: two tool calls, first with comma-less args.
+	response := "I'm superior in every way.\ncall:tool_movement{command:<|\"|>slowlook<|\"|>angle:135}\ncall:tool_movement{command:<|\"|>headshake<|\"|>}"
+	calls := ParseToolCalls(response)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].Function.Arguments["command"] != "slowlook" {
+		t.Errorf("call[0] command: got %q, want %q", calls[0].Function.Arguments["command"], "slowlook")
+	}
+	if calls[0].Function.Arguments["angle"] != "135" {
+		t.Errorf("call[0] angle: got %q, want %q", calls[0].Function.Arguments["angle"], "135")
+	}
+	if calls[1].Function.Arguments["command"] != "headshake" {
+		t.Errorf("call[1] command: got %q, want %q", calls[1].Function.Arguments["command"], "headshake")
+	}
+}


### PR DESCRIPTION
- **parser:** Update `findClosingGemmaQuote` to recognize the end of a string argument when followed immediately by the next key (e.g., `command:<|"|>look<|"|>angle:90`).