### PR TITLE
feat: automatically fallback to previous llama.cpp version on 404 errors

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -73,17 +73,13 @@ func runInstall(c *cli.Context) error {
 		}
 	}
 
-	if version == "" {
-		var err error
-		version, err = download.LlamaLatestVersion()
-		if err != nil {
-			return fmt.Errorf("could not obtain latest version: %w", err)
-		}
-	}
-
 	quiet := c.Bool("quiet")
 	if !quiet {
-		fmt.Println("installing llama.cpp version", version, "to", libPath)
+		if version == "" || version == "latest" {
+			fmt.Println("installing latest llama.cpp version to", libPath)
+		} else {
+			fmt.Println("installing llama.cpp version", version, "to", libPath)
+		}
 	} else {
 		download.ProgressTracker = nil
 	}

--- a/examples/installer/main.go
+++ b/examples/installer/main.go
@@ -21,15 +21,6 @@ func main() {
 		}
 	}
 
-	if *version == "" {
-		var err error
-		*version, err = download.LlamaLatestVersion()
-		if err != nil {
-			fmt.Println("could not obtain latest version:", err.Error())
-			return
-		}
-	}
-
 	if *processor == "" {
 		*processor = "cpu"
 		if cudaInstalled, cudaVersion := download.HasCUDA(); cudaInstalled {
@@ -38,7 +29,11 @@ func main() {
 		}
 	}
 
-	fmt.Println("installing llama.cpp version", *version, "to", *libPath)
+	if *version == "" || *version == "latest" {
+		fmt.Println("installing latest llama.cpp version to", *libPath)
+	} else {
+		fmt.Println("installing llama.cpp version", *version, "to", *libPath)
+	}
 	if err := download.Get(runtime.GOARCH, runtime.GOOS, *processor, *version, *libPath); err != nil {
 		fmt.Println("failed to download llama.cpp:", err.Error())
 		return

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -38,7 +38,13 @@ var (
 	// Actual downloads will be from the llama.cpp repo for any builds that are available there,
 	// and from the llama-cpp-builder repo for builds that are not available in the original repo
 	// (e.g. ARM64 CUDA builds). This is handled in the getDownloadLocationAndFilename function.
-	versionURL = "https://hybridgroup.github.io/llama-cpp-builder/version.json"
+	currentVersionURL = "https://hybridgroup.github.io/llama-cpp-builder/version.json"
+
+	// previousVersionURL is the URL for fetching the previous llama.cpp version. This is used as a fallback
+	// if the current version URL is not available or does not contain a valid version.
+	// This is necessary because the build server for the current version might be building the latest version
+	// and might not have it available yet, while the previous version is likely to be available and can be used as a fallback.
+	previousVersionURL = "https://hybridgroup.github.io/llama-cpp-builder/previous.json"
 )
 
 // LlamaLatestVersion fetches the latest release tag of llama.cpp from the version URL.
@@ -57,7 +63,53 @@ func LlamaLatestVersion() (string, error) {
 }
 
 func getLatestVersion() (string, error) {
-	req, err := http.NewRequest("GET", versionURL, nil)
+	req, err := http.NewRequest("GET", currentVersionURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("received status code %d from version URL: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		TagName string `json:"tag_name"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.TagName, nil
+}
+
+// LlamaPreviousVersion fetches the previous release tag of llama.cpp from the version URL.
+func LlamaPreviousVersion() (string, error) {
+	var version string
+	var err error
+	for range RetryCount {
+		version, err = getPreviousVersion()
+		if err == nil {
+			return version, nil
+		}
+		time.Sleep(RetryDelay)
+	}
+
+	return "", errors.New("unable to fetch previous version")
+}
+
+func getPreviousVersion() (string, error) {
+	req, err := http.NewRequest("GET", previousVersionURL, nil)
 	if err != nil {
 		return "", err
 	}
@@ -251,8 +303,9 @@ var getFunc = get
 // arch can be one of the following values: "amd64", "arm64".
 // os can be one of the following values: "linux", "darwin", "windows", "bookworm", "trixie".
 // processor can be one of the following values: "cpu", "cuda", "metal", "rocm", "vulkan".
-// version should be the desired `b1234` formatted llama.cpp version. You can use the
-// [LlamaLatestVersion] function to obtain the latest release.
+// version should be the desired `b1234` formatted llama.cpp version. If an empty
+// string ("") or "latest" is provided, the latest release will be downloaded,
+// with an automatic fallback to the previous version if the latest is still building.
 // dest in the destination directory for the downloaded binaries.
 func Get(architecture string, operatingSystem string, processor string, version string, dest string) error {
 	return GetWithProgress(architecture, operatingSystem, processor, version, dest, ProgressTracker)
@@ -263,8 +316,9 @@ func Get(architecture string, operatingSystem string, processor string, version 
 // arch can be one of the following values: "amd64", "arm64".
 // os can be one of the following values: "linux", "darwin", "windows", "bookworm", "trixie".
 // processor can be one of the following values: "cpu", "cuda", "metal", "rocm", "vulkan".
-// version should be the desired `b1234` formatted llama.cpp version. You can use the
-// [LlamaLatestVersion] function to obtain the latest release.
+// version should be the desired `b1234` formatted llama.cpp version. If an empty
+// string ("") or "latest" is provided, the latest release will be downloaded,
+// with an automatic fallback to the previous version if the latest is still building.
 // dest in the destination directory for the downloaded binaries.
 func GetWithProgress(architecture string, operatingSystem string, processor string, version string, dest string, progress getter.ProgressTracker) error {
 	return GetWithContext(context.Background(), architecture, operatingSystem, processor, version, dest, progress)
@@ -275,10 +329,21 @@ func GetWithProgress(architecture string, operatingSystem string, processor stri
 // arch can be one of the following values: "amd64", "arm64".
 // os can be one of the following values: "linux", "darwin", "windows", "bookworm", "trixie".
 // processor can be one of the following values: "cpu", "cuda", "metal", "rocm", "vulkan".
-// version should be the desired `b1234` formatted llama.cpp version. You can use the
-// [LlamaLatestVersion] function to obtain the latest release.
+// version should be the desired `b1234` formatted llama.cpp version. If an empty
+// string ("") or "latest" is provided, the latest release will be downloaded,
+// with an automatic fallback to the previous version if the latest is still building.
 // dest in the destination directory for the downloaded binaries.
 func GetWithContext(ctx context.Context, architecture string, operatingSystem string, processor string, version string, dest string, progress getter.ProgressTracker) error {
+	autoVersion := false
+	if version == "" || version == "latest" {
+		autoVersion = true
+		var err error
+		version, err = LlamaLatestVersion()
+		if err != nil {
+			return err
+		}
+	}
+
 	arch, err := ParseArch(architecture)
 	if err != nil {
 		return ErrUnknownArch
@@ -304,7 +369,24 @@ func GetWithContext(ctx context.Context, architecture string, operatingSystem st
 	}
 
 	url := fmt.Sprintf("%s/%s", location, filename)
-	return getFunc(ctx, url, dest, progress)
+	err = getFunc(ctx, url, dest, progress)
+
+	if err != nil && autoVersion && errors.Is(err, ErrFileNotFound) {
+		prevVersion, prevErr := LlamaPreviousVersion()
+		if prevErr != nil {
+			return err
+		}
+
+		location, filename, prevErr = getDownloadLocationAndFilename(arch, os, prcssr, prevVersion, dest)
+		if prevErr != nil {
+			return err
+		}
+
+		url = fmt.Sprintf("%s/%s", location, filename)
+		return getFunc(ctx, url, dest, progress)
+	}
+
+	return err
 }
 
 func get(ctx context.Context, url, dest string, progress getter.ProgressTracker) error {

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -39,9 +40,9 @@ func TestLlamaLatestVersion(t *testing.T) {
 	defer server.Close()
 
 	// Override the version URL for testing
-	originalURL := versionURL
-	versionURL = server.URL + "/llama-cpp-builder/version.json"
-	defer func() { versionURL = originalURL }()
+	originalURL := currentVersionURL
+	currentVersionURL = server.URL + "/llama-cpp-builder/version.json"
+	defer func() { currentVersionURL = originalURL }()
 
 	version, err := LlamaLatestVersion()
 	if err != nil {
@@ -68,9 +69,9 @@ func TestLlamaLatestVersion_Error(t *testing.T) {
 	defer server.Close()
 
 	// Override the version URL for testing
-	originalURL := versionURL
-	versionURL = server.URL + "/llama-cpp-builder/version.json"
-	defer func() { versionURL = originalURL }()
+	originalURL := currentVersionURL
+	currentVersionURL = server.URL + "/llama-cpp-builder/version.json"
+	defer func() { currentVersionURL = originalURL }()
 
 	// Reduce retry count for faster test
 	originalRetryCount := RetryCount
@@ -824,4 +825,70 @@ func TestGet404Error(t *testing.T) {
 	}
 
 	t.Logf("Got expected error: %v", err)
+}
+
+func TestGetWithContext_FallbackToPreviousVersion(t *testing.T) {
+	// Create a mock server to serve versions and mock files
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/llama-cpp-builder/version.json":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"tag_name": "b9000"}`))
+		case "/llama-cpp-builder/previous.json":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"tag_name": "b8999"}`))
+		case "/b9000/llama-b9000-bin-ubuntu-x64.tar.gz":
+			// Simulate a 404 for the latest version
+			w.WriteHeader(http.StatusNotFound)
+		case "/b8999/llama-b8999-bin-ubuntu-x64.tar.gz":
+			// Successfully return the previous version
+			w.Header().Set("Content-Type", "application/gzip")
+			w.Write(createMockTarGz(t, "b8999"))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// Override URLs
+	originalCurrent := currentVersionURL
+	originalPrev := previousVersionURL
+	currentVersionURL = server.URL + "/llama-cpp-builder/version.json"
+	previousVersionURL = server.URL + "/llama-cpp-builder/previous.json"
+	defer func() {
+		currentVersionURL = originalCurrent
+		previousVersionURL = originalPrev
+	}()
+
+	// Override getFunc to use our test server
+	originalGet := getFunc
+	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+		// Mock url rewriting to point to our test server
+		parts := strings.Split(url, "/")
+		filename := parts[len(parts)-1]
+		versionPart := parts[len(parts)-2]
+
+		mockURL := server.URL + "/" + versionPart + "/" + filename
+		err := downloadAndExtractTarGz(mockURL, dest, nil)
+		if err != nil && strings.Contains(err.Error(), "404") {
+			return fmt.Errorf("%w: %s", ErrFileNotFound, url)
+		}
+		return err
+	}
+	defer func() { getFunc = originalGet }()
+
+	dest := t.TempDir()
+
+	// Call GetWithContext with auto version resolve
+	err := GetWithContext(context.Background(), "amd64", "linux", "cpu", "", dest, nil)
+	if err != nil {
+		t.Fatalf("GetWithContext() failed: %v", err)
+	}
+
+	// Verify the downloaded file exist
+	expectedFile := filepath.Join(dest, "libllama.so")
+	if _, err := os.Stat(expectedFile); os.IsNotExist(err) {
+		t.Fatalf("Downloaded file not found: %s", expectedFile)
+	}
 }


### PR DESCRIPTION
- Updates `download.GetWithContext()` to internally resolve the "latest" version and handle a fallback to `LlamaPreviousVersion()` if the latest release gives a 404 error (indicating it's still building).
- Adjusts CLI tools (`cmd/install.go` and `examples/installer/main.go`) to defer the "latest" version resolution to the `pkg/download` module.
- Updates documentation comments and adds test coverage for the fallback logic.