### PR TITLE
context: add new parent context for MTP support added in llama.cpp

### DIFF
--- a/pkg/llama/context.go
+++ b/pkg/llama/context.go
@@ -27,7 +27,8 @@ var ffiTypeContextParams = ffi.NewType(
 	&ffi.TypeUint8, &ffi.TypeUint8,
 	&ffi.TypeUint8, &ffi.TypeUint8,
 	&ffi.TypeUint8, &ffi.TypeUint8,
-	&ffi.TypePointer, &ffi.TypeUint64)
+	&ffi.TypePointer, &ffi.TypeUint64,
+	&ffi.TypePointer)
 
 var (
 	// LLAMA_API struct llama_context_params        llama_context_default_params(void);

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -361,6 +361,10 @@ type ContextParams struct {
 	// note: the samplers must be sampler chains (i.e. use llama_sampler_chain_init)
 	Samplers  uintptr // llama_sampler_seq_config *
 	NSamplers uint64  // number of sampler chains (size_t)
+	// a source/target/parent context
+	// can be utilized in various ways, for example by sharing results or llama_memory between 2 contexts
+	// required for GEMMA4_ASSISTANT (MTP draft model), where ctx_other must be the target context
+	CtxOther Context // llama_context *
 }
 
 // ModelQuantizeParams defines the parameters for model quantize parameters


### PR DESCRIPTION
This PR adds a new field for for parent context for MTP support added in llama.cpp https://github.com/ggml-org/llama.cpp/pull/23398