### PR TITLE
mtmd: implement SetProgressCallback for ContextParamsType

### DIFF
--- a/pkg/mtmd/mtmd.go
+++ b/pkg/mtmd/mtmd.go
@@ -11,6 +11,11 @@ import (
 	"github.com/jupiterrider/ffi"
 )
 
+// ProgressCallback is an optional callback for multimodal projector loading progress.
+// It is called with a progress value between 0.0 and 1.0.
+// Return false from the callback to abort model loading, or true to continue.
+type ProgressCallback func(progress float32, userData uintptr) bool
+
 //	struct mtmd_input_text {
 //	    const char * text;
 //	    bool add_special;
@@ -224,6 +229,52 @@ func ContextParamsDefault() ContextParamsType {
 	var ctx ContextParamsType
 	contextParamsDefaultFunc.Call(unsafe.Pointer(&ctx))
 	return ctx
+}
+
+var progressCallbackCode unsafe.Pointer
+var progressCallbackCif *ffi.Cif
+var sizeOfClosure = unsafe.Sizeof(ffi.Closure{})
+
+// SetProgressCallback sets a callback that fires during mmproj model loading.
+// The callback receives a progress value in [0.0, 1.0]. Return false to cancel loading.
+// Pass nil to clear a previously set callback.
+func (p *ContextParamsType) SetProgressCallback(cb ProgressCallback) {
+	if cb == nil {
+		p.ProgressCallback = uintptr(0)
+		return
+	}
+
+	closure := ffi.ClosureAlloc(sizeOfClosure, &progressCallbackCode)
+
+	fn := ffi.NewCallback(func(cif *ffi.Cif, ret unsafe.Pointer, args *unsafe.Pointer, userData unsafe.Pointer) uintptr {
+		if args == nil || ret == nil {
+			return 1 // error
+		}
+
+		arg := unsafe.Slice(args, cif.NArgs)
+		progress := *(*float32)(arg[0])
+		userDataPtr := *(*uintptr)(arg[1])
+		result := cb(progress, userDataPtr)
+		if result {
+			*(*uint8)(ret) = 1
+		} else {
+			*(*uint8)(ret) = 0
+		}
+		return 0
+	})
+
+	progressCallbackCif = new(ffi.Cif)
+	if status := ffi.PrepCif(progressCallbackCif, ffi.DefaultAbi, 2, &ffi.TypeUint8, &ffi.TypeFloat, &ffi.TypePointer); status != ffi.OK {
+		panic(status)
+	}
+
+	if closure != nil {
+		if status := ffi.PrepClosureLoc(closure, progressCallbackCif, fn, nil, progressCallbackCode); status != ffi.OK {
+			panic(status)
+		}
+	}
+
+	p.ProgressCallback = uintptr(progressCallbackCode)
 }
 
 // InitFromFile initializes the mtmd context. mmprojFname is a projector file. model is a model that has already been opened.

--- a/pkg/mtmd/mtmd_test.go
+++ b/pkg/mtmd/mtmd_test.go
@@ -29,6 +29,24 @@ func TestContextParamsDefault(t *testing.T) {
 	t.Logf("ContextParamsDefault returned: %+v", params)
 }
 
+func TestSetProgressCallback(t *testing.T) {
+	var params ContextParamsType
+
+	// nil callback should clear the pointer
+	params.SetProgressCallback(nil)
+	if params.ProgressCallback != 0 {
+		t.Fatal("SetProgressCallback(nil) did not clear ProgressCallback")
+	}
+
+	// non-nil callback should set a non-zero pointer
+	params.SetProgressCallback(func(progress float32, userData uintptr) bool {
+		return true
+	})
+	if params.ProgressCallback == 0 {
+		t.Fatal("SetProgressCallback did not set ProgressCallback")
+	}
+}
+
 func TestInitFromFileAndFree(t *testing.T) {
 	modelFile := testModelFileName(t)
 	mmprojFile := testMMProjFileName(t)


### PR DESCRIPTION
Add ProgressCallback type and SetProgressCallback method to the mtmd package, completing the Go binding for the load progress callback introduced in llama.cpp PR #24865.