### PR TITLE
llama: update ContextParams for llama.cpp MTP support (PR #22673)

### DIFF
--- a/pkg/llama/context.go
+++ b/pkg/llama/context.go
@@ -12,7 +12,9 @@ import (
 var ffiTypeContextParams = ffi.NewType(
 	&ffi.TypeUint32, &ffi.TypeUint32,
 	&ffi.TypeUint32, &ffi.TypeUint32,
+	&ffi.TypeUint32,
 	&ffi.TypeSint32, &ffi.TypeSint32,
+	&ffi.TypeSint32,
 	&ffi.TypeSint32, &ffi.TypeSint32,
 	&ffi.TypeSint32, &ffi.TypeSint32,
 	&ffi.TypeFloat, &ffi.TypeFloat,

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -315,13 +315,22 @@ type ModelParams struct {
 }
 
 // ContextParams controls the parameters available for the model context
+type ContextType int32
+
+const (
+	ContextTypeDefault ContextType = 0 // default context type
+	ContextTypeMTP     ContextType = 1 // Multi Token Prediction context type [EXPERIMENTAL]
+)
+
 type ContextParams struct {
 	NCtx               uint32             // text context, 0 = from model
 	NBatch             uint32             // logical maximum batch size
 	NUbatch            uint32             // physical maximum batch size
 	NSeqMax            uint32             // max number of sequences
+	NRsSeq             uint32             // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
 	NThreads           int32              // number of threads to use for generation
 	NThreadsBatch      int32              // number of threads to use for batch processing
+	CtxType            ContextType        // context type (e.g. MTP)
 	RopeScalingType    RopeScalingType    // RoPE scaling type
 	PoolingType        PoolingType        // pooling type for embeddings
 	AttentionType      AttentionType      // attention type


### PR DESCRIPTION
Add two new fields to llama_context_params introduced in llama.cpp PR #22673 (Multi Token Prediction speculative decoding):

- NRsSeq uint32: number of recurrent-state snapshots per seq for rollback
- CtxType ContextType: context type (default or MTP)