### PR TITLE
pkg/llama: add llama_n_rs_seq binding

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,6 +106,7 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 - [x] `llama_n_batch`
 - [x] `llama_n_ctx_seq`
 - [x] `llama_n_ctx`
+- [x] `llama_n_rs_seq`
 - [x] `llama_n_seq_max`
 - [x] `llama_n_threads_batch`
 - [x] `llama_n_threads`
@@ -278,7 +279,6 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 
 - [ ] `llama_model_init_from_user`
 - [ ] `llama_model_load_from_file_ptr`
-- [ ] `llama_n_rs_seq`
 - [ ] `llama_opt_epoch`
 - [ ] `llama_opt_init`
 - [ ] `llama_opt_param_filter_all`

--- a/pkg/llama/context.go
+++ b/pkg/llama/context.go
@@ -110,6 +110,9 @@ var (
 	// LLAMA_API uint32_t llama_n_seq_max(const struct llama_context * ctx);
 	nSeqMaxFunc ffi.Fun
 
+	// LLAMA_API uint32_t llama_n_rs_seq(const struct llama_context * ctx);
+	nRsSeqFunc ffi.Fun
+
 	// LLAMA_API const struct llama_model * llama_get_model(const struct llama_context * ctx);
 	getModelFunc ffi.Fun
 
@@ -250,6 +253,10 @@ func loadContextFuncs(lib ffi.Lib) error {
 
 	if nSeqMaxFunc, err = lib.Prep("llama_n_seq_max", &ffi.TypeUint32, &ffi.TypePointer); err != nil {
 		return loadError("llama_n_seq_max", err)
+	}
+
+	if nRsSeqFunc, err = lib.Prep("llama_n_rs_seq", &ffi.TypeUint32, &ffi.TypePointer); err != nil {
+		return loadError("llama_n_rs_seq", err)
 	}
 
 	if getModelFunc, err = lib.Prep("llama_get_model", &ffi.TypePointer, &ffi.TypePointer); err != nil {
@@ -534,6 +541,17 @@ func NSeqMax(ctx Context) uint32 {
 	}
 	var result ffi.Arg
 	nSeqMaxFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx))
+	return uint32(result)
+}
+
+// NRsSeq returns the number of recurrent-state snapshots per sequence
+// that the context was created with (0 = no rollback).
+func NRsSeq(ctx Context) uint32 {
+	if ctx == 0 {
+		return 0
+	}
+	var result ffi.Arg
+	nRsSeqFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx))
 	return uint32(result)
 }
 

--- a/pkg/llama/context_test.go
+++ b/pkg/llama/context_test.go
@@ -164,6 +164,28 @@ func TestNSeqMax(t *testing.T) {
 	t.Logf("NSeqMax returned: %d", nSeqMax)
 }
 
+func TestNRsSeq(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer ModelFree(model)
+
+	ctx, err := InitFromModel(model, ContextDefaultParams())
+	if err != nil {
+		t.Fatalf("InitFromModel failed: %v", err)
+	}
+	defer Free(ctx)
+
+	nRsSeq := NRsSeq(ctx)
+	t.Logf("NRsSeq returned: %d", nRsSeq)
+}
+
 func TestGetModel(t *testing.T) {
 	modelFile := testModelFileName(t)
 


### PR DESCRIPTION
Bind llama_n_rs_seq (added in llama.cpp PR #22673 for MTP/GDN recurrent-state snapshot support):