### PR TITLE
pkg/llama: add support for llama_model_n_layer_nextn

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,7 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 - [x] `llama_model_n_head_kv`
 - [x] `llama_model_n_head`
 - [x] `llama_model_n_layer`
+- [x] `llama_model_n_layer_nextn`
 - [x] `llama_model_n_params`
 - [x] `llama_model_n_swa`
 - [x] `llama_model_quantize_default_params`

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -77,6 +77,9 @@ var (
 	// LLAMA_API int32_t llama_model_n_layer    (const struct llama_model * model);
 	modelNLayerFunc ffi.Fun
 
+	// LLAMA_API int32_t llama_model_n_layer_nextn(const struct llama_model * model);
+	modelNLayerNextNFunc ffi.Fun
+
 	// LLAMA_API int32_t llama_model_n_head     (const struct llama_model * model);
 	modelNHeadFunc ffi.Fun
 
@@ -214,6 +217,10 @@ func loadModelFuncs(lib ffi.Lib) error {
 
 	if modelNLayerFunc, err = lib.Prep("llama_model_n_layer", &ffi.TypeSint32, &ffi.TypePointer); err != nil {
 		return loadError("llama_model_n_layer", err)
+	}
+
+	if modelNLayerNextNFunc, err = lib.Prep("llama_model_n_layer_nextn", &ffi.TypeSint32, &ffi.TypePointer); err != nil {
+		return loadError("llama_model_n_layer_nextn", err)
 	}
 
 	if modelNHeadFunc, err = lib.Prep("llama_model_n_head", &ffi.TypeSint32, &ffi.TypePointer); err != nil {
@@ -480,6 +487,17 @@ func ModelNLayer(model Model) int32 {
 	}
 	var result ffi.Arg
 	modelNLayerFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&model))
+
+	return int32(result)
+}
+
+// ModelNLayerNextN returns the number of layers in the next-n model.
+func ModelNLayerNextN(model Model) int32 {
+	if model == 0 {
+		return 0
+	}
+	var result ffi.Arg
+	modelNLayerNextNFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&model))
 
 	return int32(result)
 }

--- a/pkg/llama/model_test.go
+++ b/pkg/llama/model_test.go
@@ -107,6 +107,22 @@ func TestModelNLayer(t *testing.T) {
 	}
 }
 
+func TestModelNLayerNextN(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer ModelFree(model)
+
+	nLayerNextN := ModelNLayerNextN(model)
+	t.Logf("ModelNLayerNextN returned: %d", nLayerNextN)
+}
+
 func TestModelNHead(t *testing.T) {
 	modelFile := testModelFileName(t)
 


### PR DESCRIPTION
This PR adds support for the new `llama_model_n_layer_nextn` function that was added to llama.cpp in https://github.com/ggml-org/llama.cpp/pull/24340