### PR TITLE
llama: add LoadMTP to ModelParams for llama.cpp b10212+

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ Sometimes there are breaking changes to `llama.cpp` that require an update to `y
 | b9616 - b9749  | v1.17.1   |
 | b9650 - b9978  | v1.18.0   |
 | b9979 - b10103  | v1.19.0   |
-| b10105+  | v1.20.0   |
+| b10105 - b10211  | v1.20.0 - v1.21.0   |
+| b10212+  | v1.22.0   |
 
 ## Benchmarks
 

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -322,6 +322,7 @@ type ModelParams struct {
 	UseExtraBufts            uint8     // use extra buffer types (bool as uint8)
 	NoHost                   uint8     // bypass host buffer allowing extra buffers to be used (bool as uint8)
 	NoAlloc                  uint8     // only load metadata and simulate memory allocations (bool as uint8)
+	LoadMTP                  uint8     // whether to load MTP layers (bool as uint8)
 }
 
 // ContextParams controls the parameters available for the model context

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -17,7 +17,7 @@ var (
 		&ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypeSint32,
 		&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer,
 		&ffi.TypeUint8, &ffi.TypeUint8,
-		&ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8)
+		&ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8)
 
 	// ffiTypeModelQuantizeParams represents the C struct llama_model_quantize_params
 	ffiTypeModelQuantizeParams = ffi.NewType(&ffi.TypeSint32, &ffi.TypeSint32,

--- a/pkg/llama/model_test.go
+++ b/pkg/llama/model_test.go
@@ -17,6 +17,96 @@ func TestModelDefaultParams(t *testing.T) {
 	}
 }
 
+// TestModelDefaultParamsLayout guards against llama_model_params layout drift.
+// ffiTypeModelParams is hand-maintained, so if llama.cpp adds, removes, or reorders
+// a field the native defaults land in the wrong Go fields. Checking the values that
+// llama.cpp is known to write catches that.
+func TestModelDefaultParamsLayout(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	params := ModelDefaultParams()
+
+	// The C bools. A field outside {0, 1} means libffi wrote struct padding
+	// into it, which is what a missing or misplaced descriptor entry looks like.
+	bools := []struct {
+		name  string
+		value uint8
+	}{
+		{"VocabOnly", params.VocabOnly},
+		{"CheckTensors", params.CheckTensors},
+		{"UseExtraBufts", params.UseExtraBufts},
+		{"NoHost", params.NoHost},
+		{"NoAlloc", params.NoAlloc},
+		{"LoadMTP", params.LoadMTP},
+	}
+	for _, b := range bools {
+		if b.value > 1 {
+			t.Errorf("%s is %d, want a 0 or 1 C bool", b.name, b.value)
+		}
+	}
+
+	// llama.cpp defaults every pointer field to NULL.
+	if params.Devices != 0 {
+		t.Errorf("Devices is %#x, want 0", params.Devices)
+	}
+	if params.TensorBuftOverrides != 0 {
+		t.Errorf("TensorBuftOverrides is %#x, want 0", params.TensorBuftOverrides)
+	}
+	if params.TensorSplit != nil {
+		t.Error("TensorSplit is not nil, want nil")
+	}
+	if params.ProgressCallback != 0 {
+		t.Errorf("ProgressCallback is %#x, want 0", params.ProgressCallback)
+	}
+	if params.ProgressCallbackUserData != 0 {
+		t.Errorf("ProgressCallbackUserData is %#x, want 0", params.ProgressCallbackUserData)
+	}
+	if params.KvOverrides != 0 {
+		t.Errorf("KvOverrides is %#x, want 0", params.KvOverrides)
+	}
+
+	// The int32 fields. Ranges rather than exact values, so an upstream default
+	// tweak does not fail the test but a shifted field does.
+	// -1 means all layers, which is the current llama.cpp default.
+	if params.NGpuLayers < -1 {
+		t.Errorf("NGpuLayers is %d, want >= -1", params.NGpuLayers)
+	}
+	if params.SplitMode < SplitModeNone || params.SplitMode > SplitModeRow {
+		t.Errorf("SplitMode is %d, want a valid SplitMode", params.SplitMode)
+	}
+	if params.LoadMode < LoadModeNone || params.LoadMode > LoadModeDirectIO {
+		t.Errorf("LoadMode is %d, want a valid LoadMode", params.LoadMode)
+	}
+	if params.MainGpu < 0 {
+		t.Errorf("MainGpu is %d, want >= 0", params.MainGpu)
+	}
+}
+
+// TestModelLoadFromFileLoadMTP checks that a caller-set LoadMTP survives the trip
+// through libffi. The test model has no MTP layers, so llama.cpp has nothing extra
+// to load and the request is a no-op, but a bad struct layout would corrupt the
+// neighboring fields and break the load.
+func TestModelLoadFromFileLoadMTP(t *testing.T) {
+	modelFile := testModelFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	params := ModelDefaultParams()
+	params.LoadMTP = 1
+
+	model, err := ModelLoadFromFile(modelFile, params)
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile with LoadMTP failed: %v", err)
+	}
+	defer ModelFree(model)
+
+	if params.LoadMTP != 1 {
+		t.Errorf("LoadMTP is %d after loading, want 1", params.LoadMTP)
+	}
+}
+
 func TestModelInvalidFile(t *testing.T) {
 	modelFile := "invalid_model.gguf"
 


### PR DESCRIPTION
Fixes #280

## Problem

llama.cpp commit [82dbc4f](https://github.com/ggml-org/llama.cpp/commit/82dbc4f017a7b005f993ac2e7af9c048ad686c04) (first in build **b10212**) added a trailing `bool load_mtp` to `llama_model_params` and, in the same change, stopped loading a model's MTP/NextN tensors unless it is set.

yzma already had the context half of MTP support — `ContextType` and `ContextParams.CtxType` landed in 91e93fb — but `ModelParams` ended at `NoAlloc`, so callers had no way to ask for the tensors an MTP context then requires. Creating one aborted in native code on:

```
GGML_ASSERT(layer.nextn.eh_proj && "MTP block missing nextn.eh_proj") failed
```

Both stages are needed:

```
model load:       llama_model_params.load_mtp = true
context creation: llama_context_params.ctx_type = LLAMA_CONTEXT_TYPE_MTP
```

This was also a live correctness bug, not only a missing field. Because `ffiTypeModelParams` described five trailing bools rather than six, the byte llama.cpp reads as `load_mtp` was whatever libffi left in the struct's tail padding — an effectively uninitialized bool on b10212+.

## Changes

- **`pkg/llama/llama.go`** — add `LoadMTP uint8` to `ModelParams` after `NoAlloc`, following the package's `(bool as uint8)` convention.
- **`pkg/llama/model.go`** — add the matching sixth `&ffi.TypeUint8` to `ffiTypeModelParams`.
- **`pkg/llama/model_test.go`** — `TestModelDefaultParamsLayout` and `TestModelLoadFromFileLoadMTP`.
- **`README.md`** — record the b10212 cutoff in the compatibility table.

Nothing else changes: `ModelDefaultParams`, `ModelLoadFromFile` and `ModelLoadFromSplits` all hand the whole struct to `Call` by pointer, so the native default is preserved and the caller's value passes through once the descriptor is right.

## Tests

`TestModelDefaultParams` only checked the struct was not all-zero and would not have caught this. `TestModelDefaultParamsLayout` pins the values llama.cpp is known to write — every C bool `0` or `1`, every pointer NULL, the int32 enums in range — so a future `llama_model_params` change fails loudly instead of silently shifting fields.

## Usage

```go
params := llama.ModelDefaultParams()
params.LoadMTP = 1

model, err := llama.ModelLoadFromFile(path, params)
if err != nil {
    return err
}

ctxParams := llama.ContextDefaultParams()
ctxParams.CtxType = llama.ContextTypeMTP
ctx, err := llama.InitFromModel(model, ctxParams)
```

## Compatibility

`load_mtp` occupies what was previously tail padding, so `sizeof` is unchanged, but this still raises the minimum llama.cpp build to **b10212**. Consistent with prior ABI bumps (c00d464 for `LoadMode`, 91e93fb for `CtxType`); users on older builds should stay on v1.21.0.

The README table's last row reads `b10212+ | v1.22.0` — worth adjusting if the next release won't be 1.22.0.

## Verification

`go build`, `go vet` and `gofmt` are clean. `go test -count=1 -p 1 ./pkg/llama/ ./pkg/vlm/ ./pkg/mtmd/` passes against a b10212+ build (confirmed affected — the local library carries the `"MTP block missing nextn.eh_proj"` assertion string added by 82dbc4f).

**Not covered:** end-to-end MTP inference. That needs a GGUF carrying `nextn` tensors (e.g. `blk.N.nextn.eh_proj.weight` / `qwen35moe.nextn_predict_layers`); the test model is SmolLM-135M, which has none. These tests confirm the flag is passed correctly, not that MTP inference works. @ardan-bkennedy — could you confirm against your model?