### PR TITLE
llama: correct LoadMode values for current llama.cpp

### DIFF
--- a/pkg/llama/backend_test.go
+++ b/pkg/llama/backend_test.go
@@ -101,6 +101,7 @@ func TestLoadModeName(t *testing.T) {
 		{LoadModeNone, "none"},
 		{LoadModeMmap, "mmap"},
 		{LoadModeMlock, "mlock"},
+		{LoadModeMmapMlock, "mmap+mlock"},
 		{LoadModeDirectIO, "dio"},
 	}
 
@@ -122,6 +123,7 @@ func TestLoadModeFromStr(t *testing.T) {
 		{"none", LoadModeNone},
 		{"mmap", LoadModeMmap},
 		{"mlock", LoadModeMlock},
+		{"mmap+mlock", LoadModeMmapMlock},
 		{"dio", LoadModeDirectIO},
 	}
 

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -176,10 +176,11 @@ const (
 type LoadMode int32
 
 const (
-	LoadModeNone     LoadMode = 0 // no special loading mode
-	LoadModeMmap     LoadMode = 1 // memory map the model
-	LoadModeMlock    LoadMode = 2 // mmap + force system to keep model in RAM rather than swapping or compressing
-	LoadModeDirectIO LoadMode = 3 // use direct I/O if available
+	LoadModeNone      LoadMode = 0 // no special loading mode
+	LoadModeMmap      LoadMode = 1 // memory map the model
+	LoadModeMlock     LoadMode = 2 // force system to keep model in RAM rather than swapping or compressing
+	LoadModeMmapMlock LoadMode = 3 // mmap + mlock
+	LoadModeDirectIO  LoadMode = 4 // use direct I/O if available
 )
 
 type GpuBackend int32


### PR DESCRIPTION
`TestLoadModeName` and `TestLoadModeFromStr` are failing on `main` against the current
llama.cpp release:

```
backend_test.go:110: LoadModeName(3) = "mmap+mlock", want "dio"
backend_test.go:131: LoadModeFromStr("dio") = 4, want 3
```

llama.cpp inserted a mmap+mlock mode at 3, which moved direct I/O to 4. Probing the
loaded library gives `0=none 1=mmap 2=mlock 3=mmap+mlock 4=dio`.

So `LoadModeDirectIO` currently selects mmap+mlock — a silent wrong mode for anyone
setting it in `ModelParams`, not just a test failure.

Adds `LoadModeMmapMlock`, renumbers `LoadModeDirectIO` to 4, covers the new value in
both tests, and drops the stale "mmap +" from the `LoadModeMlock` comment (2 is mlock
alone now).
