### PR TITLE
pkg/mtmd: add ProgressCallback fields missing since llama.cpp b9750

### DIFF
--- a/pkg/mtmd/mtmd.go
+++ b/pkg/mtmd/mtmd.go
@@ -45,6 +45,9 @@ type ContextParamsType struct {
 	CBEvalUserData uintptr
 	// batching params
 	BatchMaxTokens int32
+	// progress callback fired during model load (added in llama.cpp b9750)
+	ProgressCallback         uintptr // mtmd_progress_callback
+	ProgressCallbackUserData uintptr // void *
 }
 
 var (
@@ -64,6 +67,8 @@ var (
 		&ffi.TypePointer, // cb_eval callback
 		&ffi.TypePointer, // cb_eval_user_data void*
 		&ffi.TypeSint32,  // batch_max_tokens int
+		&ffi.TypePointer, // progress_callback (added in llama.cpp b9750)
+		&ffi.TypePointer, // progress_callback_user_data (added in llama.cpp b9750)
 	)
 
 	// ffiTypeInputText represents the C struct mtmd_input_text

--- a/pkg/mtmd/mtmd_test.go
+++ b/pkg/mtmd/mtmd_test.go
@@ -20,6 +20,12 @@ func TestContextParamsDefault(t *testing.T) {
 	if params.Threads <= 0 {
 		t.Fatal("ContextParamsDefault returned invalid thread count")
 	}
+	if params.ProgressCallback != 0 {
+		t.Fatal("ContextParamsDefault returned non-nil ProgressCallback")
+	}
+	if params.ProgressCallbackUserData != 0 {
+		t.Fatal("ContextParamsDefault returned non-nil ProgressCallbackUserData")
+	}
 	t.Logf("ContextParamsDefault returned: %+v", params)
 }
 


### PR DESCRIPTION
ContextParamsType and ffiTypeContextParams were missing the two fields appended to mtmd_context_params in b9750 (progress_callback and progress_callback_user_data), causing a SIGBUS on mtmd_init_from_file.

Fixes #262