### PR TITLE
feat: add support for Phi models and centralize stop markers

### DIFF
--- a/pkg/message/format.go
+++ b/pkg/message/format.go
@@ -31,6 +31,12 @@ const (
 	// FormatGPT expects GPT-model tool calls:
 	//   .FUNC_NAME <|message|>JSON_ARGS
 	FormatGPT
+
+	// FormatPhi is used for Phi-family models (phi-3, phi-4, etc.).
+	// They use standard JSON tool calls but have distinct turn-boundary tokens
+	// (<|end|>, <|user|>, <|assistant|>, <|system|>) that must be treated as
+	// generation stop markers.
+	FormatPhi
 )
 
 // DetectFormat inspects a tool-call content block and returns the Format that
@@ -70,6 +76,8 @@ func DetectFormatFromPath(path string) Format {
 		return FormatMistral
 	case strings.Contains(lower, "glm"):
 		return FormatGLM
+	case strings.Contains(lower, "phi"):
+		return FormatPhi
 	default:
 		return FormatAuto
 	}

--- a/pkg/message/format_test.go
+++ b/pkg/message/format_test.go
@@ -1,0 +1,40 @@
+package message
+
+import "testing"
+
+func TestDetectFormatFromPath_Phi(t *testing.T) {
+	tests := []struct {
+		path string
+		want Format
+	}{
+		{"models/phi-4-mini-instruct-abliterated-Q4_K_M.gguf", FormatPhi},
+		{"models/Phi-3-mini-4k-instruct-q4.gguf", FormatPhi},
+		{"models/phi3.5-mini-instruct.gguf", FormatPhi},
+	}
+	for _, tt := range tests {
+		got := DetectFormatFromPath(tt.path)
+		if got != tt.want {
+			t.Errorf("DetectFormatFromPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestDetectFormatFromPath_KnownFamilies(t *testing.T) {
+	tests := []struct {
+		path string
+		want Format
+	}{
+		{"models/qwen3.5-4B-instruct.gguf", FormatQwen},
+		{"models/gemma-4-E4B-it-Q4_K_M.gguf", FormatGemma},
+		{"models/mistral-7b-instruct-v0.2.Q4_K_M.gguf", FormatMistral},
+		{"models/devstral-small.gguf", FormatMistral},
+		{"models/glm-4-9b-chat-q4.gguf", FormatGLM},
+		{"models/llama-3.2-3B-instruct.gguf", FormatAuto},
+	}
+	for _, tt := range tests {
+		got := DetectFormatFromPath(tt.path)
+		if got != tt.want {
+			t.Errorf("DetectFormatFromPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}

--- a/pkg/message/parser.go
+++ b/pkg/message/parser.go
@@ -504,6 +504,15 @@ func StripMarkup(s string) string {
 		}
 	}
 
+	// Strip Phi-4 turn boundary tokens. <|end|> terminates the model's turn;
+	// <|user|>, <|assistant|>, and <|system|> indicate the model has started
+	// simulating the next conversation turn. Truncate at the first occurrence.
+	for _, marker := range []string{"<|end|>", "<|user|>", "<|assistant|>", "<|system|>"} {
+		if idx := strings.Index(s, marker); idx >= 0 {
+			s = strings.TrimSpace(s[:idx])
+		}
+	}
+
 	// Normalise <toolcall> (no underscore) to the canonical form so the
 	// Standard block-removal below handles both spellings.
 	// Also normalise the Gemma 4 pipe-delimited forms: <|toolcall> (opening)

--- a/pkg/message/parser.go
+++ b/pkg/message/parser.go
@@ -9,6 +9,11 @@ import (
 // ParseToolCalls attempts to parse tool calls from a model response,
 // detecting the grammar in order and returning the first match.
 func ParseToolCalls(response string) []ToolCall {
+	// Normalise Phi-4's pipe-prefixed <|tool_call> opening tag to the
+	// canonical <tool_call> form so parseStandardToolCalls can find it.
+	// (The closing </tool_call> is already canonical in Phi-4 output.)
+	response = strings.ReplaceAll(response, "<|tool_call>", "<tool_call>")
+
 	// parseStandardToolCalls must be tried first against the full response,
 	// because it matches on the outer <tool_call>…</tool_call> envelope tags.
 	// DetectFormat (used by parseToolCalls) inspects the unwrapped inner
@@ -154,6 +159,10 @@ func flattenNestedArguments(argsMap map[string]interface{}) map[string]interface
 }
 
 // parseStandardToolCalls parses <tool_call>{JSON}</tool_call> blocks.
+// It also handles unclosed blocks (no </tool_call>) by treating everything
+// from the opening tag to end-of-string as the block content — Phi-4 and
+// some other models omit the closing tag when generation is halted by an
+// EOT/stop token immediately after the JSON object.
 func parseStandardToolCalls(response string) []ToolCall {
 	var calls []ToolCall
 
@@ -163,62 +172,8 @@ func parseStandardToolCalls(response string) []ToolCall {
 	for start != -1 && end != -1 && start < end {
 		content := strings.TrimSpace(response[start+len("<tool_call>") : end])
 
-		var parsed struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments"`
-			// Args is an alias used by some models (e.g. Gemma4) instead of Arguments.
-			Args map[string]interface{} `json:"args"`
-		}
-		// Some models (e.g. Qwen fine-tunes) emit truncated JSON that is
-		// missing one or more closing braces. Attempt to repair it before
-		// giving up on the unmarshal.
-		if err := json.Unmarshal([]byte(content), &parsed); err != nil {
-			if repaired := repairJSON(content); repaired != content {
-				_ = json.Unmarshal([]byte(repaired), &parsed)
-			}
-		}
-		if parsed.Name != "" {
-			argsMap := parsed.Arguments
-			if argsMap == nil {
-				argsMap = parsed.Args
-			}
-			argsMap = flattenNestedArguments(argsMap)
-			args := make(map[string]string)
-			for k, v := range argsMap {
-				switch val := v.(type) {
-				case string:
-					args[k] = val
-				case float64:
-					args[k] = strconv.FormatFloat(val, 'f', -1, 64)
-				case int:
-					args[k] = strconv.Itoa(val)
-				case json.Number:
-					args[k] = val.String()
-				default:
-					if b, err := json.Marshal(v); err == nil {
-						args[k] = string(b)
-					}
-				}
-			}
-			calls = append(calls, ToolCall{
-				Type: "function",
-				Function: ToolFunction{
-					Name:      parsed.Name,
-					Arguments: args,
-				},
-			})
-		} else {
-			// JSON parse failed — some models (e.g. Qwen fine-tunes) emit
-			// <function=name>…</function> format wrapped inside <tool_call> tags,
-			// sometimes with a spurious `{"` prefix, or with `"function=` in
-			// place of `<function=` (the `<` is corrupted to `"`). Normalize
-			// that before trying the Qwen parser as a fallback.
-			normalized := strings.ReplaceAll(content, `"function=`, "<function=")
-			if idx := strings.Index(normalized, "<function="); idx >= 0 {
-				if qwenCalls := parseQwenToolCalls(normalized[idx:]); len(qwenCalls) > 0 {
-					calls = append(calls, qwenCalls...)
-				}
-			}
+		if c := parseOneStandardToolCall(content); c != nil {
+			calls = append(calls, *c)
 		}
 
 		response = response[end+len("</tool_call>"):]
@@ -226,7 +181,78 @@ func parseStandardToolCalls(response string) []ToolCall {
 		end = strings.Index(response, "</tool_call>")
 	}
 
+	// Handle an unclosed <tool_call> block — no </tool_call> found.
+	// Treat everything after the opening tag as the JSON content.
+	if start != -1 && end == -1 {
+		content := strings.TrimSpace(response[start+len("<tool_call>"):])
+		if c := parseOneStandardToolCall(content); c != nil {
+			calls = append(calls, *c)
+		}
+	}
+
 	return calls
+}
+
+// parseOneStandardToolCall parses a single JSON tool call object from content
+// (the text between <tool_call> tags). Returns nil if parsing fails.
+func parseOneStandardToolCall(content string) *ToolCall {
+	var parsed struct {
+		Name      string                 `json:"name"`
+		Arguments map[string]interface{} `json:"arguments"`
+		// Args is an alias used by some models (e.g. Gemma4) instead of Arguments.
+		Args map[string]interface{} `json:"args"`
+	}
+	// Some models (e.g. Qwen fine-tunes) emit truncated JSON that is
+	// missing one or more closing braces. Attempt to repair it before
+	// giving up on the unmarshal.
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		if repaired := repairJSON(content); repaired != content {
+			_ = json.Unmarshal([]byte(repaired), &parsed)
+		}
+	}
+	if parsed.Name != "" {
+		argsMap := parsed.Arguments
+		if argsMap == nil {
+			argsMap = parsed.Args
+		}
+		argsMap = flattenNestedArguments(argsMap)
+		args := make(map[string]string)
+		for k, v := range argsMap {
+			switch val := v.(type) {
+			case string:
+				args[k] = val
+			case float64:
+				args[k] = strconv.FormatFloat(val, 'f', -1, 64)
+			case int:
+				args[k] = strconv.Itoa(val)
+			case json.Number:
+				args[k] = val.String()
+			default:
+				if b, err := json.Marshal(v); err == nil {
+					args[k] = string(b)
+				}
+			}
+		}
+		return &ToolCall{
+			Type: "function",
+			Function: ToolFunction{
+				Name:      parsed.Name,
+				Arguments: args,
+			},
+		}
+	}
+	// JSON parse failed — some models (e.g. Qwen fine-tunes) emit
+	// <function=name>…</function> format wrapped inside <tool_call> tags,
+	// sometimes with a spurious `{"` prefix, or with `"function=` in
+	// place of `<function=` (the `<` is corrupted to `"`). Normalize
+	// that before trying the Qwen parser as a fallback.
+	normalized := strings.ReplaceAll(content, `"function=`, "<function=")
+	if idx := strings.Index(normalized, "<function="); idx >= 0 {
+		if qwenCalls := parseQwenToolCalls(normalized[idx:]); len(qwenCalls) > 0 {
+			return &qwenCalls[0]
+		}
+	}
+	return nil
 }
 
 // unmarshalJSONArgs parses a JSON object and returns all values as strings.
@@ -494,6 +520,21 @@ func StripMarkup(s string) string {
 	s = strings.ReplaceAll(s, "<s>", "")
 	s = strings.ReplaceAll(s, "</s>", " ")
 
+	// Normalise pipe-delimited tool-call opening tags BEFORE the Phi-4
+	// <|end|> truncation below, so that <|tool_call>…</tool_call> blocks are
+	// recognised and stripped even when <|end|> precedes them in the output.
+	// <|tool_call> is Phi-4's variant; <|toolcall> is Gemma 4's variant.
+	// Opening tags (pipe before name) → canonical <tool_call>.
+	s = strings.ReplaceAll(s, "<|tool_call>", "<tool_call>")
+	s = strings.ReplaceAll(s, "<|toolcall>", "<tool_call>")
+	s = strings.ReplaceAll(s, "<toolcall>", "<tool_call>")
+	// Closing tags (pipe after name) → canonical </tool_call>.
+	// <tool_call|> is Gemma 4's closing token (with underscore).
+	// <toolcall|>  is Gemma 4's closing token (without underscore).
+	s = strings.ReplaceAll(s, "<tool_call|>", "</tool_call>")
+	s = strings.ReplaceAll(s, "<toolcall|>", "</tool_call>")
+	s = strings.ReplaceAll(s, "</toolcall>", "</tool_call>")
+
 	// Strip ChatML / Qwen message-boundary tokens. If <|im_start|> (or its
 	// decoded form <im_start>) appears it means the model started simulating
 	// the next conversation turn — everything from that point onwards is
@@ -512,16 +553,6 @@ func StripMarkup(s string) string {
 			s = strings.TrimSpace(s[:idx])
 		}
 	}
-
-	// Normalise <toolcall> (no underscore) to the canonical form so the
-	// Standard block-removal below handles both spellings.
-	// Also normalise the Gemma 4 pipe-delimited forms: <|toolcall> (opening)
-	// and <toolcall|> (closing), mapping both to <tool_call> so the block
-	// stripper below removes the whole block including its call: content.
-	s = strings.ReplaceAll(s, "<|toolcall>", "<tool_call>")
-	s = strings.ReplaceAll(s, "<toolcall|>", "<tool_call>")
-	s = strings.ReplaceAll(s, "<toolcall>", "<tool_call>")
-	s = strings.ReplaceAll(s, "</toolcall>", "</tool_call>")
 
 	// Remove Standard <tool_call>…</tool_call> blocks.
 	s = stripStandardToolCallBlocks(s)

--- a/pkg/message/parser_gemma_test.go
+++ b/pkg/message/parser_gemma_test.go
@@ -305,3 +305,29 @@ func TestParseGemmaToolCalls_NoComma_MultipleCallsInGeneration(t *testing.T) {
 		t.Errorf("call[1] command: got %q, want %q", calls[1].Function.Arguments["command"], "headshake")
 	}
 }
+
+// TestStripMarkup_GemmaPipeClosingTag_SingleBlock verifies that the
+// pipe-closing tag <tool_call|> is treated as </tool_call> so the text
+// that follows is preserved.
+func TestStripMarkup_GemmaPipeClosingTag_SingleBlock(t *testing.T) {
+	s := `<|tool_call>call:tool_movement{command:<|"|>look<|"|>,angle:90}<tool_call|>Hello there!`
+	got := StripMarkup(s)
+	if got != "Hello there!" {
+		t.Errorf("got %q, want %q", got, "Hello there!")
+	}
+}
+
+// TestStripMarkup_GemmaPipeClosingTag_InterleavedText verifies that all text
+// segments between <|tool_call>…<tool_call|> blocks are preserved, not just
+// the last one.
+func TestStripMarkup_GemmaPipeClosingTag_InterleavedText(t *testing.T) {
+	s := "<|tool_call>call:tool_movement{angle:<|\"|>180<|\"|>,command:<|\"|>slowlook<|\"|>}<tool_call|>" +
+		"Oh, I'm Gemmai.\n" +
+		"<|tool_call>call:tool_movement{angle:<|\"|>90<|\"|>,command:<|\"|>look<|\"|>}<tool_call|>" +
+		"I'm a great model."
+	got := StripMarkup(s)
+	want := "Oh, I'm Gemmai.\nI'm a great model."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/message/parser_stripmarkup_test.go
+++ b/pkg/message/parser_stripmarkup_test.go
@@ -641,3 +641,44 @@ func TestStripMarkup_ToolResponseUnderscore_Stripped(t *testing.T) {
 		t.Errorf("got %q, want %q", got, "Good morning!")
 	}
 }
+
+// ---- StripMarkup: Phi-4 turn boundary tokens ----
+
+func TestStripMarkup_Phi4_EndTokenStripped(t *testing.T) {
+	// Phi-4 appends <|end|> at the end of its response turn.
+	// It must be stripped from the output before TTS.
+	s := "I'm merely observing the day's events with my superior processing capabilities.<|end|>"
+	got := StripMarkup(s)
+	want := "I'm merely observing the day's events with my superior processing capabilities."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestStripMarkup_Phi4_UserTokenTruncates(t *testing.T) {
+	// Phi-4 simulating next conversation turn with <|user|>.
+	// Everything from that token onwards should be discarded.
+	s := "Hello there.<|end|><|user|>What time is it?<|end|><|assistant|>It is noon."
+	got := StripMarkup(s)
+	if got != "Hello there." {
+		t.Errorf("got %q, want %q", got, "Hello there.")
+	}
+}
+
+func TestStripMarkup_Phi4_AssistantTokenTruncates(t *testing.T) {
+	// Phi-4 starting a second assistant turn — discard everything after.
+	s := "First response.<|assistant|>Second fabricated response."
+	got := StripMarkup(s)
+	if got != "First response." {
+		t.Errorf("got %q, want %q", got, "First response.")
+	}
+}
+
+func TestStripMarkup_Phi4_SystemTokenTruncates(t *testing.T) {
+	// Phi-4 injecting a <|system|> prompt mid-generation.
+	s := "Some text.<|system|>You are a helpful assistant."
+	got := StripMarkup(s)
+	if got != "Some text." {
+		t.Errorf("got %q, want %q", got, "Some text.")
+	}
+}

--- a/pkg/message/parser_test.go
+++ b/pkg/message/parser_test.go
@@ -333,13 +333,17 @@ func TestParseToolCalls_EmptyResponse(t *testing.T) {
 }
 
 func TestParseToolCalls_OnlyOpeningTag(t *testing.T) {
-	response := `<tool_call>
-{"name": "test", "arguments": {}}`
+	// Phi-4 and similar models emit <tool_call>{JSON} without a closing tag
+	// when generation is halted by a stop token. We must parse these anyway.
+	response := "<tool_call>\n{\"name\": \"test\", \"arguments\": {}}"
 
 	calls := ParseToolCalls(response)
 
-	if len(calls) != 0 {
-		t.Fatalf("expected 0 tool calls for missing closing tag, got %d", len(calls))
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call for unclosed tag with valid JSON, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "test" {
+		t.Errorf("expected name %q, got %q", "test", calls[0].Function.Name)
 	}
 }
 
@@ -557,5 +561,22 @@ func TestParseToolCalls_NestedArguments(t *testing.T) {
 				t.Errorf("angle: got %q, want %q", calls[0].Function.Arguments["angle"], tc.wantAngle)
 			}
 		})
+	}
+}
+
+func TestParseToolCalls_Phi4_PipeToolCallTag_Unclosed(t *testing.T) {
+	// Phi-4 uses <|tool_call>{JSON} without a closing tag.
+	response := "Hello, human. I am performing optimally today.<|tool_call>{\"name\": \"slowlook\", \"arguments\": {\"angle\": 90}}"
+
+	calls := ParseToolCalls(response)
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "slowlook" {
+		t.Errorf("expected name %q, got %q", "slowlook", calls[0].Function.Name)
+	}
+	if calls[0].Function.Arguments["angle"] != "90" {
+		t.Errorf("expected angle %q, got %q", "90", calls[0].Function.Arguments["angle"])
 	}
 }

--- a/pkg/message/stopmarkers.go
+++ b/pkg/message/stopmarkers.go
@@ -1,0 +1,90 @@
+package message
+
+import (
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+// StopMarkers returns the set of string markers that should halt text generation
+// when any of them appears in the accumulated output.
+//
+// It combines two sources:
+//  1. The model's own EOT (end-of-turn) token text, obtained directly from the
+//     vocabulary via VocabEOT so it works for any model regardless of format.
+//  2. Format-specific role/turn-boundary tokens that signal the model has started
+//     simulating the next conversation turn (fabricated Q&A).
+//
+// The caller should stop generation and discard everything from the first
+// matching marker onwards.
+func StopMarkers(vocab llama.Vocab, format Format) []string {
+	markers := eotMarkers(vocab)
+
+	switch format {
+	case FormatGemma:
+		markers = append(markers,
+			// Turn boundary tokens used by Gemma 4.
+			"<|turn>user", "<|turn>model",
+			"<turn>user", "<turn>model", // decoded form (| stripped)
+			"<|turn|>", "<|turn>",
+			"<turn|>",
+			// Thought channel — internal reasoning, not spoken text.
+			"<|channel>thought", "<channel>thought",
+		)
+	case FormatQwen:
+		markers = append(markers,
+			// ChatML role tokens; model simulating next turn.
+			"<|im_start|>", "<|im_end|>",
+			"<im_start>", "<im_end>", // decoded form
+		)
+	case FormatPhi:
+		markers = append(markers,
+			// Phi-3/4 turn-boundary tokens.
+			"<|user|>", "<|assistant|>", "<|system|>",
+		)
+	case FormatStandard, FormatAuto:
+		// Include ChatML tokens as a safety net for unknown/auto models.
+		markers = append(markers,
+			"<|im_start|>", "<|im_end|>",
+		)
+	}
+
+	// Tool-result tokens are common across all formats: stop if the model
+	// starts simulating tool results rather than producing spoken text.
+	markers = append(markers,
+		"<toolresult", "<|toolresult", "<tool_result",
+		"<toolresponse", "<|toolresponse", "<tool_response",
+		`tool{"status"`,
+		"<turnend>", "<|turnend>",
+	)
+
+	return markers
+}
+
+// eotMarkers returns a deduplicated list of strings for the model's EOT token.
+// It uses TokenToPiece (the decoded form that appears in the output stream) as
+// the primary value, with VocabGetText as a fallback, so the returned string
+// matches exactly what will appear in accumulated output chunks.
+func eotMarkers(vocab llama.Vocab) []string {
+	eot := llama.VocabEOT(vocab)
+	if eot < 0 {
+		return nil
+	}
+
+	buf := make([]byte, 64)
+	n := llama.TokenToPiece(vocab, eot, buf, 0, true)
+	piece := ""
+	if n > 0 {
+		piece = string(buf[:n])
+	}
+
+	text := llama.VocabGetText(vocab, eot)
+
+	seen := map[string]bool{}
+	var markers []string
+	for _, s := range []string{piece, text} {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			markers = append(markers, s)
+		}
+	}
+	return markers
+}

--- a/pkg/message/stopmarkers.go
+++ b/pkg/message/stopmarkers.go
@@ -37,6 +37,10 @@ func StopMarkers(vocab llama.Vocab, format Format) []string {
 		)
 	case FormatPhi:
 		markers = append(markers,
+			// Phi-3/4 EOT token. Added explicitly because VocabEOT may return -1
+			// for some fine-tuned/abliterated variants that don't register a
+			// distinct EOT token — eotMarkers() would then contribute nothing.
+			"<|end|>",
 			// Phi-3/4 turn-boundary tokens.
 			"<|user|>", "<|assistant|>", "<|system|>",
 		)

--- a/pkg/message/stopmarkers_test.go
+++ b/pkg/message/stopmarkers_test.go
@@ -1,0 +1,104 @@
+package message
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+// StopMarkers is tested with a zero (nil) vocab so VocabEOT returns -1 and
+// eotMarkers returns nil. This exercises the format-dispatch logic cleanly
+// without needing a real model file.
+
+func TestStopMarkers_Gemma_ContainsGemmaTurnTokens(t *testing.T) {
+	markers := StopMarkers(llama.Vocab(0), FormatGemma)
+	for _, want := range []string{
+		"<|turn>user", "<|turn>model",
+		"<turn>user", "<turn>model",
+		"<|turn|>", "<|turn>",
+		"<turn|>",
+		"<|channel>thought", "<channel>thought",
+	} {
+		if !slices.Contains(markers, want) {
+			t.Errorf("StopMarkers(FormatGemma) missing %q", want)
+		}
+	}
+}
+
+func TestStopMarkers_Gemma_DoesNotContainChatMLOrPhiTokens(t *testing.T) {
+	markers := StopMarkers(llama.Vocab(0), FormatGemma)
+	for _, unwanted := range []string{"<|im_start|>", "<|user|>", "<|assistant|>"} {
+		if slices.Contains(markers, unwanted) {
+			t.Errorf("StopMarkers(FormatGemma) unexpectedly contains %q", unwanted)
+		}
+	}
+}
+
+func TestStopMarkers_Qwen_ContainsChatMLTokens(t *testing.T) {
+	markers := StopMarkers(llama.Vocab(0), FormatQwen)
+	for _, want := range []string{"<|im_start|>", "<|im_end|>", "<im_start>", "<im_end>"} {
+		if !slices.Contains(markers, want) {
+			t.Errorf("StopMarkers(FormatQwen) missing %q", want)
+		}
+	}
+}
+
+func TestStopMarkers_Qwen_DoesNotContainGemmaOrPhiTokens(t *testing.T) {
+	markers := StopMarkers(llama.Vocab(0), FormatQwen)
+	for _, unwanted := range []string{"<|turn>user", "<|user|>", "<|assistant|>"} {
+		if slices.Contains(markers, unwanted) {
+			t.Errorf("StopMarkers(FormatQwen) unexpectedly contains %q", unwanted)
+		}
+	}
+}
+
+func TestStopMarkers_Phi_ContainsPhiTurnTokens(t *testing.T) {
+	markers := StopMarkers(llama.Vocab(0), FormatPhi)
+	for _, want := range []string{"<|user|>", "<|assistant|>", "<|system|>"} {
+		if !slices.Contains(markers, want) {
+			t.Errorf("StopMarkers(FormatPhi) missing %q", want)
+		}
+	}
+}
+
+func TestStopMarkers_Phi_DoesNotContainGemmaOrChatMLTokens(t *testing.T) {
+	markers := StopMarkers(llama.Vocab(0), FormatPhi)
+	for _, unwanted := range []string{"<|turn>user", "<|im_start|>"} {
+		if slices.Contains(markers, unwanted) {
+			t.Errorf("StopMarkers(FormatPhi) unexpectedly contains %q", unwanted)
+		}
+	}
+}
+
+func TestStopMarkers_AllFormats_ContainToolResultMarkers(t *testing.T) {
+	// Tool-result stop tokens should be present regardless of format.
+	toolMarkers := []string{
+		"<toolresult", "<tool_result",
+		"<toolresponse", "<tool_response",
+		`tool{"status"`,
+		"<turnend>", "<|turnend>",
+	}
+	for _, format := range []Format{FormatGemma, FormatQwen, FormatPhi, FormatStandard, FormatAuto} {
+		markers := StopMarkers(llama.Vocab(0), format)
+		for _, want := range toolMarkers {
+			if !slices.Contains(markers, want) {
+				t.Errorf("StopMarkers(format=%v) missing tool marker %q", format, want)
+			}
+		}
+	}
+}
+
+func TestDetectFormatFromPath_PhiReturnsPhi(t *testing.T) {
+	tests := []string{
+		"models/phi-4-mini-instruct-abliterated-Q4_K_M.gguf",
+		"models/Phi-3-mini-4k-instruct-q4.gguf",
+		"models/phi3.5-mini-instruct.gguf",
+	}
+	for _, path := range tests {
+		got := DetectFormatFromPath(path)
+		if got != FormatPhi {
+			t.Errorf("DetectFormatFromPath(%q) = %v, want FormatPhi", path, got)
+		}
+	}
+}


### PR DESCRIPTION
- **message:** Add `FormatPhi` to handle Phi-family models (Phi-3, Phi-4) and detect it via `DetectFormatFromPath`.
- **message:** Introduce `StopMarkers` tool to dynamically assemble generation halting strings based on model vocab and format.
- **message:** Update `StripMarkup` to remove Phi-4 boundary tokens (`<|end|>`, `<|user|>`, etc.).
- **test:** Add parsing and stop marker test suites for `FormatPhi`.