### PR TITLE
mtmd: update bitmap helpers for llama.cpp PR #23913 placeholder support

### DIFF
--- a/examples/describe/describe.go
+++ b/examples/describe/describe.go
@@ -57,7 +57,7 @@ func describe(tmpFile string) error {
 	output := mtmd.InputChunksInit()
 	input := mtmd.NewInputText(chatTemplate(true), true, true)
 
-	bitmap := mtmd.BitmapInitFromFile(mtmdCtx, tmpFile)
+	bitmap := mtmd.BitmapInitFromFile(mtmdCtx, tmpFile, false)
 	defer mtmd.BitmapFree(bitmap)
 
 	mtmd.Tokenize(mtmdCtx, output, input, []mtmd.Bitmap{bitmap})

--- a/examples/vlm/main.go
+++ b/examples/vlm/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	output := mtmd.InputChunksInit()
 	input := mtmd.NewInputText(chatTemplate(true), true, true)
-	bitmap := mtmd.BitmapInitFromFile(mtmdCtx, *imageFile)
+	bitmap := mtmd.BitmapInitFromFile(mtmdCtx, *imageFile, false)
 	defer mtmd.BitmapFree(bitmap)
 
 	mtmd.Tokenize(mtmdCtx, output, input, []mtmd.Bitmap{bitmap})

--- a/pkg/mtmd/bitmap.go
+++ b/pkg/mtmd/bitmap.go
@@ -67,11 +67,11 @@ func loadBitmapFuncs(lib ffi.Lib) error {
 		return loadError("mtmd_bitmap_get_n_bytes", err)
 	}
 
-	if bitmapInitFromFileFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_file", &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer); err != nil {
+	if bitmapInitFromFileFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_file", &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint8); err != nil {
 		return loadError("mtmd_helper_bitmap_init_from_file", err)
 	}
 
-	if bitmapInitFromBufFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_buf", &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize); err != nil {
+	if bitmapInitFromBufFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_buf", &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize, &ffi.TypeUint8); err != nil {
 		return loadError("mtmd_helper_bitmap_init_from_buf", err)
 	}
 
@@ -134,7 +134,8 @@ func BitmapGetNBytes(bitmap Bitmap) uint64 {
 }
 
 // BitmapInitFromFile initializes a Bitmap from a file.
-func BitmapInitFromFile(ctx Context, fname string) Bitmap {
+// If placeholder is true, the bitmap will have dimensions but no pixel data, suitable for counting tokens without preprocessing.
+func BitmapInitFromFile(ctx Context, fname string, placeholder bool) Bitmap {
 	var bitmap Bitmap
 	if ctx == 0 {
 		return bitmap
@@ -144,19 +145,28 @@ func BitmapInitFromFile(ctx Context, fname string) Bitmap {
 		return bitmap
 	}
 
+	var ph uint8
+	if placeholder {
+		ph = 1
+	}
 	file := &[]byte(fname + "\x00")[0]
-	bitmapInitFromFileFunc.Call(unsafe.Pointer(&bitmap), unsafe.Pointer(&ctx), unsafe.Pointer(&file))
+	bitmapInitFromFileFunc.Call(unsafe.Pointer(&bitmap), unsafe.Pointer(&ctx), unsafe.Pointer(&file), unsafe.Pointer(&ph))
 
 	return bitmap
 }
 
 // BitmapInitFromBuf initializes a Bitmap from a buffer of bytes.
-func BitmapInitFromBuf(ctx Context, buf *byte, len uint64) Bitmap {
+// If placeholder is true, the bitmap will have dimensions but no pixel data, suitable for counting tokens without preprocessing.
+func BitmapInitFromBuf(ctx Context, buf *byte, len uint64, placeholder bool) Bitmap {
 	var bitmap Bitmap
 	if ctx == 0 {
 		return bitmap
 	}
-	bitmapInitFromBufFunc.Call(unsafe.Pointer(&bitmap), unsafe.Pointer(&ctx), unsafe.Pointer(&buf), &len)
+	var ph uint8
+	if placeholder {
+		ph = 1
+	}
+	bitmapInitFromBufFunc.Call(unsafe.Pointer(&bitmap), unsafe.Pointer(&ctx), unsafe.Pointer(&buf), &len, unsafe.Pointer(&ph))
 
 	return bitmap
 }
@@ -234,11 +244,22 @@ func BitmapSetId(bitmap Bitmap, id string) {
 }
 
 // BitmapInitFromAudio initializes a Bitmap from audio data (PCM F32).
+// If data is nil, the bitmap is a placeholder with the given sample count but no audio data,
+// suitable for counting tokens without preprocessing.
 func BitmapInitFromAudio(nSamples uint64, data *float32) Bitmap {
 	var bitmap Bitmap
-	if data == nil {
+	if nSamples == 0 {
 		return bitmap
 	}
 	bitmapInitFromAudioFunc.Call(unsafe.Pointer(&bitmap), &nSamples, unsafe.Pointer(&data))
 	return bitmap
+}
+
+// BitmapIsPlaceholder returns true if the bitmap was created without pixel/audio data.
+// Placeholder bitmaps can be tokenized to count tokens but cannot be encoded for inference.
+func BitmapIsPlaceholder(bitmap Bitmap) bool {
+	if bitmap == 0 {
+		return false
+	}
+	return BitmapGetNBytes(bitmap) == 0
 }

--- a/pkg/mtmd/bitmap_test.go
+++ b/pkg/mtmd/bitmap_test.go
@@ -2,8 +2,11 @@ package mtmd
 
 import (
 	_ "image/jpeg"
+	"os"
 	"testing"
 	"unsafe"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
 )
 
 func TestBitmap(t *testing.T) {
@@ -131,4 +134,265 @@ func TestBitmapInitFromAudio(t *testing.T) {
 	}
 
 	t.Logf("BitmapInitFromAudio created bitmap with %d samples", nSamples)
+}
+
+func TestBitmapInitPlaceholder(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	// BitmapInit with data=0 creates a placeholder bitmap.
+	bitmap := BitmapInit(640, 480, 0)
+	defer BitmapFree(bitmap)
+
+	if bitmap == Bitmap(0) {
+		t.Fatal("BitmapInit returned an invalid bitmap for placeholder")
+	}
+
+	if BitmapGetNx(bitmap) != 640 {
+		t.Fatalf("BitmapGetNx returned unexpected value: %d", BitmapGetNx(bitmap))
+	}
+	if BitmapGetNy(bitmap) != 480 {
+		t.Fatalf("BitmapGetNy returned unexpected value: %d", BitmapGetNy(bitmap))
+	}
+}
+
+func TestBitmapIsPlaceholder(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	// Placeholder bitmap created with nil data.
+	placeholder := BitmapInit(640, 480, 0)
+	defer BitmapFree(placeholder)
+
+	if !BitmapIsPlaceholder(placeholder) {
+		t.Fatal("BitmapIsPlaceholder returned false for a placeholder bitmap")
+	}
+}
+
+func TestBitmapIsPlaceholderForRegularBitmap(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	data, x, y, err := openImageFile("../../images/domestic_llama.jpg")
+	if err != nil {
+		t.Fatal("could not open file")
+	}
+
+	bitmap := BitmapInit(x, y, uintptr(unsafe.Pointer(&data[0])))
+	defer BitmapFree(bitmap)
+
+	if BitmapIsPlaceholder(bitmap) {
+		t.Fatal("BitmapIsPlaceholder returned true for a regular (non-placeholder) bitmap")
+	}
+}
+
+func TestBitmapIsPlaceholderReturnsFalseForZero(t *testing.T) {
+	// No library load needed; BitmapIsPlaceholder short-circuits on zero handle.
+	if BitmapIsPlaceholder(Bitmap(0)) {
+		t.Fatal("BitmapIsPlaceholder should return false for a zero (nil) Bitmap handle")
+	}
+}
+
+func TestBitmapGetNBytesPlaceholder(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	bitmap := BitmapInit(640, 480, 0)
+	defer BitmapFree(bitmap)
+
+	if BitmapGetNBytes(bitmap) != 0 {
+		t.Fatalf("BitmapGetNBytes should return 0 for placeholder, got %d", BitmapGetNBytes(bitmap))
+	}
+}
+
+func TestBitmapGetDataPlaceholder(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	bitmap := BitmapInit(640, 480, 0)
+	defer BitmapFree(bitmap)
+
+	if BitmapGetData(bitmap) != nil {
+		t.Fatal("BitmapGetData should return nil for a placeholder bitmap")
+	}
+}
+
+func TestBitmapInitFromAudioPlaceholder(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	nSamples := uint64(16000)
+	bitmap := BitmapInitFromAudio(nSamples, nil)
+	defer BitmapFree(bitmap)
+
+	if bitmap == Bitmap(0) {
+		t.Fatal("BitmapInitFromAudio returned an invalid bitmap for placeholder")
+	}
+
+	if !BitmapIsAudio(bitmap) {
+		t.Fatal("BitmapIsAudio returned false for audio placeholder bitmap")
+	}
+
+	if !BitmapIsPlaceholder(bitmap) {
+		t.Fatal("BitmapIsPlaceholder returned false for audio placeholder bitmap")
+	}
+
+	if BitmapGetNx(bitmap) != uint32(nSamples) {
+		t.Fatalf("BitmapGetNx returned unexpected value for audio placeholder: %d", BitmapGetNx(bitmap))
+	}
+}
+
+func testSetupMtmdCtx(t *testing.T) (llama.Model, Context) {
+	t.Helper()
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+
+	ctx, err := InitFromFile(mmprojFile, model, ContextParamsDefault())
+	if err != nil {
+		llama.ModelFree(model)
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	return model, ctx
+}
+
+func TestBitmapInitFromFile(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, ctx := testSetupMtmdCtx(t)
+	defer llama.ModelFree(model)
+	defer Free(ctx)
+
+	bitmap := BitmapInitFromFile(ctx, "../../images/domestic_llama.jpg", false)
+	defer BitmapFree(bitmap)
+
+	if bitmap == Bitmap(0) {
+		t.Fatal("BitmapInitFromFile returned an invalid bitmap")
+	}
+
+	if BitmapGetNBytes(bitmap) == 0 {
+		t.Fatal("BitmapInitFromFile returned a bitmap with zero bytes")
+	}
+
+	t.Logf("BitmapInitFromFile created bitmap with %d bytes", BitmapGetNBytes(bitmap))
+}
+
+func TestBitmapInitFromFilePlaceholder(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, ctx := testSetupMtmdCtx(t)
+	defer llama.ModelFree(model)
+	defer Free(ctx)
+
+	bitmap := BitmapInitFromFile(ctx, "../../images/domestic_llama.jpg", true)
+	defer BitmapFree(bitmap)
+
+	if bitmap == Bitmap(0) {
+		t.Fatal("BitmapInitFromFile (placeholder) returned an invalid bitmap")
+	}
+
+	if !BitmapIsPlaceholder(bitmap) {
+		t.Fatal("BitmapIsPlaceholder returned false for a file-loaded placeholder bitmap")
+	}
+
+	if BitmapGetNx(bitmap) == 0 || BitmapGetNy(bitmap) == 0 {
+		t.Fatal("BitmapInitFromFile placeholder has zero dimensions")
+	}
+
+	t.Logf("BitmapInitFromFile placeholder: nx=%d, ny=%d", BitmapGetNx(bitmap), BitmapGetNy(bitmap))
+}
+
+func TestBitmapInitFromFileZeroCtx(t *testing.T) {
+	// BitmapInitFromFile should return a zero Bitmap when ctx is 0.
+	bitmap := BitmapInitFromFile(Context(0), "../../images/domestic_llama.jpg", false)
+	if bitmap != Bitmap(0) {
+		t.Fatal("BitmapInitFromFile should return zero Bitmap for zero context")
+	}
+}
+
+func TestBitmapInitFromFileNonExistent(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, ctx := testSetupMtmdCtx(t)
+	defer llama.ModelFree(model)
+	defer Free(ctx)
+
+	bitmap := BitmapInitFromFile(ctx, "/nonexistent/path/image.jpg", false)
+	if bitmap != Bitmap(0) {
+		BitmapFree(bitmap)
+		t.Fatal("BitmapInitFromFile should return zero Bitmap for non-existent file")
+	}
+}
+
+func TestBitmapInitFromBuf(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, ctx := testSetupMtmdCtx(t)
+	defer llama.ModelFree(model)
+	defer Free(ctx)
+
+	fileBytes, err := os.ReadFile("../../images/domestic_llama.jpg")
+	if err != nil {
+		t.Fatalf("could not read image file: %v", err)
+	}
+
+	bitmap := BitmapInitFromBuf(ctx, &fileBytes[0], uint64(len(fileBytes)), false)
+	defer BitmapFree(bitmap)
+
+	if bitmap == Bitmap(0) {
+		t.Fatal("BitmapInitFromBuf returned an invalid bitmap")
+	}
+
+	if BitmapGetNBytes(bitmap) == 0 {
+		t.Fatal("BitmapInitFromBuf returned a bitmap with zero bytes")
+	}
+
+	t.Logf("BitmapInitFromBuf created bitmap with %d bytes", BitmapGetNBytes(bitmap))
+}
+
+func TestBitmapInitFromBufPlaceholder(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, ctx := testSetupMtmdCtx(t)
+	defer llama.ModelFree(model)
+	defer Free(ctx)
+
+	fileBytes, err := os.ReadFile("../../images/domestic_llama.jpg")
+	if err != nil {
+		t.Fatalf("could not read image file: %v", err)
+	}
+
+	bitmap := BitmapInitFromBuf(ctx, &fileBytes[0], uint64(len(fileBytes)), true)
+	defer BitmapFree(bitmap)
+
+	if bitmap == Bitmap(0) {
+		t.Fatal("BitmapInitFromBuf (placeholder) returned an invalid bitmap")
+	}
+
+	if !BitmapIsPlaceholder(bitmap) {
+		t.Fatal("BitmapIsPlaceholder returned false for a buf-loaded placeholder bitmap")
+	}
+
+	if BitmapGetNx(bitmap) == 0 || BitmapGetNy(bitmap) == 0 {
+		t.Fatal("BitmapInitFromBuf placeholder has zero dimensions")
+	}
+
+	t.Logf("BitmapInitFromBuf placeholder: nx=%d, ny=%d", BitmapGetNx(bitmap), BitmapGetNy(bitmap))
+}
+
+func TestBitmapInitFromBufZeroCtx(t *testing.T) {
+	fileBytes := []byte{0xFF, 0xD8, 0xFF} // minimal JPEG header bytes
+	bitmap := BitmapInitFromBuf(Context(0), &fileBytes[0], uint64(len(fileBytes)), false)
+	if bitmap != Bitmap(0) {
+		t.Fatal("BitmapInitFromBuf should return zero Bitmap for zero context")
+	}
 }


### PR DESCRIPTION
- Add placeholder bool param to BitmapInitFromFile and BitmapInitFromBuf
- Allow nil data in BitmapInitFromAudio to create audio placeholders
- Add BitmapIsPlaceholder helper
- Update examples to pass placeholder=false
- Add unit tests for all new and previously untested bitmap functions