### PR TITLE
pkg/llama: refactor mmap/mlock/directio into load_mode enum

### DIFF
--- a/pkg/llama/backend.go
+++ b/pkg/llama/backend.go
@@ -47,6 +47,12 @@ var (
 
 	// LLAMA_API const char * llama_print_system_info(void);
 	printSystemInfoFunc ffi.Fun
+
+	// LLAMA_API const char * llama_load_mode_name(enum llama_load_mode load_mode);
+	loadModeNameFunc ffi.Fun
+
+	// LLAMA_API enum llama_load_mode llama_load_mode_from_str(const char * str);
+	loadModeFromStrFunc ffi.Fun
 )
 
 func loadBackendFuncs(lib ffi.Lib) error {
@@ -105,6 +111,14 @@ func loadBackendFuncs(lib ffi.Lib) error {
 
 	if printSystemInfoFunc, err = lib.Prep("llama_print_system_info", &ffi.TypePointer); err != nil {
 		return loadError("llama_print_system_info", err)
+	}
+
+	if loadModeNameFunc, err = lib.Prep("llama_load_mode_name", &ffi.TypePointer, &ffi.TypeSint32); err != nil {
+		return loadError("llama_load_mode_name", err)
+	}
+
+	if loadModeFromStrFunc, err = lib.Prep("llama_load_mode_from_str", &ffi.TypeSint32, &ffi.TypePointer); err != nil {
+		return loadError("llama_load_mode_from_str", err)
 	}
 
 	return nil
@@ -179,6 +193,26 @@ func TimeUs() int64 {
 	var result ffi.Arg
 	timeUsFunc.Call(unsafe.Pointer(&result))
 	return int64(result)
+}
+
+// LoadModeName returns the name for a given load mode.
+func LoadModeName(loadMode LoadMode) string {
+	var result *byte
+	loadModeNameFunc.Call(unsafe.Pointer(&result), &loadMode)
+
+	if result == nil {
+		return ""
+	}
+
+	return utils.BytePtrToString(result)
+}
+
+// LoadModeFromStr returns the load mode for a given string.
+func LoadModeFromStr(str string) LoadMode {
+	var result LoadMode
+	s, _ := utils.BytePtrFromString(str)
+	loadModeFromStrFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&s))
+	return result
 }
 
 // FlashAttnTypeName returns the name for a given flash attention type.

--- a/pkg/llama/backend_test.go
+++ b/pkg/llama/backend_test.go
@@ -91,6 +91,48 @@ func TestFlashAttnTypeName(t *testing.T) {
 	t.Logf("FlashAttnTypeName returned: %s", name)
 }
 
+func TestLoadModeName(t *testing.T) {
+	testSetup(t)
+
+	tests := []struct {
+		mode LoadMode
+		want string
+	}{
+		{LoadModeNone, "none"},
+		{LoadModeMmap, "mmap"},
+		{LoadModeMlock, "mlock"},
+		{LoadModeDirectIO, "dio"},
+	}
+
+	for _, tc := range tests {
+		name := LoadModeName(tc.mode)
+		if name != tc.want {
+			t.Errorf("LoadModeName(%d) = %q, want %q", tc.mode, name, tc.want)
+		}
+	}
+}
+
+func TestLoadModeFromStr(t *testing.T) {
+	testSetup(t)
+
+	tests := []struct {
+		str  string
+		want LoadMode
+	}{
+		{"none", LoadModeNone},
+		{"mmap", LoadModeMmap},
+		{"mlock", LoadModeMlock},
+		{"dio", LoadModeDirectIO},
+	}
+
+	for _, tc := range tests {
+		mode := LoadModeFromStr(tc.str)
+		if mode != tc.want {
+			t.Errorf("LoadModeFromStr(%q) = %d, want %d", tc.str, mode, tc.want)
+		}
+	}
+}
+
 func TestFtypeName(t *testing.T) {
 	testSetup(t)
 	var ftype Ftype = FtypeMostlyQ1_0

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -173,6 +173,15 @@ const (
 	SplitModeRow   SplitMode = 2 // split layers and KV across GPUs, use tensor parallelism if supported
 )
 
+type LoadMode int32
+
+const (
+	LoadModeNone     LoadMode = 0 // no special loading mode
+	LoadModeMmap     LoadMode = 1 // memory map the model
+	LoadModeMlock    LoadMode = 2 // mmap + force system to keep model in RAM rather than swapping or compressing
+	LoadModeDirectIO LoadMode = 3 // use direct I/O if available
+)
+
 type GpuBackend int32
 
 const (
@@ -301,15 +310,13 @@ type ModelParams struct {
 	TensorBuftOverrides      uintptr   // const struct llama_model_tensor_buft_override *
 	NGpuLayers               int32     // number of layers to store in VRAM
 	SplitMode                SplitMode // how to split the model across multiple GPUs
+	LoadMode                 LoadMode  // how to load the model
 	MainGpu                  int32     // the GPU that is used for the entire model
 	TensorSplit              *float32  // proportion of the model to offload to each GPU
 	ProgressCallback         uintptr   // llama_progress_callback function pointer
 	ProgressCallbackUserData uintptr   // context pointer passed to the progress callback
 	KvOverrides              uintptr   // const struct llama_model_kv_override *
 	VocabOnly                uint8     // only load the vocabulary, no weights (bool as uint8)
-	UseMmap                  uint8     // use mmap if possible (bool as uint8)
-	UseDirectIO              uint8     // use direct I/O, takes precedence over use_mmap (bool as uint8)
-	UseMlock                 uint8     // force system to keep model in RAM (bool as uint8)
 	CheckTensors             uint8     // validate model tensor data (bool as uint8)
 	UseExtraBufts            uint8     // use extra buffer types (bool as uint8)
 	NoHost                   uint8     // bypass host buffer allowing extra buffers to be used (bool as uint8)

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -14,9 +14,9 @@ var (
 
 	// ffiTypeModelParams represents the C struct llama_model_params
 	ffiTypeModelParams = ffi.NewType(&ffi.TypePointer, &ffi.TypePointer, &ffi.TypeSint32,
-		&ffi.TypeSint32, &ffi.TypeSint32,
+		&ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypeSint32,
 		&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer,
-		&ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8,
+		&ffi.TypeUint8, &ffi.TypeUint8,
 		&ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8)
 
 	// ffiTypeModelQuantizeParams represents the C struct llama_model_quantize_params

--- a/pkg/llama/testmain_test.go
+++ b/pkg/llama/testmain_test.go
@@ -47,7 +47,7 @@ func benchmarkSetupOnce(b *testing.B) {
 	benchmarkSetup(b)
 
 	mparams := ModelDefaultParams()
-	mparams.UseMmap = 0
+	mparams.LoadMode = LoadModeNone
 
 	if device != "" {
 		devs := []GGMLBackendDevice{}

--- a/pkg/mtmd/testmain_test.go
+++ b/pkg/mtmd/testmain_test.go
@@ -63,7 +63,7 @@ func benchmarkSetupOnce(b *testing.B) {
 	benchmarkSetup(b)
 
 	mparams := llama.ModelDefaultParams()
-	mparams.UseMmap = 0
+	mparams.LoadMode = llama.LoadModeNone
 
 	if device != "" {
 		devs := []llama.GGMLBackendDevice{}


### PR DESCRIPTION
Update llama_model_params to replace use_mmap, use_direct_io, and use_mlock booleans with a single load_mode enum, matching the upstream llama.cpp change (ggml-org/llama.cpp#20834).

Add Go bindings for llama_load_mode_name and llama_load_mode_from_str with test coverage.