### PR TITLE
mtmd: add BatchMaxTokens for new field added by llama.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Check out the [Model Usage](./MODELS.md) page for more information.
 
 ## Support
 
-`yzma` currently has support for over 92% of `llama.cpp` functionality. See [ROADMAP.md](./ROADMAP.md) for the complete list.
+`yzma` currently has support for over 91% of `llama.cpp` functionality. See [ROADMAP.md](./ROADMAP.md) for the complete list.
 
 You can use multimodal models (image/audio) and text language models with full hardware acceleration on Linux, macOS, and Windows.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-`yzma` currently has support for over 92% of `llama.cpp` functionality.
+`yzma` currently has support for over 91% of `llama.cpp` functionality.
 
 This is a list of all functions exposed by `llama.cpp` and the current state of the associated `yzma` wrapper.
 
@@ -287,6 +287,11 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 
 ### `mtmd` Functions
 
+- [ ] `mtmd_batch_add_chunk`
+- [ ] `mtmd_batch_encode`
+- [ ] `mtmd_batch_free`
+- [ ] `mtmd_batch_get_output_embd`
+- [ ] `mtmd_batch_init`
 - [ ] `mtmd_bitmap_init_lazy`
 - [ ] `mtmd_get_cap_from_file`
 - [ ] `mtmd_get_marker`

--- a/pkg/mtmd/mtmd.go
+++ b/pkg/mtmd/mtmd.go
@@ -43,19 +43,14 @@ type ContextParamsType struct {
 	// callback function passed over to mtmd proper
 	CBEval         uintptr
 	CBEvalUserData uintptr
+	// batching params
+	BatchMaxTokens int32
 }
 
 var (
 	ffiTypeSize = ffi.TypeUint64
 
-	// ffiTypeContextParams represents the C struct mtmd_context_params:
-	//   bool use_gpu, bool print_timings, int n_threads,
-	//   const char * image_marker, const char * media_marker,
-	//   enum llama_flash_attn_type flash_attn_type (int-sized, NOT uint8),
-	//   bool warmup, int image_min_tokens, int image_max_tokens,
-	//   ggml_backend_sched_eval_callback cb_eval, void * cb_eval_user_data
-	// The struct has no size_t field — the trailing ffiTypeSize was wrong and
-	// caused libffi to write 64 bytes into a 56-byte Go variable (heap overrun).
+	// ffiTypeContextParams represents the C struct mtmd_context_params.
 	ffiTypeContextParams = ffi.NewType(
 		&ffi.TypeUint8,   // use_gpu bool
 		&ffi.TypeUint8,   // print_timings bool
@@ -68,6 +63,7 @@ var (
 		&ffi.TypeSint32,  // image_max_tokens int
 		&ffi.TypePointer, // cb_eval callback
 		&ffi.TypePointer, // cb_eval_user_data void*
+		&ffi.TypeSint32,  // batch_max_tokens int
 	)
 
 	// ffiTypeInputText represents the C struct mtmd_input_text

--- a/pkg/vlm/vlm.go
+++ b/pkg/vlm/vlm.go
@@ -121,7 +121,7 @@ func (m *VLM) Results(chunks mtmd.InputChunks) (string, error) {
 	var n llama.Pos
 	nBatch := llama.NBatch(m.ModelContext)
 
-	if res := mtmd.HelperEvalChunks(m.ProjectorContext, m.ModelContext, chunks, 1, 0, int32(nBatch), true, &n); res != 0 {
+	if res := mtmd.HelperEvalChunks(m.ProjectorContext, m.ModelContext, chunks, 0, 0, int32(nBatch), true, &n); res != 0 {
 		return "", errors.New("unable to evaluate chunks")
 	}
 


### PR DESCRIPTION
This PR adds `BatchMaxTokens` to the mtmd Context for new field added by llama.cpp. Needed for upstream compatibility.