### PR TITLE
fix(mtmd): resolve file path to absolute before passing to C library

### DIFF
--- a/pkg/mtmd/bitmap.go
+++ b/pkg/mtmd/bitmap.go
@@ -2,6 +2,7 @@ package mtmd
 
 import (
 	"os"
+	"path/filepath"
 	"unsafe"
 
 	"github.com/hybridgroup/yzma/pkg/utils"
@@ -145,12 +146,20 @@ func BitmapInitFromFile(ctx Context, fname string, placeholder bool) Bitmap {
 		return bitmap
 	}
 
+	// Resolve to an absolute, OS-native path so the C library can open it
+	// regardless of path separator style or working-directory assumptions
+	// (critical on Windows where fopen may not handle forward-slash relative paths).
+	absPath, err := filepath.Abs(fname)
+	if err != nil {
+		absPath = fname
+	}
+
 	var ph uint8
 	if placeholder {
 		ph = 1
 	}
-	file := &[]byte(fname + "\x00")[0]
-	bitmapInitFromFileFunc.Call(unsafe.Pointer(&bitmap), unsafe.Pointer(&ctx), unsafe.Pointer(&file), unsafe.Pointer(&ph))
+	filePtr, _ := utils.BytePtrFromString(absPath)
+	bitmapInitFromFileFunc.Call(unsafe.Pointer(&bitmap), unsafe.Pointer(&ctx), unsafe.Pointer(&filePtr), unsafe.Pointer(&ph))
 
 	return bitmap
 }


### PR DESCRIPTION
BitmapInitFromFile now calls filepath.Abs on the caller-supplied path before constructing the C string. This ensures the native path separator and an absolute path are used, fixing a silent failure on Windows where fopen would receive a forward-slash relative path and return NULL with no error message, causing TestBitmapInitFromFile to fail.