### PR TITLE
message: add Gemma 3 format support 

### DIFF
--- a/pkg/message/format.go
+++ b/pkg/message/format.go
@@ -24,6 +24,12 @@ const (
 	//   [TOOL_CALLS]funcname[ARGS]{...}
 	FormatMistral
 
+	// FormatGemma3 expects Gemma 3's turn-based format:
+	//   <start_of_turn>user\n…<end_of_turn>\n
+	//   <start_of_turn>model\n…<end_of_turn>\n
+	// No system role: system instructions are prepended to the first user turn.
+	FormatGemma3
+
 	// FormatGemma expects Gemma 4's call: syntax:
 	//   call:funcname{key:<|"|>value<|"|>}
 	FormatGemma
@@ -70,6 +76,8 @@ func DetectFormatFromPath(path string) Format {
 	switch {
 	case strings.Contains(lower, "qwen"):
 		return FormatQwen
+	case strings.Contains(lower, "gemma-3"), strings.Contains(lower, "gemma3"):
+		return FormatGemma3
 	case strings.Contains(lower, "gemma"):
 		return FormatGemma
 	case strings.Contains(lower, "mistral"), strings.Contains(lower, "devstral"):

--- a/pkg/message/format_test.go
+++ b/pkg/message/format_test.go
@@ -26,6 +26,8 @@ func TestDetectFormatFromPath_KnownFamilies(t *testing.T) {
 	}{
 		{"models/qwen3.5-4B-instruct.gguf", FormatQwen},
 		{"models/gemma-4-E4B-it-Q4_K_M.gguf", FormatGemma},
+		{"models/gemma-3-1b-it-Q4_K_M.gguf", FormatGemma3},
+		{"models/gemma3-4b-it-Q4_K_M.gguf", FormatGemma3},
 		{"models/mistral-7b-instruct-v0.2.Q4_K_M.gguf", FormatMistral},
 		{"models/devstral-small.gguf", FormatMistral},
 		{"models/glm-4-9b-chat-q4.gguf", FormatGLM},

--- a/pkg/message/parser.go
+++ b/pkg/message/parser.go
@@ -554,6 +554,15 @@ func StripMarkup(s string) string {
 		}
 	}
 
+	// Strip Gemma 3 turn boundary tokens. <end_of_turn> is the EOT separator;
+	// <start_of_turn>user and <start_of_turn>model indicate the model has
+	// started simulating the next conversation turn.
+	for _, marker := range []string{"<end_of_turn>", "<start_of_turn>user", "<start_of_turn>model"} {
+		if idx := strings.Index(s, marker); idx >= 0 {
+			s = strings.TrimSpace(s[:idx])
+		}
+	}
+
 	// Remove Standard <tool_call>…</tool_call> blocks.
 	s = stripStandardToolCallBlocks(s)
 

--- a/pkg/message/parser_gemma.go
+++ b/pkg/message/parser_gemma.go
@@ -17,9 +17,13 @@ const gemmaQuoteToken = "<|\"|>"
 // gemmaShortQuoteToken is an alternate form emitted by some Gemma 4 variants.
 const gemmaShortQuoteToken = "<\">"
 
-// gemmaQuoteTokens lists all recognised Gemma 4 string delimiters, longest first
+// gemmaBarePipeToken is the minimal pipe-delimited form emitted by Gemma 3
+// models: <|> (pipe between angle brackets, no embedded quote character).
+const gemmaBarePipeToken = "<|>"
+
+// gemmaQuoteTokens lists all recognised Gemma string delimiters, longest first
 // so prefix checks prefer the longer form when both could match.
-var gemmaQuoteTokens = []string{gemmaQuoteToken, gemmaShortQuoteToken}
+var gemmaQuoteTokens = []string{gemmaQuoteToken, gemmaShortQuoteToken, gemmaBarePipeToken}
 
 // gemma4TurnTagRE matches Gemma 4 turn boundary tokens in all observed forms:
 //

--- a/pkg/message/parser_gemma_test.go
+++ b/pkg/message/parser_gemma_test.go
@@ -331,3 +331,50 @@ func TestStripMarkup_GemmaPipeClosingTag_InterleavedText(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+// TestParseGemmaToolCalls_BarePipeToken tests the <|> minimal pipe-delimited
+// quote form emitted by Gemma 3 models (no embedded " character).
+func TestParseGemmaToolCalls_BarePipeToken(t *testing.T) {
+	// Exact format observed in real Gemma 3 model output.
+	response := `call:tool_movement{command:<|>look<|>angle:45}`
+	calls := ParseToolCalls(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "tool_movement" {
+		t.Errorf("name: got %q, want %q", calls[0].Function.Name, "tool_movement")
+	}
+	if calls[0].Function.Arguments["command"] != "look" {
+		t.Errorf("command: got %q, want %q", calls[0].Function.Arguments["command"], "look")
+	}
+	if calls[0].Function.Arguments["angle"] != "45" {
+		t.Errorf("angle: got %q, want %q", calls[0].Function.Arguments["angle"], "45")
+	}
+}
+
+// TestParseGemmaToolCalls_BarePipeToken_WithComma tests the <|> form with an
+// explicit comma separator between arguments.
+func TestParseGemmaToolCalls_BarePipeToken_WithComma(t *testing.T) {
+	response := `call:tool_movement{command:<|>look<|>,angle:90}`
+	calls := ParseToolCalls(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Function.Arguments["command"] != "look" {
+		t.Errorf("command: got %q, want %q", calls[0].Function.Arguments["command"], "look")
+	}
+	if calls[0].Function.Arguments["angle"] != "90" {
+		t.Errorf("angle: got %q, want %q", calls[0].Function.Arguments["angle"], "90")
+	}
+}
+
+// TestStripMarkup_BarePipeTokenCallBlock verifies that call:func{} blocks
+// using the <|> quote token are stripped from spoken output.
+func TestStripMarkup_BarePipeTokenCallBlock(t *testing.T) {
+	s := "Hello there!\ncall:tool_movement{command:<|>look<|>angle:45}\nI looked right."
+	got := StripMarkup(s)
+	want := "Hello there!\n\nI looked right."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/message/stopmarkers.go
+++ b/pkg/message/stopmarkers.go
@@ -19,6 +19,12 @@ func StopMarkers(vocab llama.Vocab, format Format) []string {
 	markers := eotMarkers(vocab)
 
 	switch format {
+	case FormatGemma3:
+		markers = append(markers,
+			// Turn boundary tokens for Gemma 3. Stop if the model starts
+			// simulating the next conversation turn.
+			"<start_of_turn>user", "<start_of_turn>model",
+		)
 	case FormatGemma:
 		markers = append(markers,
 			// Turn boundary tokens used by Gemma 4.

--- a/pkg/message/stopmarkers_test.go
+++ b/pkg/message/stopmarkers_test.go
@@ -79,12 +79,32 @@ func TestStopMarkers_AllFormats_ContainToolResultMarkers(t *testing.T) {
 		`tool{"status"`,
 		"<turnend>", "<|turnend>",
 	}
-	for _, format := range []Format{FormatGemma, FormatQwen, FormatPhi, FormatStandard, FormatAuto} {
+	for _, format := range []Format{FormatGemma, FormatGemma3, FormatQwen, FormatPhi, FormatStandard, FormatAuto} {
 		markers := StopMarkers(llama.Vocab(0), format)
 		for _, want := range toolMarkers {
 			if !slices.Contains(markers, want) {
 				t.Errorf("StopMarkers(format=%v) missing tool marker %q", format, want)
 			}
+		}
+	}
+}
+
+func TestStopMarkers_Gemma3_ContainsTurnTokens(t *testing.T) {
+	markers := StopMarkers(llama.Vocab(0), FormatGemma3)
+	for _, want := range []string{
+		"<start_of_turn>user", "<start_of_turn>model",
+	} {
+		if !slices.Contains(markers, want) {
+			t.Errorf("StopMarkers(FormatGemma3) missing %q", want)
+		}
+	}
+}
+
+func TestStopMarkers_Gemma3_DoesNotContainGemma4Tokens(t *testing.T) {
+	markers := StopMarkers(llama.Vocab(0), FormatGemma3)
+	for _, unwanted := range []string{"<|turn>user", "<|turn>model", "<|channel>thought"} {
+		if slices.Contains(markers, unwanted) {
+			t.Errorf("StopMarkers(FormatGemma3) unexpectedly contains %q", unwanted)
 		}
 	}
 }

--- a/pkg/template/jinja.go
+++ b/pkg/template/jinja.go
@@ -1,9 +1,26 @@
 package template
 
 import (
+	"embed"
+	"strings"
+
 	"github.com/ardanlabs/jinja"
 	"github.com/hybridgroup/yzma/pkg/message"
 )
+
+//go:embed prompts/*.jinja
+var builtinTemplates embed.FS
+
+// BuiltinTemplate returns the raw Jinja template string for a named built-in
+// template (e.g. "gemma3", "chatml", "qwen2.5-instruct"). The second return
+// value is false when no built-in with that name exists.
+func BuiltinTemplate(name string) (string, bool) {
+	data, err := builtinTemplates.ReadFile("prompts/" + strings.TrimSuffix(name, ".jinja") + ".jinja")
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}
 
 // Options controls optional template rendering behaviour.
 type Options struct {

--- a/pkg/template/jinja_test.go
+++ b/pkg/template/jinja_test.go
@@ -299,3 +299,86 @@ func TestApplyJinjaTemplateWithMultipleToolCalls(t *testing.T) {
 		t.Error("Output does not contain expected tool response '35'")
 	}
 }
+
+func TestGemma3Template_BasicConversation(t *testing.T) {
+	tmplPath := "./prompts/gemma3.jinja"
+	tmplBytes, err := os.ReadFile(tmplPath)
+	if err != nil {
+		t.Fatalf("Failed to read template file: %v", err)
+	}
+	tmpl := string(tmplBytes)
+
+	messages := []message.Message{
+		message.Chat{Role: "user", Content: "knock knock"},
+		message.Chat{Role: "assistant", Content: "who is there"},
+	}
+
+	result, err := Apply(tmpl, messages, true)
+	if err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+
+	t.Logf("Apply output:\n%s", result)
+
+	if !strings.Contains(result, "<start_of_turn>user") {
+		t.Error("Output does not contain <start_of_turn>user")
+	}
+	if !strings.Contains(result, "<start_of_turn>model") {
+		t.Error("Output does not contain <start_of_turn>model")
+	}
+	if !strings.Contains(result, "<end_of_turn>") {
+		t.Error("Output does not contain <end_of_turn>")
+	}
+	if !strings.Contains(result, "knock knock") {
+		t.Error("Output does not contain user message content")
+	}
+	if !strings.Contains(result, "who is there") {
+		t.Error("Output does not contain assistant message content")
+	}
+	// Generation prompt should be appended
+	if !strings.HasSuffix(strings.TrimRight(result, "\n"), "<start_of_turn>model") {
+		t.Errorf("Output does not end with <start_of_turn>model, got: %q", result)
+	}
+}
+
+func TestGemma3Template_SystemMessageMergedIntoFirstUserTurn(t *testing.T) {
+	tmplPath := "./prompts/gemma3.jinja"
+	tmplBytes, err := os.ReadFile(tmplPath)
+	if err != nil {
+		t.Fatalf("Failed to read template file: %v", err)
+	}
+	tmpl := string(tmplBytes)
+
+	messages := []message.Message{
+		message.Chat{Role: "system", Content: "Only reply like a pirate."},
+		message.Chat{Role: "user", Content: "What is the answer to life the universe and everything?"},
+	}
+
+	result, err := Apply(tmpl, messages, true)
+	if err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+
+	t.Logf("Apply output:\n%s", result)
+
+	// System content must appear inside the first user turn, not as its own turn.
+	if strings.Contains(result, "<start_of_turn>system") {
+		t.Error("Output must not contain a <start_of_turn>system turn")
+	}
+	if !strings.Contains(result, "Only reply like a pirate.") {
+		t.Error("Output does not contain system instruction text")
+	}
+	if !strings.Contains(result, "What is the answer to life the universe and everything?") {
+		t.Error("Output does not contain user message content")
+	}
+	// Both system and user text should be inside the same user turn.
+	userTurnIdx := strings.Index(result, "<start_of_turn>user")
+	systemIdx := strings.Index(result, "Only reply like a pirate.")
+	userContentIdx := strings.Index(result, "What is the answer to life the universe and everything?")
+	if systemIdx < userTurnIdx {
+		t.Error("System instruction appears before the user turn marker")
+	}
+	if userContentIdx < systemIdx {
+		t.Error("User content appears before system instruction within the user turn")
+	}
+}

--- a/pkg/template/prompts/gemma3.jinja
+++ b/pkg/template/prompts/gemma3.jinja
@@ -1,0 +1,28 @@
+{%- if messages[0]['role'] == 'system' -%}
+{%- set first_user_prefix = messages[0]['content'] + '\n\n' -%}
+{%- set loop_messages = messages[1:] -%}
+{%- else -%}
+{%- set first_user_prefix = "" -%}
+{%- set loop_messages = messages -%}
+{%- endif -%}
+{%- for message in loop_messages -%}
+{%- if (message['role'] == 'assistant') -%}
+{%- set role = "model" -%}
+{%- else -%}
+{%- set role = message['role'] -%}
+{%- endif -%}
+{{ '<start_of_turn>' + role + '\n' + (first_user_prefix if loop.first else "") }}
+{%- if message['content'] is string -%}
+{{ message['content'] | trim }}
+{%- elif message['content'] is iterable -%}
+{%- for item in message['content'] -%}
+{%- if item['type'] == 'text' -%}
+{{ item['text'] | trim }}
+{%- endif -%}
+{%- endfor -%}
+{%- endif -%}
+{{ '<end_of_turn>\n' }}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+{{'<start_of_turn>model\n'}}
+{%- endif -%}


### PR DESCRIPTION
This PR is to add `FormatGemma3` for Gemma 3's `<start_of_turn>/<end_of_turn>` turn format, distinct from the existing `FormatGemma` (Gemma 4).

It also improves the templates by embedding the `prompts/` directory at build time and exposing the `BuiltinTemplate(name)` to look up a built-in Jinja template by name (e.g. "gemma3", "chatml") without requiring callers to read files from disk.