### PR TITLE
mtmd: modify Bitmap file helpers to return new BitmapWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Check out the [Model Usage](./MODELS.md) page for more information.
 
 ## Support
 
-`yzma` currently has support for over 96% of `llama.cpp` functionality. See [ROADMAP.md](./ROADMAP.md) for the complete list.
+`yzma` currently has support for over 92% of `llama.cpp` functionality. See [ROADMAP.md](./ROADMAP.md) for the complete list.
 
 You can use multimodal models (image/audio) and text language models with full hardware acceleration on Linux, macOS, and Windows.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-`yzma` currently has support for over 96% of `llama.cpp` functionality.
+`yzma` currently has support for over 92% of `llama.cpp` functionality.
 
 This is a list of all functions exposed by `llama.cpp` and the current state of the associated `yzma` wrapper.
 
@@ -287,5 +287,14 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 
 ### `mtmd` Functions
 
+- [ ] `mtmd_bitmap_init_lazy`
 - [ ] `mtmd_get_cap_from_file`
+- [ ] `mtmd_get_marker`
+- [ ] `mtmd_helper_support_video`
+- [ ] `mtmd_helper_video_free`
+- [ ] `mtmd_helper_video_get_info`
+- [ ] `mtmd_helper_video_init_from_buf`
+- [ ] `mtmd_helper_video_init_params_default`
+- [ ] `mtmd_helper_video_init`
+- [ ] `mtmd_helper_video_read_next`
 - [ ] `mtmd_image_tokens_get_decoder_pos`

--- a/examples/describe/describe.go
+++ b/examples/describe/describe.go
@@ -58,9 +58,9 @@ func describe(tmpFile string) error {
 	input := mtmd.NewInputText(chatTemplate(true), true, true)
 
 	bitmap := mtmd.BitmapInitFromFile(mtmdCtx, tmpFile, false)
-	defer mtmd.BitmapFree(bitmap)
+	defer mtmd.BitmapFree(bitmap.Bitmap)
 
-	mtmd.Tokenize(mtmdCtx, output, input, []mtmd.Bitmap{bitmap})
+	mtmd.Tokenize(mtmdCtx, output, input, []mtmd.Bitmap{bitmap.Bitmap})
 
 	var n llama.Pos
 	mtmd.HelperEvalChunks(mtmdCtx, lctx, output, 0, 0, int32(ctxParams.NBatch), true, &n)

--- a/examples/vlm/main.go
+++ b/examples/vlm/main.go
@@ -97,9 +97,9 @@ func main() {
 	output := mtmd.InputChunksInit()
 	input := mtmd.NewInputText(chatTemplate(true), true, true)
 	bitmap := mtmd.BitmapInitFromFile(mtmdCtx, *imageFile, false)
-	defer mtmd.BitmapFree(bitmap)
+	defer mtmd.BitmapFree(bitmap.Bitmap)
 
-	mtmd.Tokenize(mtmdCtx, output, input, []mtmd.Bitmap{bitmap})
+	mtmd.Tokenize(mtmdCtx, output, input, []mtmd.Bitmap{bitmap.Bitmap})
 
 	var n llama.Pos
 	mtmd.HelperEvalChunks(mtmdCtx, lctx, output, 0, 0, int32(ctxParams.NBatch), true, &n)

--- a/pkg/mtmd/bitmap.go
+++ b/pkg/mtmd/bitmap.go
@@ -10,6 +10,22 @@ import (
 
 // Opaque types (represented as pointers)
 type Bitmap uintptr
+type VideoContext uintptr
+
+//	struct mtmd_helper_bitmap_wrapper {
+//	    mtmd_bitmap * bitmap;
+//	    mtmd_helper_video * video_ctx;
+//	};
+
+type BitmapWrapper struct {
+	Bitmap       Bitmap
+	VideoContext VideoContext
+}
+
+var (
+	// ffiTypeBitmapWrapper represents the C struct mtmd_helper_bitmap_wrapper as an FFI type.
+	ffiTypeBitmapWrapper = ffi.NewType(&ffi.TypePointer, &ffi.TypePointer)
+)
 
 var (
 	// MTMD_API mtmd_bitmap *         mtmd_bitmap_init           (uint32_t nx, uint32_t ny, const unsigned char * data);
@@ -21,10 +37,10 @@ var (
 	// MTMD_API size_t                mtmd_bitmap_get_n_bytes(const mtmd_bitmap * bitmap);
 	bitmapGetNBytesFunc ffi.Fun
 
-	// MTMD_API mtmd_bitmap * mtmd_helper_bitmap_init_from_file(mtmd_context * ctx, const char * fname);
+	// MTMD_API mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_file(mtmd_context * ctx, const char * fname);
 	bitmapInitFromFileFunc ffi.Fun
 
-	// MTMD_API mtmd_bitmap * mtmd_helper_bitmap_init_from_buf(mtmd_context * ctx, const unsigned char * buf, size_t len);
+	// MTMD_API mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_buf(mtmd_context * ctx, const unsigned char * buf, size_t len);
 	bitmapInitFromBufFunc ffi.Fun
 
 	// MTMD_API uint32_t mtmd_bitmap_get_nx(const mtmd_bitmap * bitmap);
@@ -67,11 +83,11 @@ func loadBitmapFuncs(lib ffi.Lib) error {
 		return loadError("mtmd_bitmap_get_n_bytes", err)
 	}
 
-	if bitmapInitFromFileFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_file", &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint8); err != nil {
+	if bitmapInitFromFileFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_file", &ffiTypeBitmapWrapper, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint8); err != nil {
 		return loadError("mtmd_helper_bitmap_init_from_file", err)
 	}
 
-	if bitmapInitFromBufFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_buf", &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize, &ffi.TypeUint8); err != nil {
+	if bitmapInitFromBufFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_buf", &ffiTypeBitmapWrapper, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize, &ffi.TypeUint8); err != nil {
 		return loadError("mtmd_helper_bitmap_init_from_buf", err)
 	}
 
@@ -133,10 +149,10 @@ func BitmapGetNBytes(bitmap Bitmap) uint64 {
 	return uint64(result)
 }
 
-// BitmapInitFromFile initializes a Bitmap from a file.
+// BitmapInitFromFile initializes a BitmapWrapper from a file.
 // If placeholder is true, the bitmap will have dimensions but no pixel data, suitable for counting tokens without preprocessing.
-func BitmapInitFromFile(ctx Context, fname string, placeholder bool) Bitmap {
-	var bitmap Bitmap
+func BitmapInitFromFile(ctx Context, fname string, placeholder bool) BitmapWrapper {
+	var bitmap BitmapWrapper
 	if ctx == 0 {
 		return bitmap
 	}
@@ -155,10 +171,10 @@ func BitmapInitFromFile(ctx Context, fname string, placeholder bool) Bitmap {
 	return bitmap
 }
 
-// BitmapInitFromBuf initializes a Bitmap from a buffer of bytes.
+// BitmapInitFromBuf initializes a BitmapWrapper from a buffer of bytes.
 // If placeholder is true, the bitmap will have dimensions but no pixel data, suitable for counting tokens without preprocessing.
-func BitmapInitFromBuf(ctx Context, buf *byte, len uint64, placeholder bool) Bitmap {
-	var bitmap Bitmap
+func BitmapInitFromBuf(ctx Context, buf *byte, len uint64, placeholder bool) BitmapWrapper {
+	var bitmap BitmapWrapper
 	if ctx == 0 {
 		return bitmap
 	}

--- a/pkg/mtmd/bitmap_test.go
+++ b/pkg/mtmd/bitmap_test.go
@@ -269,17 +269,17 @@ func TestBitmapInitFromFile(t *testing.T) {
 	defer Free(ctx)
 
 	bitmap := BitmapInitFromFile(ctx, "../../images/domestic_llama.jpg", false)
-	defer BitmapFree(bitmap)
+	defer BitmapFree(bitmap.Bitmap)
 
-	if bitmap == Bitmap(0) {
+	if bitmap.Bitmap == Bitmap(0) {
 		t.Fatal("BitmapInitFromFile returned an invalid bitmap")
 	}
 
-	if BitmapGetNBytes(bitmap) == 0 {
+	if BitmapGetNBytes(bitmap.Bitmap) == 0 {
 		t.Fatal("BitmapInitFromFile returned a bitmap with zero bytes")
 	}
 
-	t.Logf("BitmapInitFromFile created bitmap with %d bytes", BitmapGetNBytes(bitmap))
+	t.Logf("BitmapInitFromFile created bitmap with %d bytes", BitmapGetNBytes(bitmap.Bitmap))
 }
 
 func TestBitmapInitFromFilePlaceholder(t *testing.T) {
@@ -291,27 +291,27 @@ func TestBitmapInitFromFilePlaceholder(t *testing.T) {
 	defer Free(ctx)
 
 	bitmap := BitmapInitFromFile(ctx, "../../images/domestic_llama.jpg", true)
-	defer BitmapFree(bitmap)
+	defer BitmapFree(bitmap.Bitmap)
 
-	if bitmap == Bitmap(0) {
+	if bitmap.Bitmap == Bitmap(0) {
 		t.Fatal("BitmapInitFromFile (placeholder) returned an invalid bitmap")
 	}
 
-	if !BitmapIsPlaceholder(bitmap) {
+	if !BitmapIsPlaceholder(bitmap.Bitmap) {
 		t.Fatal("BitmapIsPlaceholder returned false for a file-loaded placeholder bitmap")
 	}
 
-	if BitmapGetNx(bitmap) == 0 || BitmapGetNy(bitmap) == 0 {
+	if BitmapGetNx(bitmap.Bitmap) == 0 || BitmapGetNy(bitmap.Bitmap) == 0 {
 		t.Fatal("BitmapInitFromFile placeholder has zero dimensions")
 	}
 
-	t.Logf("BitmapInitFromFile placeholder: nx=%d, ny=%d", BitmapGetNx(bitmap), BitmapGetNy(bitmap))
+	t.Logf("BitmapInitFromFile placeholder: nx=%d, ny=%d", BitmapGetNx(bitmap.Bitmap), BitmapGetNy(bitmap.Bitmap))
 }
 
 func TestBitmapInitFromFileZeroCtx(t *testing.T) {
 	// BitmapInitFromFile should return a zero Bitmap when ctx is 0.
 	bitmap := BitmapInitFromFile(Context(0), "../../images/domestic_llama.jpg", false)
-	if bitmap != Bitmap(0) {
+	if bitmap.Bitmap != Bitmap(0) {
 		t.Fatal("BitmapInitFromFile should return zero Bitmap for zero context")
 	}
 }
@@ -325,8 +325,8 @@ func TestBitmapInitFromFileNonExistent(t *testing.T) {
 	defer Free(ctx)
 
 	bitmap := BitmapInitFromFile(ctx, "/nonexistent/path/image.jpg", false)
-	if bitmap != Bitmap(0) {
-		BitmapFree(bitmap)
+	if bitmap.Bitmap != Bitmap(0) {
+		BitmapFree(bitmap.Bitmap)
 		t.Fatal("BitmapInitFromFile should return zero Bitmap for non-existent file")
 	}
 }
@@ -345,17 +345,17 @@ func TestBitmapInitFromBuf(t *testing.T) {
 	}
 
 	bitmap := BitmapInitFromBuf(ctx, &fileBytes[0], uint64(len(fileBytes)), false)
-	defer BitmapFree(bitmap)
+	defer BitmapFree(bitmap.Bitmap)
 
-	if bitmap == Bitmap(0) {
+	if bitmap.Bitmap == Bitmap(0) {
 		t.Fatal("BitmapInitFromBuf returned an invalid bitmap")
 	}
 
-	if BitmapGetNBytes(bitmap) == 0 {
+	if BitmapGetNBytes(bitmap.Bitmap) == 0 {
 		t.Fatal("BitmapInitFromBuf returned a bitmap with zero bytes")
 	}
 
-	t.Logf("BitmapInitFromBuf created bitmap with %d bytes", BitmapGetNBytes(bitmap))
+	t.Logf("BitmapInitFromBuf created bitmap with %d bytes", BitmapGetNBytes(bitmap.Bitmap))
 }
 
 func TestBitmapInitFromBufPlaceholder(t *testing.T) {
@@ -372,27 +372,27 @@ func TestBitmapInitFromBufPlaceholder(t *testing.T) {
 	}
 
 	bitmap := BitmapInitFromBuf(ctx, &fileBytes[0], uint64(len(fileBytes)), true)
-	defer BitmapFree(bitmap)
+	defer BitmapFree(bitmap.Bitmap)
 
-	if bitmap == Bitmap(0) {
+	if bitmap.Bitmap == Bitmap(0) {
 		t.Fatal("BitmapInitFromBuf (placeholder) returned an invalid bitmap")
 	}
 
-	if !BitmapIsPlaceholder(bitmap) {
+	if !BitmapIsPlaceholder(bitmap.Bitmap) {
 		t.Fatal("BitmapIsPlaceholder returned false for a buf-loaded placeholder bitmap")
 	}
 
-	if BitmapGetNx(bitmap) == 0 || BitmapGetNy(bitmap) == 0 {
+	if BitmapGetNx(bitmap.Bitmap) == 0 || BitmapGetNy(bitmap.Bitmap) == 0 {
 		t.Fatal("BitmapInitFromBuf placeholder has zero dimensions")
 	}
 
-	t.Logf("BitmapInitFromBuf placeholder: nx=%d, ny=%d", BitmapGetNx(bitmap), BitmapGetNy(bitmap))
+	t.Logf("BitmapInitFromBuf placeholder: nx=%d, ny=%d", BitmapGetNx(bitmap.Bitmap), BitmapGetNy(bitmap.Bitmap))
 }
 
 func TestBitmapInitFromBufZeroCtx(t *testing.T) {
 	fileBytes := []byte{0xFF, 0xD8, 0xFF} // minimal JPEG header bytes
 	bitmap := BitmapInitFromBuf(Context(0), &fileBytes[0], uint64(len(fileBytes)), false)
-	if bitmap != Bitmap(0) {
+	if bitmap.Bitmap != Bitmap(0) {
 		t.Fatal("BitmapInitFromBuf should return zero Bitmap for zero context")
 	}
 }


### PR DESCRIPTION
This PR is to modify Bitmap file helpers to return new BitmapWrapper type added by llama.cpp in the `mtmd` sub-package.