### PR TITLE
addition: limit max outputs of llama_context

### DIFF
--- a/pkg/llama/context.go
+++ b/pkg/llama/context.go
@@ -12,7 +12,7 @@ import (
 var ffiTypeContextParams = ffi.NewType(
 	&ffi.TypeUint32, &ffi.TypeUint32,
 	&ffi.TypeUint32, &ffi.TypeUint32,
-	&ffi.TypeUint32,
+	&ffi.TypeUint32, &ffi.TypeUint32,
 	&ffi.TypeSint32, &ffi.TypeSint32,
 	&ffi.TypeSint32,
 	&ffi.TypeSint32, &ffi.TypeSint32,

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -328,6 +328,7 @@ type ContextParams struct {
 	NUbatch            uint32             // physical maximum batch size
 	NSeqMax            uint32             // max number of sequences
 	NRsSeq             uint32             // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
+	NOutputsMax        uint32             // max outputs in a ubatch (0 = n_batch)
 	NThreads           int32              // number of threads to use for generation
 	NThreadsBatch      int32              // number of threads to use for batch processing
 	CtxType            ContextType        // context type (e.g. MTP)


### PR DESCRIPTION
This adds a new field to the Context to accomodate the new field in llama.cpp from https://github.com/ggml-org/llama.cpp/pull/23861