### PR TITLE
fix(ffi): correct FFI return/param type sizes to prevent heap corruption

### DIFF
--- a/pkg/llama/sampling.go
+++ b/pkg/llama/sampling.go
@@ -28,7 +28,9 @@ const (
 
 var (
 	// ffiSamplerChainParams represents the C struct llama_sampler_chain_params
-	ffiSamplerChainParams = ffi.NewType(&ffi.TypePointer)
+	// { bool no_perf; } — exactly 1 byte; must NOT be TypePointer (8 bytes)
+	// or libffi will overrun the return-value buffer by 7 bytes.
+	ffiSamplerChainParams = ffi.NewType(&ffi.TypeUint8)
 )
 
 var (

--- a/pkg/mtmd/mtmd.go
+++ b/pkg/mtmd/mtmd.go
@@ -48,9 +48,27 @@ type ContextParamsType struct {
 var (
 	ffiTypeSize = ffi.TypeUint64
 
-	// ffiTypeContextParams represents the C struct mtmd_context_params
-	ffiTypeContextParams = ffi.NewType(&ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer,
-		&ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize)
+	// ffiTypeContextParams represents the C struct mtmd_context_params:
+	//   bool use_gpu, bool print_timings, int n_threads,
+	//   const char * image_marker, const char * media_marker,
+	//   enum llama_flash_attn_type flash_attn_type (int-sized, NOT uint8),
+	//   bool warmup, int image_min_tokens, int image_max_tokens,
+	//   ggml_backend_sched_eval_callback cb_eval, void * cb_eval_user_data
+	// The struct has no size_t field — the trailing ffiTypeSize was wrong and
+	// caused libffi to write 64 bytes into a 56-byte Go variable (heap overrun).
+	ffiTypeContextParams = ffi.NewType(
+		&ffi.TypeUint8,   // use_gpu bool
+		&ffi.TypeUint8,   // print_timings bool
+		&ffi.TypeSint32,  // n_threads int
+		&ffi.TypePointer, // image_marker *char
+		&ffi.TypePointer, // media_marker *char
+		&ffi.TypeSint32,  // flash_attn_type enum llama_flash_attn_type (int-sized)
+		&ffi.TypeUint8,   // warmup bool
+		&ffi.TypeSint32,  // image_min_tokens int
+		&ffi.TypeSint32,  // image_max_tokens int
+		&ffi.TypePointer, // cb_eval callback
+		&ffi.TypePointer, // cb_eval_user_data void*
+	)
 
 	// ffiTypeInputText represents the C struct mtmd_input_text
 	ffiTypeInputText = ffi.NewType(&ffi.TypePointer, &ffi.TypeUint8, &ffi.TypeUint8)


### PR DESCRIPTION
llama.SamplerChainDefaultParams: ffiSamplerChainParams was registered as TypePointer (8 bytes) but llama_sampler_chain_params is a 1-byte C struct (bool no_perf). libffi was writing 8 bytes into a 1-byte Go variable on every call, corrupting 7 adjacent heap bytes. Fix: use TypeUint8.

mtmd.ContextParamsDefault / ContextInit: ffiTypeContextParams had two errors vs the actual mtmd_context_params C struct:
  - flash_attn_type was registered as TypeUint8 (1 byte) instead of TypeSint32 (4 bytes), corrupting flash_attn_type and warmup values
  - a trailing TypeUint64 (size_t) field not present in the C struct caused libffi to write 64 bytes into a 56-byte Go variable, an 8-byte heap overrun identical to the sampler bug

Fixes #247