### PR TITLE
vocab: add wrapper for llama_vocab_get_suppress_tokens

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,6 +84,7 @@ This is a list of all functions exposed by `llama.cpp` and the current state of 
 - [x] `llama_vocab_get_add_sep`
 - [x] `llama_vocab_get_attr`
 - [x] `llama_vocab_get_score`
+- [x] `llama_vocab_get_suppress_tokens`
 - [x] `llama_vocab_get_text`
 - [x] `llama_vocab_is_control`
 - [x] `llama_vocab_is_eog`

--- a/pkg/llama/vocab.go
+++ b/pkg/llama/vocab.go
@@ -106,6 +106,9 @@ var (
 	// LLAMA_API const char * llama_vocab_get_text(const struct llama_vocab * vocab, llama_token token);
 	vocabGetTextFunc ffi.Fun
 
+	// LLAMA_API const llama_token * llama_vocab_get_suppress_tokens(const struct llama_vocab * vocab, int32_t * n_suppress_tokens);
+	vocabGetSuppressTokensFunc ffi.Fun
+
 	// LLAMA_API enum llama_vocab_type llama_vocab_type(const struct llama_vocab * vocab);
 	vocabTypeFunc ffi.Fun
 )
@@ -218,6 +221,10 @@ func loadVocabFuncs(lib ffi.Lib) error {
 
 	if vocabGetTextFunc, err = lib.Prep("llama_vocab_get_text", &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeSint32); err != nil {
 		return loadError("llama_vocab_get_text", err)
+	}
+
+	if vocabGetSuppressTokensFunc, err = lib.Prep("llama_vocab_get_suppress_tokens", &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer); err != nil {
+		return loadError("llama_vocab_get_suppress_tokens", err)
 	}
 
 	if vocabTypeFunc, err = lib.Prep("llama_vocab_type", &ffi.TypeSint32, &ffi.TypePointer); err != nil {
@@ -568,6 +575,30 @@ func VocabGetText(vocab Vocab, token Token) string {
 	}
 
 	return utils.BytePtrToString(textPtr)
+}
+
+// VocabGetSuppressTokens retrieves the tokens that the model specifies should be
+// suppressed during sampling, or nil if the vocabulary has none.
+//
+// The returned slice aliases memory owned by the vocabulary, so it is only valid
+// for as long as the model that owns the vocabulary has not been freed.
+func VocabGetSuppressTokens(vocab Vocab) []Token {
+	if vocab == 0 {
+		return nil
+	}
+
+	var (
+		tokensPtr *Token
+		nTokens   int32
+	)
+	n := &nTokens
+	vocabGetSuppressTokensFunc.Call(unsafe.Pointer(&tokensPtr), unsafe.Pointer(&vocab), unsafe.Pointer(&n))
+
+	if tokensPtr == nil || nTokens <= 0 {
+		return nil
+	}
+
+	return unsafe.Slice(tokensPtr, nTokens)
 }
 
 // GetVocabType retrieves the type of the vocabulary.

--- a/pkg/llama/vocab_test.go
+++ b/pkg/llama/vocab_test.go
@@ -483,6 +483,26 @@ func TestVocabGetText(t *testing.T) {
 	t.Logf("VocabGetText returned text: %s for token: %d", text, token)
 }
 
+func TestVocabGetSuppressTokens(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	params := ModelDefaultParams()
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer ModelFree(model)
+
+	vocab := ModelGetVocab(model)
+
+	// Most models do not specify any tokens to suppress, so an empty result is valid.
+	tokens := VocabGetSuppressTokens(vocab)
+	t.Logf("VocabGetSuppressTokens returned %d tokens: %v", len(tokens), tokens)
+}
+
 func TestGetVocabType(t *testing.T) {
 	modelFile := testModelFileName(t)
 


### PR DESCRIPTION
llama.cpp [PR #26276](https://github.com/ggml-org/llama.cpp/pull/26276) promoted `llama_vocab::get_suppress_tokens()` to the public C API:

```c
LLAMA_API const llama_token * llama_vocab_get_suppress_tokens(const struct llama_vocab * vocab, int32_t * n_suppress_tokens);
```

These are the tokens a model's metadata marks as never-to-be-sampled. Upstream `common/sampling.cpp` folds them into the logit bias at `-INFINITY`; until now nothing in `yzma` could see the list at all.

## Changes

- `pkg/llama/vocab.go`: adds `vocabGetSuppressTokensFunc`, its `lib.Prep` in `loadVocabFuncs`, and the `VocabGetSuppressTokens(vocab Vocab) []Token` wrapper.
- `pkg/llama/vocab_test.go`: adds `TestVocabGetSuppressTokens`.
- `ROADMAP.md`: ticks `llama_vocab_get_suppress_tokens`.

The count comes back through an `int32_t *` out-param, so this uses the same double-indirection idiom as `mtmd.InputChunkGetTokensText`. The returned slice aliases the vocabulary's own memory rather than copying, matching `AdapterGetAloraInvocationTokens`; the doc comment states that it is only valid while the owning model is alive.

## Notes for review

- **This raises the minimum llama.cpp build**, since `loadVocabFuncs` treats a missing symbol as fatal. The version table in `README.md` will need a new row at release time.
- **The test only exercises the empty-list path.** `SmolLM-135M` reports zero suppress tokens, and none of the other local test models carry the `suppress_tokens` metadata key, so the non-empty `unsafe.Slice` path is unverified against real data. A Whisper-derived GGUF in the test models would close that gap.
- Sampling behaviour is deliberately unchanged — `NewSampler` was left alone rather than biasing these tokens the way upstream does.

## Testing

Against a llama.cpp build containing the PR (`nm -D lib/libllama.so` confirms the symbol is exported):

- `go build ./...`, `go vet ./pkg/llama`, `gofmt -l` all clean
- `go test ./pkg/llama -run 'TestVocab|TestGetVocabType|TestTokenToPiece'` — 23 pass, 1 skip (`TestVocabGetAddSEP`, pre-existing model-dependent skip), 0 fail