### PR TITLE
mtmd: add batch API wrappers (llama.cpp PR #24384)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Check out the [Model Usage](./MODELS.md) page for more information.
 
 ## Support
 
-`yzma` currently has support for over 91% of `llama.cpp` functionality. See [ROADMAP.md](./ROADMAP.md) for the complete list.
+`yzma` currently has support for over 96% of `llama.cpp` functionality. See [ROADMAP.md](./ROADMAP.md) for the complete list.
 
 You can use multimodal models (image/audio) and text language models with full hardware acceleration on Linux, macOS, and Windows.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-`yzma` currently has support for over 91% of `llama.cpp` functionality.
+`yzma` currently has support for over 96% of `llama.cpp` functionality.
 
 This is a list of all functions exposed by `llama.cpp` and the current state of the associated `yzma` wrapper.
 
@@ -227,6 +227,11 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 
 Note that these functions are considered by `llama.cpp` to be experimental, and are subject to change.
 
+- [x] `mtmd_batch_add_chunk`
+- [x] `mtmd_batch_encode`
+- [x] `mtmd_batch_free`
+- [x] `mtmd_batch_get_output_embd`
+- [x] `mtmd_batch_init`
 - [x] `mtmd_bitmap_free`
 - [x] `mtmd_bitmap_get_data`
 - [x] `mtmd_bitmap_get_id`
@@ -295,11 +300,6 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 
 ### `mtmd` Functions
 
-- [ ] `mtmd_batch_add_chunk`
-- [ ] `mtmd_batch_encode`
-- [ ] `mtmd_batch_free`
-- [ ] `mtmd_batch_get_output_embd`
-- [ ] `mtmd_batch_init`
 - [ ] `mtmd_bitmap_init_lazy`
 - [ ] `mtmd_get_cap_from_file`
 - [ ] `mtmd_helper_video_read_next`

--- a/pkg/mtmd/batch.go
+++ b/pkg/mtmd/batch.go
@@ -1,0 +1,155 @@
+package mtmd
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"github.com/jupiterrider/ffi"
+)
+
+// Batch is an opaque handle to an mtmd_batch object.
+// It is valid only for the context that created it and cannot be shared across contexts.
+// Chunks added to the batch are not owned by it; they will not be freed when the batch is freed.
+type Batch uintptr
+
+// BatchAddResult is the return code from BatchAddChunk.
+type BatchAddResult int32
+
+const (
+	// BatchAddSuccess indicates the chunk was added to the batch successfully.
+	BatchAddSuccess BatchAddResult = 0
+	// BatchAddError indicates a generic error while adding the chunk.
+	BatchAddError BatchAddResult = 1
+	// BatchAddTooLarge indicates the batch is already full; the chunk was not added.
+	BatchAddTooLarge BatchAddResult = 2
+	// BatchAddIncompatible indicates the chunk cannot be batched with the existing chunks.
+	BatchAddIncompatible BatchAddResult = 3
+)
+
+var (
+	// MTMD_API mtmd_batch * mtmd_batch_init(mtmd_context * ctx);
+	batchInitFunc ffi.Fun
+
+	// MTMD_API void mtmd_batch_free(mtmd_batch * batch);
+	batchFreeFunc ffi.Fun
+
+	// MTMD_API int32_t mtmd_batch_add_chunk(mtmd_batch * batch, const mtmd_input_chunk * chunk);
+	// returns 0 on success
+	// returns 1 on generic error
+	// returns 2 if the batch is too large (chunk won't be added)
+	// returns 3 if it cannot be batched with the existing chunks in the batch
+	batchAddChunkFunc ffi.Fun
+
+	// MTMD_API int32_t mtmd_batch_encode(mtmd_batch * batch);
+	// returns 0 on success
+	// returns 1 on generic error
+	batchEncodeFunc ffi.Fun
+
+	// MTMD_API float * mtmd_batch_get_output_embd(mtmd_batch * batch, const mtmd_input_chunk * chunk);
+	batchGetOutputEmbdFunc ffi.Fun
+)
+
+func loadBatchFuncs(lib ffi.Lib) error {
+	var err error
+
+	if batchInitFunc, err = lib.Prep("mtmd_batch_init", &ffi.TypePointer, &ffi.TypePointer); err != nil {
+		return loadError("mtmd_batch_init", err)
+	}
+
+	if batchFreeFunc, err = lib.Prep("mtmd_batch_free", &ffi.TypeVoid, &ffi.TypePointer); err != nil {
+		return loadError("mtmd_batch_free", err)
+	}
+
+	if batchAddChunkFunc, err = lib.Prep("mtmd_batch_add_chunk", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer); err != nil {
+		return loadError("mtmd_batch_add_chunk", err)
+	}
+
+	if batchEncodeFunc, err = lib.Prep("mtmd_batch_encode", &ffi.TypeSint32, &ffi.TypePointer); err != nil {
+		return loadError("mtmd_batch_encode", err)
+	}
+
+	if batchGetOutputEmbdFunc, err = lib.Prep("mtmd_batch_get_output_embd", &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer); err != nil {
+		return loadError("mtmd_batch_get_output_embd", err)
+	}
+
+	return nil
+}
+
+// BatchInit creates a new Batch object for the given context.
+// The batch is valid only for the given context.
+// Call BatchFree when done.
+func BatchInit(ctx Context) (Batch, error) {
+	if ctx == 0 {
+		return 0, errors.New("invalid mtmd context handle")
+	}
+	var batch Batch
+	batchInitFunc.Call(unsafe.Pointer(&batch), unsafe.Pointer(&ctx))
+	if batch == 0 {
+		return 0, errors.New("mtmd_batch_init returned null")
+	}
+	return batch, nil
+}
+
+// BatchFree frees a Batch object previously created by BatchInit.
+// Chunks added to the batch are not freed; only the batch container itself is freed.
+func BatchFree(batch Batch) {
+	if batch == 0 {
+		return
+	}
+	batchFreeFunc.Call(nil, unsafe.Pointer(&batch))
+}
+
+// BatchAddChunk attempts to add a media chunk to the batch.
+// Only media chunks (image/audio) are accepted; text chunks will be rejected with BatchAddError.
+// The chunk is not owned by the batch and must outlive the batch encode call.
+//
+// Return values:
+//
+//	BatchAddSuccess      – chunk was added
+//	BatchAddError        – generic error (e.g. text chunk passed)
+//	BatchAddTooLarge     – batch is full; chunk was not added
+//	BatchAddIncompatible – chunk cannot be batched with existing chunks (e.g. different size)
+func BatchAddChunk(batch Batch, chunk InputChunk) BatchAddResult {
+	if batch == 0 || chunk == 0 {
+		return BatchAddError
+	}
+	var result ffi.Arg
+	batchAddChunkFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&batch), unsafe.Pointer(&chunk))
+	return BatchAddResult(result)
+}
+
+// BatchEncode runs the encoder on all chunks currently in the batch.
+// Returns nil on success, or an error if encoding fails.
+func BatchEncode(batch Batch) error {
+	if batch == 0 {
+		return errors.New("invalid batch handle")
+	}
+	var result ffi.Arg
+	batchEncodeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&batch))
+	if int32(result) != 0 {
+		return fmt.Errorf("mtmd_batch_encode failed: %d", result)
+	}
+	return nil
+}
+
+// BatchGetOutputEmbd returns the output embeddings for a specific chunk after a BatchEncode call.
+// embedSize must be:
+//
+//	llama.ModelNEmbdInp(model) * int32(InputChunkGetNTokens(chunk))
+//
+// The returned slice is valid until the next encode call or BatchFree.
+func BatchGetOutputEmbd(batch Batch, chunk InputChunk, embedSize int32) ([]float32, error) {
+	if batch == 0 {
+		return nil, errors.New("invalid batch handle")
+	}
+	if chunk == 0 {
+		return nil, errors.New("invalid chunk handle")
+	}
+	var embdPtr unsafe.Pointer
+	batchGetOutputEmbdFunc.Call(unsafe.Pointer(&embdPtr), unsafe.Pointer(&batch), unsafe.Pointer(&chunk))
+	if embdPtr == nil {
+		return nil, errors.New("mtmd_batch_get_output_embd returned null pointer")
+	}
+	return unsafe.Slice((*float32)(embdPtr), embedSize), nil
+}

--- a/pkg/mtmd/batch_test.go
+++ b/pkg/mtmd/batch_test.go
@@ -1,0 +1,508 @@
+package mtmd
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+func TestBatchInitAndFree(t *testing.T) {
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer llama.ModelFree(model)
+
+	params := ContextParamsDefault()
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	defer Free(ctx)
+
+	batch, err := BatchInit(ctx)
+	if err != nil {
+		t.Fatalf("BatchInit failed: %v", err)
+	}
+	if batch == 0 {
+		t.Fatal("BatchInit returned an invalid batch handle")
+	}
+
+	t.Log("BatchInit successfully created a batch")
+
+	BatchFree(batch)
+	t.Log("BatchFree successfully freed the batch")
+}
+
+func TestBatchInitInvalidContext(t *testing.T) {
+	_, err := BatchInit(0)
+	if err == nil {
+		t.Fatal("BatchInit with zero context should return an error")
+	}
+}
+
+func TestBatchFreeZeroBatch(t *testing.T) {
+	// BatchFree with a zero handle should not panic
+	BatchFree(0)
+}
+
+func TestBatchAddChunk(t *testing.T) {
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer llama.ModelFree(model)
+
+	params := ContextParamsDefault()
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	defer Free(ctx)
+
+	chunks := InputChunksInit()
+	defer InputChunksFree(chunks)
+
+	testSetupChunks(t, ctx, chunks)
+
+	batch, err := BatchInit(ctx)
+	if err != nil {
+		t.Fatalf("BatchInit failed: %v", err)
+	}
+	defer BatchFree(batch)
+
+	// Find the image chunk (index 1 is the media chunk from testSetupChunks)
+	var imageChunk InputChunk
+	for i := uint64(0); i < InputChunksSize(chunks); i++ {
+		c := InputChunksGet(chunks, i)
+		if InputChunkGetType(c) == InputChunkTypeImage {
+			imageChunk = c
+			break
+		}
+	}
+	if imageChunk == 0 {
+		t.Fatal("no image chunk found in tokenized output")
+	}
+
+	result := BatchAddChunk(batch, imageChunk)
+	if result != BatchAddSuccess {
+		t.Fatalf("BatchAddChunk failed with result: %d", result)
+	}
+
+	t.Log("BatchAddChunk successfully added the image chunk")
+}
+
+func TestBatchAddChunkInvalidHandles(t *testing.T) {
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer llama.ModelFree(model)
+
+	params := ContextParamsDefault()
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	defer Free(ctx)
+
+	batch, err := BatchInit(ctx)
+	if err != nil {
+		t.Fatalf("BatchInit failed: %v", err)
+	}
+	defer BatchFree(batch)
+
+	// Zero chunk should return error
+	if BatchAddChunk(batch, 0) != BatchAddError {
+		t.Fatal("BatchAddChunk with zero chunk should return BatchAddError")
+	}
+
+	// Zero batch should return error
+	chunks := InputChunksInit()
+	defer InputChunksFree(chunks)
+	testSetupChunks(t, ctx, chunks)
+
+	for i := uint64(0); i < InputChunksSize(chunks); i++ {
+		c := InputChunksGet(chunks, i)
+		if InputChunkGetType(c) == InputChunkTypeImage {
+			if BatchAddChunk(0, c) != BatchAddError {
+				t.Fatal("BatchAddChunk with zero batch should return BatchAddError")
+			}
+			break
+		}
+	}
+}
+
+func TestBatchAddChunkTextChunkRejected(t *testing.T) {
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer llama.ModelFree(model)
+
+	params := ContextParamsDefault()
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	defer Free(ctx)
+
+	chunks := InputChunksInit()
+	defer InputChunksFree(chunks)
+
+	testSetupChunks(t, ctx, chunks)
+
+	batch, err := BatchInit(ctx)
+	if err != nil {
+		t.Fatalf("BatchInit failed: %v", err)
+	}
+	defer BatchFree(batch)
+
+	// Text chunks must be rejected (result != BatchAddSuccess)
+	for i := uint64(0); i < InputChunksSize(chunks); i++ {
+		c := InputChunksGet(chunks, i)
+		if InputChunkGetType(c) == InputChunkTypeText {
+			result := BatchAddChunk(batch, c)
+			if result == BatchAddSuccess {
+				t.Fatal("BatchAddChunk should reject text chunks")
+			}
+			t.Logf("BatchAddChunk correctly rejected text chunk with result: %d", result)
+			return
+		}
+	}
+	t.Skip("no text chunk found to test rejection")
+}
+
+func TestBatchEncode(t *testing.T) {
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer llama.ModelFree(model)
+
+	params := ContextParamsDefault()
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	defer Free(ctx)
+
+	chunks := InputChunksInit()
+	defer InputChunksFree(chunks)
+
+	testSetupChunks(t, ctx, chunks)
+
+	batch, err := BatchInit(ctx)
+	if err != nil {
+		t.Fatalf("BatchInit failed: %v", err)
+	}
+	defer BatchFree(batch)
+
+	var imageChunk InputChunk
+	for i := uint64(0); i < InputChunksSize(chunks); i++ {
+		c := InputChunksGet(chunks, i)
+		if InputChunkGetType(c) == InputChunkTypeImage {
+			imageChunk = c
+			break
+		}
+	}
+	if imageChunk == 0 {
+		t.Fatal("no image chunk found in tokenized output")
+	}
+
+	if result := BatchAddChunk(batch, imageChunk); result != BatchAddSuccess {
+		t.Fatalf("BatchAddChunk failed with result: %d", result)
+	}
+
+	if err := BatchEncode(batch); err != nil {
+		t.Fatalf("BatchEncode failed: %v", err)
+	}
+
+	t.Log("BatchEncode successfully encoded the batch")
+}
+
+func TestBatchEncodeInvalidHandle(t *testing.T) {
+	if err := BatchEncode(0); err == nil {
+		t.Fatal("BatchEncode with zero batch should return an error")
+	}
+}
+
+func TestBatchGetOutputEmbd(t *testing.T) {
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer llama.ModelFree(model)
+
+	params := ContextParamsDefault()
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	defer Free(ctx)
+
+	chunks := InputChunksInit()
+	defer InputChunksFree(chunks)
+
+	testSetupChunks(t, ctx, chunks)
+
+	batch, err := BatchInit(ctx)
+	if err != nil {
+		t.Fatalf("BatchInit failed: %v", err)
+	}
+	defer BatchFree(batch)
+
+	var imageChunk InputChunk
+	for i := uint64(0); i < InputChunksSize(chunks); i++ {
+		c := InputChunksGet(chunks, i)
+		if InputChunkGetType(c) == InputChunkTypeImage {
+			imageChunk = c
+			break
+		}
+	}
+	if imageChunk == 0 {
+		t.Fatal("no image chunk found in tokenized output")
+	}
+
+	if result := BatchAddChunk(batch, imageChunk); result != BatchAddSuccess {
+		t.Fatalf("BatchAddChunk failed with result: %d", result)
+	}
+
+	if err := BatchEncode(batch); err != nil {
+		t.Fatalf("BatchEncode failed: %v", err)
+	}
+
+	sz := llama.ModelNEmbdInp(model) * int32(InputChunkGetNTokens(imageChunk))
+	if sz <= 0 {
+		t.Fatal("calculated embedding size is invalid")
+	}
+
+	embd, err := BatchGetOutputEmbd(batch, imageChunk, sz)
+	if err != nil {
+		t.Fatalf("BatchGetOutputEmbd failed: %v", err)
+	}
+	if len(embd) == 0 {
+		t.Fatal("BatchGetOutputEmbd returned an empty slice")
+	}
+
+	t.Logf("BatchGetOutputEmbd returned embeddings of length: %d", len(embd))
+}
+
+func TestBatchGetOutputEmbdInvalidHandles(t *testing.T) {
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer llama.ModelFree(model)
+
+	params := ContextParamsDefault()
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	defer Free(ctx)
+
+	chunks := InputChunksInit()
+	defer InputChunksFree(chunks)
+
+	testSetupChunks(t, ctx, chunks)
+
+	var imageChunk InputChunk
+	for i := uint64(0); i < InputChunksSize(chunks); i++ {
+		c := InputChunksGet(chunks, i)
+		if InputChunkGetType(c) == InputChunkTypeImage {
+			imageChunk = c
+			break
+		}
+	}
+	if imageChunk == 0 {
+		t.Fatal("no image chunk found in tokenized output")
+	}
+
+	batch, err := BatchInit(ctx)
+	if err != nil {
+		t.Fatalf("BatchInit failed: %v", err)
+	}
+	defer BatchFree(batch)
+
+	// Zero batch handle
+	if _, err := BatchGetOutputEmbd(0, imageChunk, 1); err == nil {
+		t.Fatal("BatchGetOutputEmbd with zero batch should return an error")
+	}
+
+	// Zero chunk handle
+	if _, err := BatchGetOutputEmbd(batch, 0, 1); err == nil {
+		t.Fatal("BatchGetOutputEmbd with zero chunk should return an error")
+	}
+}
+
+func TestBatchAddResultConstants(t *testing.T) {
+	// Verify the constant values match the C API contract
+	if BatchAddSuccess != 0 {
+		t.Fatalf("BatchAddSuccess expected 0, got %d", BatchAddSuccess)
+	}
+	if BatchAddError != 1 {
+		t.Fatalf("BatchAddError expected 1, got %d", BatchAddError)
+	}
+	if BatchAddTooLarge != 2 {
+		t.Fatalf("BatchAddTooLarge expected 2, got %d", BatchAddTooLarge)
+	}
+	if BatchAddIncompatible != 3 {
+		t.Fatalf("BatchAddIncompatible expected 3, got %d", BatchAddIncompatible)
+	}
+}
+
+func TestBatchEncodeMultipleChunks(t *testing.T) {
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer llama.ModelFree(model)
+
+	params := ContextParamsDefault()
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	defer Free(ctx)
+
+	// Tokenize the same image twice to get two identical image chunks
+	data, x, y, err := openImageFile("../../images/domestic_llama.jpg")
+	if err != nil {
+		t.Fatal("could not open image file")
+	}
+
+	bitmap1 := BitmapInit(x, y, uintptr(unsafe.Pointer(&data[0])))
+	defer BitmapFree(bitmap1)
+	bitmap2 := BitmapInit(x, y, uintptr(unsafe.Pointer(&data[0])))
+	defer BitmapFree(bitmap2)
+
+	chunks1 := InputChunksInit()
+	defer InputChunksFree(chunks1)
+	text1 := NewInputText("First image: <__media__>", true, true)
+	if Tokenize(ctx, chunks1, text1, []Bitmap{bitmap1}) != 0 {
+		t.Fatal("Tokenize failed for first image")
+	}
+
+	chunks2 := InputChunksInit()
+	defer InputChunksFree(chunks2)
+	text2 := NewInputText("Second image: <__media__>", false, false)
+	if Tokenize(ctx, chunks2, text2, []Bitmap{bitmap2}) != 0 {
+		t.Fatal("Tokenize failed for second image")
+	}
+
+	var imgChunk1, imgChunk2 InputChunk
+	for i := uint64(0); i < InputChunksSize(chunks1); i++ {
+		c := InputChunksGet(chunks1, i)
+		if InputChunkGetType(c) == InputChunkTypeImage {
+			imgChunk1 = c
+			break
+		}
+	}
+	for i := uint64(0); i < InputChunksSize(chunks2); i++ {
+		c := InputChunksGet(chunks2, i)
+		if InputChunkGetType(c) == InputChunkTypeImage {
+			imgChunk2 = c
+			break
+		}
+	}
+	if imgChunk1 == 0 || imgChunk2 == 0 {
+		t.Fatal("could not find image chunks")
+	}
+
+	batch, err := BatchInit(ctx)
+	if err != nil {
+		t.Fatalf("BatchInit failed: %v", err)
+	}
+	defer BatchFree(batch)
+
+	// Add both same-size image chunks; same-size images should be batchable
+	r1 := BatchAddChunk(batch, imgChunk1)
+	if r1 != BatchAddSuccess {
+		t.Fatalf("BatchAddChunk for first chunk failed with result: %d", r1)
+	}
+
+	r2 := BatchAddChunk(batch, imgChunk2)
+	switch r2 {
+	case BatchAddSuccess:
+		t.Log("both chunks added to batch; encoding together")
+		if err := BatchEncode(batch); err != nil {
+			t.Fatalf("BatchEncode failed: %v", err)
+		}
+		sz1 := llama.ModelNEmbdInp(model) * int32(InputChunkGetNTokens(imgChunk1))
+		embd1, err := BatchGetOutputEmbd(batch, imgChunk1, sz1)
+		if err != nil {
+			t.Fatalf("BatchGetOutputEmbd for chunk1 failed: %v", err)
+		}
+		sz2 := llama.ModelNEmbdInp(model) * int32(InputChunkGetNTokens(imgChunk2))
+		embd2, err := BatchGetOutputEmbd(batch, imgChunk2, sz2)
+		if err != nil {
+			t.Fatalf("BatchGetOutputEmbd for chunk2 failed: %v", err)
+		}
+		t.Logf("encoded 2 chunks in one batch; embd1 len=%d embd2 len=%d", len(embd1), len(embd2))
+
+	case BatchAddTooLarge:
+		t.Log("second chunk not added: batch too large (batch_max_tokens limit); encoding first chunk only")
+		if err := BatchEncode(batch); err != nil {
+			t.Fatalf("BatchEncode failed: %v", err)
+		}
+
+	case BatchAddIncompatible:
+		t.Log("second chunk not added: incompatible with existing chunks; encoding first chunk only")
+		if err := BatchEncode(batch); err != nil {
+			t.Fatalf("BatchEncode failed: %v", err)
+		}
+
+	default:
+		t.Fatalf("BatchAddChunk for second chunk returned unexpected result: %d", r2)
+	}
+}

--- a/pkg/mtmd/loader.go
+++ b/pkg/mtmd/loader.go
@@ -32,6 +32,10 @@ func Load(path string) error {
 		return err
 	}
 
+	if err := loadBatchFuncs(lib); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Add Go bindings for the five new mtmd batch functions introduced in llama.cpp PR #24384:

- mtmd_batch_init / mtmd_batch_free
- mtmd_batch_add_chunk (with BatchAddResult constants)
- mtmd_batch_encode
- mtmd_batch_get_output_embd