### PR TITLE
download: add a Resolver interface for choosing release assets

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -323,3 +323,49 @@ set YZMA_LIB=C:\yzma\lib
 Want to use Go code to install the `llama.cpp` precompiled binaries from within your own application? We have the `download` package for that!
 
 Check out the [installer example code](./examples/installer/).
+
+### Choosing which build to install
+
+`download.Install` takes a `Target` and an optional `Resolver`. Passing `nil` uses the
+built-in table, which is what `Get` does:
+
+```go
+target := download.Target{
+	Arch:      download.MustParseArch(runtime.GOARCH),
+	OS:        download.MustParseOS(runtime.GOOS),
+	Processor: download.CUDA,
+	Version:   "latest",
+}
+
+err := download.Install(context.Background(), target, libPath, download.ProgressTracker, nil)
+```
+
+A `Resolver` reports the assets to install for a target, as URLs downloaded in the order
+returned. Implement one to install a build the table doesn't name — from an internal
+mirror or artifact server, from a `file://` path on an air-gapped machine, from your own
+llama.cpp build, or a different CUDA major version than the default:
+
+```go
+resolver := download.ResolverFunc(func(t download.Target) ([]string, error) {
+	if t.OS == download.Linux && t.Arch == download.AMD64 && t.Processor == download.CUDA {
+		return []string{"https://mirror.example.com/llama/" + t.Version + "-cuda12-x64.tar.gz"}, nil
+	}
+	// Anything you don't care about falls through to the built-in table.
+	return download.DefaultResolver.Resolve(t)
+})
+
+err := download.Install(context.Background(), target, libPath, download.ProgressTracker, resolver)
+```
+
+Notes:
+
+- Return several URLs when a build needs more than one archive; they install in order, so
+  put a dependency (such as a CUDA runtime archive) before the libraries that need it.
+- Resolvers must not download anything themselves — return URLs and let `Install` fetch
+  them, so `.tar.gz` and `.zip` archives are unpacked the same way as the built-in builds.
+- `Version` may be `""` or `"latest"`; `Install` resolves it to a release tag before
+  calling the resolver, so `t.Version` is always concrete.
+- Anything [go-getter](https://github.com/hashicorp/go-getter) supports works as a URL,
+  including `file://` and S3/GCS.
+
+See the [resolver example code](./examples/resolver/).

--- a/examples/resolver/main.go
+++ b/examples/resolver/main.go
@@ -1,0 +1,70 @@
+// Installs the llama.cpp libraries using a custom Resolver.
+//
+// A Resolver decides which release assets a Target needs, so an application can
+// install builds the built-in table does not name: an internal mirror, a local
+// file:// path on an air-gapped machine, its own llama.cpp build, or a different
+// CUDA major version. Targets it does not care about fall through to
+// download.DefaultResolver.
+//
+// Run with -mirror to point the CUDA build at somewhere else:
+//
+//	go run ./examples/resolver -lib ./lib -mirror https://mirror.example.com/llama
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/hybridgroup/yzma/pkg/download"
+)
+
+func main() {
+	libPath := flag.String("lib", os.Getenv("YZMA_LIB"), "directory to install the libraries into")
+	version := flag.String("version", "latest", "llama.cpp release tag, or latest")
+	mirror := flag.String("mirror", "", "base URL to fetch the CUDA build from instead")
+	flag.Parse()
+
+	if *libPath == "" {
+		fmt.Println("missing -lib flag or YZMA_LIB env var")
+		os.Exit(1)
+	}
+
+	arch, err := download.ParseArch(runtime.GOARCH)
+	if err != nil {
+		fmt.Println("unsupported architecture:", runtime.GOARCH)
+		os.Exit(1)
+	}
+	operatingSystem, err := download.ParseOS(runtime.GOOS)
+	if err != nil {
+		fmt.Println("unsupported OS:", runtime.GOOS)
+		os.Exit(1)
+	}
+
+	processor := download.CPU
+	if installed, cudaVersion := download.HasCUDA(); installed {
+		fmt.Printf("CUDA detected (version %s), using CUDA build\n", cudaVersion)
+		processor = download.CUDA
+	}
+
+	// Redirect only the target we have a mirror for; everything else keeps whatever
+	// the built-in table says.
+	resolver := download.ResolverFunc(func(target download.Target) ([]string, error) {
+		if *mirror == "" || target.Processor != download.CUDA {
+			return download.DefaultResolver.Resolve(target)
+		}
+		url := fmt.Sprintf("%s/llama-%s-bin-%s-cuda-%s.tar.gz", *mirror, target.Version, target.OS, target.Arch)
+		fmt.Println("resolving CUDA build to", url)
+		return []string{url}, nil
+	})
+
+	target := download.Target{Arch: arch, OS: operatingSystem, Processor: processor, Version: *version}
+	fmt.Println("installing llama.cpp", *version, "to", *libPath)
+	if err := download.Install(context.Background(), target, *libPath, download.ProgressTracker, resolver); err != nil {
+		fmt.Println("failed to download llama.cpp:", err)
+		os.Exit(1)
+	}
+	fmt.Println("done.")
+}

--- a/pkg/download/doc.go
+++ b/pkg/download/doc.go
@@ -1,3 +1,19 @@
 // Package download provides utilities for downloading both the llama.cpp
 // libraries and also model files.
+//
+// [Get] and its variants install the build the built-in table picks for a platform.
+// [Install] takes a [Target] plus an optional [Resolver], so an application can install
+// builds the table does not name — an internal mirror, a local file, its own llama.cpp
+// build, or another CUDA major version:
+//
+//	resolver := download.ResolverFunc(func(t download.Target) ([]string, error) {
+//		if t.OS == download.Linux && t.Processor == download.CUDA {
+//			return []string{mirrorURL(t.Version)}, nil
+//		}
+//		return download.DefaultResolver.Resolve(t)
+//	})
+//
+//	err := download.Install(ctx, target, libPath, download.ProgressTracker, resolver)
+//
+// See INSTALL.md for the longer version.
 package download

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -139,161 +139,24 @@ func getPreviousVersion() (string, error) {
 	return result.TagName, nil
 }
 
-// getDownloadLocationAndFilename returns the download location and filename for the given parameters.
+// getDownloadLocationAndFilename returns the download location and filename for the
+// given parameters.
+//
+// Deprecated: use [DefaultResolver] or [Install]. Unlike the resolver, it downloads
+// auxiliary assets (the Windows CUDA runtime) itself.
 func getDownloadLocationAndFilename(arch Arch, os OS, prcssr Processor, version string, dest string) (location, filename string, err error) {
-	location = fmt.Sprintf("https://github.com/ggml-org/llama.cpp/releases/download/%s", version)
-
-	switch os {
-	case Linux:
-		switch prcssr {
-		case CPU:
-			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cpu-arm64.tar.gz", version)
-				break
-			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-x64.tar.gz", version)
-		case CUDA:
-			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-			if arch == ARM64 {
-				// defaults to CUDA 12 assuming that is running Jetson Orin.
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-arm64.tar.gz", version)
-			} else {
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-13-x64.tar.gz", version)
-			}
-		case Vulkan:
-			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-arm64.tar.gz", version)
-				break
-			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.tar.gz", version)
-		case ROCm:
-			if arch != AMD64 {
-				return "", "", errors.New("precompiled binaries for Linux ARM64 ROCm are not available")
-			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-rocm-7.2-x64.tar.gz", version)
-		default:
-			return "", "", ErrUnknownProcessor
-		}
-
-	case Bookworm:
-		switch prcssr {
-		case CPU:
-			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cpu-arm64.tar.gz", version)
-				break
-			}
-
-			// no AMD64 for bookworm
-			return "", "", ErrUnknownProcessor
-		case CUDA:
-			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-			if arch == ARM64 {
-				// Jetson Orin.
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-arm64.tar.gz", version)
-				break
-			}
-
-			// no AMD64 for bookworm
-			return "", "", ErrUnknownProcessor
-		case Vulkan:
-			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-arm64.tar.gz", version)
-				break
-			}
-
-			// no AMD64 for bookworm
-			return "", "", ErrUnknownProcessor
-		default:
-			return "", "", ErrUnknownProcessor
-		}
-
-	case Trixie:
-		switch prcssr {
-		case CPU:
-			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-trixie-cpu-arm64.tar.gz", version)
-				break
-			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-x64.tar.gz", version)
-		case CUDA:
-			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-			if arch == ARM64 {
-				// not yet
-				return "", "", ErrUnknownProcessor
-			} else {
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-13-x64.tar.gz", version)
-			}
-		case Vulkan:
-			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-trixie-vulkan-arm64.tar.gz", version)
-				break
-			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.tar.gz", version)
-		default:
-			return "", "", ErrUnknownProcessor
-		}
-
-	case Darwin:
-		switch prcssr {
-		case Metal:
-			if arch != ARM64 {
-				return "", "", errors.New("precompiled binaries for macOS non-ARM64 CPU/Metal are not available")
-			}
-			filename = fmt.Sprintf("llama-%s-bin-macos-arm64.tar.gz", version)
-		case CPU:
-			if arch == ARM64 {
-				filename = fmt.Sprintf("llama-%s-bin-macos-arm64.tar.gz", version)
-			} else {
-				filename = fmt.Sprintf("llama-%s-bin-macos-x64.tar.gz", version)
-			}
-		default:
-			return "", "", ErrUnknownProcessor
-		}
-
-	case Windows:
-		switch prcssr {
-		case CPU:
-			if arch == ARM64 {
-				filename = fmt.Sprintf("llama-%s-bin-win-cpu-arm64.zip", version)
-			} else {
-				filename = fmt.Sprintf("llama-%s-bin-win-cpu-x64.zip", version)
-			}
-		case CUDA:
-			if arch == ARM64 {
-				return "", "", errors.New("precompiled binaries for Windows ARM64 CUDA are not available")
-			}
-			// also requires the CUDA RT files
-			cudart := "cudart-llama-bin-win-cuda-13.3-x64.zip"
-			url := fmt.Sprintf("%s/%s", location, cudart)
-			if err := get(context.Background(), url, dest, ProgressTracker); err != nil {
-				return "", "", err
-			}
-			filename = fmt.Sprintf("llama-%s-bin-win-cuda-13.3-x64.zip", version)
-		case Vulkan:
-			if arch == ARM64 {
-				return "", "", errors.New("precompiled binaries for Windows ARM64 Vulkan are not available")
-			}
-			filename = fmt.Sprintf("llama-%s-bin-win-vulkan-x64.zip", version)
-		case ROCm:
-			if arch != AMD64 {
-				return "", "", errors.New("precompiled binaries for Windows ARM64 ROCm are not available")
-			}
-			filename = fmt.Sprintf("llama-%s-bin-win-hip-radeon-x64.zip", version)
-		default:
-			return "", "", ErrUnknownProcessor
-		}
-
-	default:
-		return "", "", ErrUnknownOS
+	urls, err := defaultResolve(Target{Arch: arch, OS: os, Processor: prcssr, Version: version})
+	if err != nil {
+		return "", "", err
 	}
-
-	return location, filename, nil
+	for _, url := range urls[:len(urls)-1] {
+		if err := get(context.Background(), url, dest, ProgressTracker); err != nil {
+			return "", "", err
+		}
+	}
+	last := urls[len(urls)-1]
+	i := strings.LastIndex(last, "/")
+	return last[:i], last[i+1:], nil
 }
 
 // getFunc is the function used to download files. It can be overridden for testing.

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -1,0 +1,244 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	getter "github.com/hashicorp/go-getter"
+)
+
+// Target identifies the machine a llama.cpp build is for.
+type Target struct {
+	Arch      Arch
+	OS        OS
+	Processor Processor
+
+	// Version is the llama.cpp release tag, e.g. "b7974". "" or "latest" resolves to
+	// the newest release.
+	Version string
+}
+
+// Resolver reports the release assets to install for a Target, as URLs downloaded in
+// the order returned. Implement it to reach builds the built-in table does not name.
+// Implementations must not download.
+type Resolver interface {
+	Resolve(target Target) (urls []string, err error)
+}
+
+// ResolverFunc adapts an ordinary function to [Resolver].
+type ResolverFunc func(target Target) ([]string, error)
+
+// Resolve calls f.
+func (f ResolverFunc) Resolve(target Target) ([]string, error) { return f(target) }
+
+// DefaultResolver resolves the assets published on the llama.cpp and llama-cpp-builder
+// release pages. [Install] uses it when no resolver is given.
+var DefaultResolver Resolver = ResolverFunc(defaultResolve)
+
+// defaultResolve is the built-in platform table.
+func defaultResolve(target Target) ([]string, error) {
+	arch, os, prcssr, version := target.Arch, target.OS, target.Processor, target.Version
+
+	var extra []string
+	var location, filename string
+	location = fmt.Sprintf("https://github.com/ggml-org/llama.cpp/releases/download/%s", version)
+
+	location = fmt.Sprintf("https://github.com/ggml-org/llama.cpp/releases/download/%s", version)
+
+	switch os {
+	case Linux:
+		switch prcssr {
+		case CPU:
+			if arch == ARM64 {
+				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cpu-arm64.tar.gz", version)
+				break
+			}
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-x64.tar.gz", version)
+		case CUDA:
+			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+			if arch == ARM64 {
+				// defaults to CUDA 12 assuming that is running Jetson Orin.
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-arm64.tar.gz", version)
+			} else {
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-13-x64.tar.gz", version)
+			}
+		case Vulkan:
+			if arch == ARM64 {
+				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-arm64.tar.gz", version)
+				break
+			}
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.tar.gz", version)
+		case ROCm:
+			if arch != AMD64 {
+				return nil, errors.New("precompiled binaries for Linux ARM64 ROCm are not available")
+			}
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-rocm-7.2-x64.tar.gz", version)
+		default:
+			return nil, ErrUnknownProcessor
+		}
+
+	case Bookworm:
+		switch prcssr {
+		case CPU:
+			if arch == ARM64 {
+				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cpu-arm64.tar.gz", version)
+				break
+			}
+
+			// no AMD64 for bookworm
+			return nil, ErrUnknownProcessor
+		case CUDA:
+			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+			if arch == ARM64 {
+				// Jetson Orin.
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-arm64.tar.gz", version)
+				break
+			}
+
+			// no AMD64 for bookworm
+			return nil, ErrUnknownProcessor
+		case Vulkan:
+			if arch == ARM64 {
+				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-arm64.tar.gz", version)
+				break
+			}
+
+			// no AMD64 for bookworm
+			return nil, ErrUnknownProcessor
+		default:
+			return nil, ErrUnknownProcessor
+		}
+
+	case Trixie:
+		switch prcssr {
+		case CPU:
+			if arch == ARM64 {
+				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-trixie-cpu-arm64.tar.gz", version)
+				break
+			}
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-x64.tar.gz", version)
+		case CUDA:
+			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+			if arch == ARM64 {
+				// not yet
+				return nil, ErrUnknownProcessor
+			} else {
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-13-x64.tar.gz", version)
+			}
+		case Vulkan:
+			if arch == ARM64 {
+				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-trixie-vulkan-arm64.tar.gz", version)
+				break
+			}
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.tar.gz", version)
+		default:
+			return nil, ErrUnknownProcessor
+		}
+
+	case Darwin:
+		switch prcssr {
+		case Metal:
+			if arch != ARM64 {
+				return nil, errors.New("precompiled binaries for macOS non-ARM64 CPU/Metal are not available")
+			}
+			filename = fmt.Sprintf("llama-%s-bin-macos-arm64.tar.gz", version)
+		case CPU:
+			if arch == ARM64 {
+				filename = fmt.Sprintf("llama-%s-bin-macos-arm64.tar.gz", version)
+			} else {
+				filename = fmt.Sprintf("llama-%s-bin-macos-x64.tar.gz", version)
+			}
+		default:
+			return nil, ErrUnknownProcessor
+		}
+
+	case Windows:
+		switch prcssr {
+		case CPU:
+			if arch == ARM64 {
+				filename = fmt.Sprintf("llama-%s-bin-win-cpu-arm64.zip", version)
+			} else {
+				filename = fmt.Sprintf("llama-%s-bin-win-cpu-x64.zip", version)
+			}
+		case CUDA:
+			if arch == ARM64 {
+				return nil, errors.New("precompiled binaries for Windows ARM64 CUDA are not available")
+			}
+			// also requires the CUDA RT files
+			cudart := "cudart-llama-bin-win-cuda-13.3-x64.zip"
+			extra = append(extra, fmt.Sprintf("%s/%s", location, cudart))
+			filename = fmt.Sprintf("llama-%s-bin-win-cuda-13.3-x64.zip", version)
+		case Vulkan:
+			if arch == ARM64 {
+				return nil, errors.New("precompiled binaries for Windows ARM64 Vulkan are not available")
+			}
+			filename = fmt.Sprintf("llama-%s-bin-win-vulkan-x64.zip", version)
+		case ROCm:
+			if arch != AMD64 {
+				return nil, errors.New("precompiled binaries for Windows ARM64 ROCm are not available")
+			}
+			filename = fmt.Sprintf("llama-%s-bin-win-hip-radeon-x64.zip", version)
+		default:
+			return nil, ErrUnknownProcessor
+		}
+
+	default:
+		return nil, ErrUnknownOS
+	}
+
+	return append(extra, fmt.Sprintf("%s/%s", location, filename)), nil
+}
+
+// Install downloads the llama.cpp binaries for target into dest. A nil resolver means
+// [DefaultResolver].
+func Install(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver) error {
+	if resolver == nil {
+		resolver = DefaultResolver
+	}
+
+	autoVersion := target.Version == "" || target.Version == "latest"
+	if autoVersion {
+		latest, err := LlamaLatestVersion()
+		if err != nil {
+			return err
+		}
+		target.Version = latest
+	}
+	if err := VersionIsValid(target.Version); err != nil {
+		return ErrInvalidVersion
+	}
+
+	err := installAssets(ctx, target, dest, progress, resolver)
+
+	// The newest release may still be building for this platform.
+	if err != nil && autoVersion && errors.Is(err, ErrFileNotFound) {
+		previous, prevErr := LlamaPreviousVersion()
+		if prevErr != nil {
+			return err
+		}
+		target.Version = previous
+		return installAssets(ctx, target, dest, progress, resolver)
+	}
+
+	return err
+}
+
+func installAssets(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver) error {
+	urls, err := resolver.Resolve(target)
+	if err != nil {
+		return err
+	}
+	for _, url := range urls {
+		if err := getFunc(ctx, url, dest, progress); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/download/resolver_test.go
+++ b/pkg/download/resolver_test.go
@@ -1,0 +1,111 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	getter "github.com/hashicorp/go-getter"
+)
+
+func TestInstallUsesResolver(t *testing.T) {
+	var got []string
+	originalGet := getFunc
+	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+		got = append(got, url)
+		return nil
+	}
+	defer func() { getFunc = originalGet }()
+
+	target := Target{Arch: AMD64, OS: Linux, Processor: CUDA, Version: "b7974"}
+	resolver := ResolverFunc(func(resolved Target) ([]string, error) {
+		if resolved != target {
+			t.Errorf("resolver got target %+v, want %+v", resolved, target)
+		}
+		return []string{"https://example.com/runtime.zip", "https://example.com/llama.tar.gz"}, nil
+	})
+
+	if err := Install(context.Background(), target, t.TempDir(), nil, resolver); err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+	// Order matters: an auxiliary runtime lands before the libraries linking it.
+	want := []string{"https://example.com/runtime.zip", "https://example.com/llama.tar.gz"}
+	if len(got) != len(want) {
+		t.Fatalf("downloaded %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("downloaded %v, want %v", got, want)
+		}
+	}
+}
+
+func TestInstallResolverError(t *testing.T) {
+	originalGet := getFunc
+	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+		t.Fatal("Install() downloaded despite a resolver error")
+		return nil
+	}
+	defer func() { getFunc = originalGet }()
+
+	sentinel := errors.New("no build for this target")
+	resolver := ResolverFunc(func(Target) ([]string, error) { return nil, sentinel })
+
+	err := Install(context.Background(), Target{Arch: AMD64, OS: Linux, Processor: CPU, Version: "b7974"},
+		t.TempDir(), nil, resolver)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Install() error = %v, want %v", err, sentinel)
+	}
+}
+
+func TestInstallNilResolverUsesDefault(t *testing.T) {
+	var got []string
+	originalGet := getFunc
+	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+		got = append(got, url)
+		return nil
+	}
+	defer func() { getFunc = originalGet }()
+
+	target := Target{Arch: AMD64, OS: Linux, Processor: CPU, Version: "b7974"}
+	if err := Install(context.Background(), target, t.TempDir(), nil, nil); err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+	want := "https://github.com/ggml-org/llama.cpp/releases/download/b7974/llama-b7974-bin-ubuntu-x64.tar.gz"
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("downloaded %v, want [%s]", got, want)
+	}
+}
+
+func TestInstallInvalidVersion(t *testing.T) {
+	err := Install(context.Background(), Target{Arch: AMD64, OS: Linux, Processor: CPU, Version: "nogood"},
+		t.TempDir(), nil, nil)
+	if err != ErrInvalidVersion {
+		t.Fatalf("Install() error = %v, want %v", err, ErrInvalidVersion)
+	}
+}
+
+// The Windows CUDA build needs the CUDA runtime archive alongside it.
+func TestDefaultResolverWindowsCUDA(t *testing.T) {
+	urls, err := DefaultResolver.Resolve(Target{Arch: AMD64, OS: Windows, Processor: CUDA, Version: "b7974"})
+	if err != nil {
+		t.Fatalf("Resolve() failed: %v", err)
+	}
+	if len(urls) != 2 {
+		t.Fatalf("Resolve() returned %d urls, want 2: %v", len(urls), urls)
+	}
+	if !strings.Contains(urls[0], "cudart-llama-bin-win-cuda") {
+		t.Errorf("first asset = %q, want the CUDA runtime archive", urls[0])
+	}
+	if !strings.Contains(urls[1], "llama-b7974-bin-win-cuda") {
+		t.Errorf("second asset = %q, want the llama.cpp build", urls[1])
+	}
+}
+
+func TestDefaultResolverUnknownProcessor(t *testing.T) {
+	_, err := DefaultResolver.Resolve(Target{Arch: ARM64, OS: Windows, Processor: CUDA, Version: "b7974"})
+	if err == nil {
+		t.Fatal("Resolve() accepted a target with no published build")
+	}
+}


### PR DESCRIPTION
Which release asset gets downloaded for a target is decided by a private table, so an
application embedding yzma cannot influence it. That's limiting in a few settings:

- **Internal mirrors.** Plenty of environments don't allow pulling release archives
  straight from GitHub — artifacts are proxied through Artifactory/Nexus, an S3 bucket,
  or an internal HTTP host. A resolver can point at those instead (any scheme
  go-getter handles).
- **Air-gapped or offline installs.** Resolve to a `file://` path or an on-premises URL
  and the rest of the install flow is unchanged.
- **Pinned or vetted artifacts.** Where builds have to be reviewed before use, the
  embedder can restrict resolution to approved copies rather than whatever is newest.
- **Custom builds.** An organisation compiling llama.cpp with its own flags (specific
  compute architectures, a particular BLAS) can serve those without patching yzma.
- **Host-specific choices.** The embedding application often knows more about the
  machine than a static table can: it can probe at runtime and pick accordingly.
- **Assets the table doesn't name yet**, which is how I ran into this — see below.

## Change

```go
type Target struct { Arch; OS; Processor; Version string }

type Resolver interface {
	Resolve(target Target) (urls []string, err error)
}

func Install(ctx context.Context, target Target, dest string,
	progress getter.ProgressTracker, resolver Resolver) error
```

- `Install` takes a resolver; `nil` means `DefaultResolver`, the built-in table.
- `Get`, `GetWithProgress` and `GetWithContext` keep their signatures and behaviour and
  delegate to `Install`.
- The table moves to `defaultResolve` and becomes pure. The Windows CUDA branch used to
  download the CUDA runtime archive as a side effect of resolving a filename; it now
  returns it as an extra asset, downloaded in order. That's what makes the branch
  testable — `TestDefaultResolverWindowsCUDA` couldn't exist before.
- `getDownloadLocationAndFilename` stays as a deprecated wrapper.

Overriding one target and deferring to the table for everything else:

```go
resolver := download.ResolverFunc(func(t download.Target) ([]string, error) {
	if mirrored(t) {
		return []string{mirrorURL(t)}, nil
	}
	return download.DefaultResolver.Resolve(t)
})
```

## The case that led me here

`linux/amd64` + `cuda` always resolves to `cuda-13-x64`. On a host with a CUDA 12
driver, `libggml-cuda.so` can't resolve `libcudart.so.13`, so llama.cpp drops the
backend and runs on the CPU — no error, just a silent slowdown. llama-cpp-builder
already publishes `llama-<tag>-bin-ubuntu-cuda-x64` (CUDA 12.9) for this, and with a
resolver I could reach it. Happy to also add `cuda-12` to the built-in table, or gate it
on a driver probe, if you'd like that independently of this.

## Notes

No behaviour change and no new dependency. The existing `pkg/download` tests are
untouched and pass, which is the check that no URL moved; 6 tests added for the new API.
