### PR TITLE
switched to use CUDA 13.3 for Windows llama.cpp

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -269,12 +269,12 @@ func getDownloadLocationAndFilename(arch Arch, os OS, prcssr Processor, version 
 				return "", "", errors.New("precompiled binaries for Windows ARM64 CUDA are not available")
 			}
 			// also requires the CUDA RT files
-			cudart := "cudart-llama-bin-win-cuda-13.1-x64.zip"
+			cudart := "cudart-llama-bin-win-cuda-13.3-x64.zip"
 			url := fmt.Sprintf("%s/%s", location, cudart)
 			if err := get(context.Background(), url, dest, ProgressTracker); err != nil {
 				return "", "", err
 			}
-			filename = fmt.Sprintf("llama-%s-bin-win-cuda-13.1-x64.zip", version)
+			filename = fmt.Sprintf("llama-%s-bin-win-cuda-13.3-x64.zip", version)
 		case Vulkan:
 			if arch == ARM64 {
 				return "", "", errors.New("precompiled binaries for Windows ARM64 Vulkan are not available")


### PR DESCRIPTION
llama.cpp stopped shipping the cuda-13.1 Windows variant around b9500;
current releases only offer 12.4 and 13.3. Requesting 13.1 always 404s
and drops the host into degraded mode. This switches the Windows/CUDA
downloader to the available 13.3 build.

Fixes #272 