### PR TITLE
yzma-checker: add a standalone FFI type-contract auditor

### DIFF
--- a/cmd/yzma-checker/.gitignore
+++ b/cmd/yzma-checker/.gitignore
@@ -1,0 +1,1 @@
+/yzma-checker

--- a/cmd/yzma-checker/README.md
+++ b/cmd/yzma-checker/README.md
@@ -1,0 +1,158 @@
+# yzma-checker
+
+Mechanical verification of the **FFI parameter and return types** in every yzma
+binding, against the llama.cpp headers for the build yzma installs.
+
+yzma binds llama.cpp through purego/libffi, not cgo. There is no `cgocheck`, no
+automatic pinning, and no compiler validation of argument widths, so a mismatch
+between
+
+1. the C declaration,
+2. the libffi type descriptor passed to `ffi.PrepCif`, and
+3. the Go variable whose address is passed to `ffi.Fun.Call`
+
+is completely silent at build time and only shows up at runtime as a corrupted
+value or corrupted memory. 265 bindings is far too many to eyeball credibly,
+which is why this exists.
+
+## Running it
+
+```sh
+cd cmd/yzma-checker
+go run .          # add -v to dump every binding with its C signature
+```
+
+No arguments needed, and nothing outside this repository is assumed. It works
+out:
+
+| what | how |
+|---|---|
+| yzma tree | walks up for the `github.com/hybridgroup/yzma` `go.mod` |
+| llama.cpp ref | `tag_name` from `llama-cpp-builder`, the same endpoint yzma's installer uses |
+| headers | fetched from `ggml-org/llama.cpp` at that ref, cached under `$XDG_CACHE_HOME` |
+
+The banner prints all three, so a run is self-documenting. Only the first run
+for a given ref needs the network; after that the header cache serves it.
+
+It exits non-zero when it reports a violation, so it can be wired into CI as-is.
+
+### Auditing a consumer's yzma
+
+Run it from another module's root and it audits the yzma **that module actually
+compiles against**, resolved with `go list -m`:
+
+```
+$ cd ../some-project && yzma-checker
+yzma:   /Users/me/go/pkg/mod/github.com/hybridgroup/yzma@v1.21.0 (module cache (via go list))
+```
+
+This distinction has caused real confusion: a locally-patched yzma checkout that
+is not referenced by a `replace` directive or `go.work` is not compiled, so
+auditing it describes code that does not run.
+
+### Flags
+
+```
+-yzma   <dir>   yzma tree to audit (default: auto-detect, as above)
+-ref    <ref>   llama.cpp git ref, or "auto" to resolve the current release
+-llama  <dir>   read headers from a llama.cpp git checkout via `git show <ref>:`
+                instead of the network; the checkout's own worktree state is
+                irrelevant, only the ref matters
+-hdrs   <dir>   use pre-extracted headers; the dir must contain llama.h, ggml.h,
+                ggml-backend.h, ggml-cpu.h, mtmd.h and mtmd-helper.h
+-pkgs   <list>  comma-separated package patterns to audit
+-v              dump every binding: cif types, C signature, and every call site
+```
+
+`-llama` and `-hdrs` are the offline paths.
+
+## The three rules
+
+**RULE 1 — the cif must match the C prototype.** Parameter for parameter, in
+width and in class. On arm64: `size_t`/`uint64_t`/any pointer = 8 bytes,
+`int`/`int32_t`/`enum`/`float` = 4, `double` = 8. A struct passed by value has
+its own descriptor and is a common error site.
+
+**RULE 2 — the Go variable must be exactly as wide as the cif claims.** libffi
+reads exactly `ffi.Type.Size` bytes from each pointer it is handed. `&x` where
+`x` is a Go `int32` behind an `ffi.TypeUint64` slot makes libffi splice 4 bytes
+of adjacent Go memory into the high half of the C argument.
+
+**RULE 3 — return buffers must match the return *kind*.**
+- Integer/pointer returns: the buffer must be **8 bytes** (`ffi.Arg`), because
+  libffi always stores a full `ffi_arg`. A narrower variable is written past.
+- Float returns are the **opposite**: they must be `float32`. libffi stores only
+  4 bytes and leaves the rest of the buffer alone, so an `ffi.Arg` ends up
+  holding the IEEE-754 bit pattern in its low word — and `float32(someArg)` is a
+  numeric conversion, not a bit reinterpretation.
+- A `TypeVoid` return descriptor makes libffi write **nothing at all**, so a
+  supplied buffer silently keeps its zero value.
+
+`jupiterrider/ffi` states both halves of RULE 3 in its `Fun.Call` doc comment
+(`fun.go:19-20`): *"You cannot use integer types smaller than 8 bytes here
+(float32 and structs are not affected)."*
+
+## Output
+
+Only mismatches are printed, plus three accounting sections that matter as much
+as the findings, because they are what makes *"these are the only ones"* a
+measurement rather than an assertion:
+
+- `NOT VERIFIED (skips)` — every slot the tool could not decide, and why. A
+  clean run reports **0 skips**; anything else means the coverage claim is
+  weaker than the violation list suggests.
+- `STRUCT-BY-VALUE COMPARISONS` — each struct slot with the cif descriptor size
+  next to the C struct size, so those checks are visible rather than implied.
+- `SUMMARY` — declarations parsed, bindings matched, and checked/clean counts
+  per rule.
+
+Argument types come from `go/types`, not regex, so a named type like
+`llama.SeqId` or an alias like `ffiTypeSize` resolves to a real width instead of
+being guessed at.
+
+## Correctness gate
+
+A tool that reports nothing is indistinguishable from a tool that checks
+nothing, so the checker has to demonstrate it can still find things:
+
+```sh
+go test ./...
+```
+
+`testdata/fixture` is a miniature binding package carrying one planted defect
+per rule per direction, plus one deliberately clean binding. The gate asserts
+that every plant is found *and* that the clean binding is never reported, along
+with the accounting counters and run-to-run repeatability.
+
+**Treat a failing `go test` as "do not trust anything this run reports."**
+
+The previous gate was "a run must re-derive these two live defects in yzma."
+That is no longer usable, because those defects are fixed — which is exactly the
+failure mode the fixture avoids.
+
+## Files
+
+| file | role |
+|---|---|
+| `main.go` | the three rules, the report, and the CLI |
+| `sources.go` | resolving the yzma tree, the llama.cpp ref, and the headers |
+| `cheader.go` | C declaration parser: comment blanking that preserves byte offsets, `DEPRECATED(...)` unwrapping, typedef/enum resolution, top-level comma splitting |
+| `cstruct.go` | C struct layout for struct-by-value slots; iterates to a fixpoint because `llama.h` structs reference typedefs declared in `ggml-backend.h` |
+| `goside.go` | `go/packages` type-checked walk: `lib.Prep`/`PrepVar` → binding spec, `<var>.Call(...)` → the Go type libffi will actually read bytes from |
+| `main_test.go` | the correctness gate |
+
+## What it does not cover
+
+- **Callback descriptors.** Four bindings use `ffi.PrepCif` / `PrepClosureLoc` /
+  `purego.NewCallback` rather than `lib.Prep`, so they fall outside the 265.
+- **Struct field order.** Only total struct sizes are compared, so two structs
+  that agree in size but disagree in field order pass.
+- **Pointer lifetime.** Go pointers stored in C-visible memory, missing
+  `runtime.KeepAlive`, and slices retained over C-owned memory are a separate
+  class of hazard entirely.
+
+## Note on the nested module
+
+This directory has its own `go.mod` so the `golang.org/x/tools` dependency never
+reaches the root yzma module. `go build ./...`, `go vet ./...` and
+`go test ./...` at the repo root skip it entirely.

--- a/cmd/yzma-checker/cheader.go
+++ b/cmd/yzma-checker/cheader.go
@@ -1,0 +1,548 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// CParam is one parameter of a C function declaration.
+type CParam struct {
+	Raw  string // original text
+	Norm string // normalised type text (name stripped)
+	Kind Kind
+	Size int
+}
+
+// CFunc is one LLAMA_API / GGML_API / MTMD_API declaration.
+type CFunc struct {
+	Name    string
+	File    string
+	Line    int
+	RetRaw  string
+	RetKind Kind
+	RetSize int
+	Params  []CParam
+	Vararg  bool
+	Raw     string
+}
+
+// Kind classifies a C type for ABI purposes.
+type Kind int
+
+const (
+	KindUnknown Kind = iota
+	KindVoid
+	KindSint
+	KindUint
+	KindFloat  // 4 byte float
+	KindDouble // 8 byte float
+	KindPointer
+	KindStruct
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindVoid:
+		return "void"
+	case KindSint:
+		return "sint"
+	case KindUint:
+		return "uint"
+	case KindFloat:
+		return "float"
+	case KindDouble:
+		return "double"
+	case KindPointer:
+		return "ptr"
+	case KindStruct:
+		return "struct"
+	}
+	return "?"
+}
+
+// stripComments blanks out comments while preserving byte offsets/newlines.
+func stripComments(src string) string {
+	b := []byte(src)
+	out := make([]byte, len(b))
+	copy(out, b)
+	i := 0
+	for i < len(b) {
+		switch {
+		case b[i] == '/' && i+1 < len(b) && b[i+1] == '/':
+			for i < len(b) && b[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+		case b[i] == '/' && i+1 < len(b) && b[i+1] == '*':
+			for i < len(b) && !(b[i] == '*' && i+1 < len(b) && b[i+1] == '/') {
+				if b[i] != '\n' {
+					out[i] = ' '
+				}
+				i++
+			}
+			if i < len(b) {
+				out[i] = ' '
+				i++
+			}
+			if i < len(b) {
+				out[i] = ' '
+				i++
+			}
+		case b[i] == '"':
+			i++
+			for i < len(b) && b[i] != '"' {
+				if b[i] == '\\' {
+					i++
+				}
+				i++
+			}
+			i++
+		default:
+			i++
+		}
+	}
+	return string(out)
+}
+
+// unwrapDeprecated rewrites DEPRECATED(<decl>, "msg") into <decl> in place,
+// blanking the wrapper so byte offsets and line numbers are preserved.
+func unwrapDeprecated(src string) string {
+	b := []byte(src)
+	const tok = "DEPRECATED("
+	for _, idx := range findAll(string(b), tok) {
+		if idx > 0 && isIdentChar(b[idx-1]) {
+			continue
+		}
+		depth := 0
+		close := -1
+		for i := idx + len(tok) - 1; i < len(b); i++ {
+			if b[i] == '(' {
+				depth++
+			} else if b[i] == ')' {
+				depth--
+				if depth == 0 {
+					close = i
+					break
+				}
+			}
+		}
+		if close < 0 {
+			continue
+		}
+		// last top-level comma inside the wrapper
+		depth = 0
+		comma := -1
+		for i := idx + len(tok); i < close; i++ {
+			switch b[i] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			case ',':
+				if depth == 0 {
+					comma = i
+				}
+			}
+		}
+		for i := idx; i < idx+len(tok); i++ {
+			b[i] = ' '
+		}
+		from := comma
+		if from < 0 {
+			from = close
+		}
+		for i := from; i <= close; i++ {
+			if b[i] != '\n' {
+				b[i] = ' '
+			}
+		}
+	}
+	return string(b)
+}
+
+// typedefs maps a typedef name -> the underlying type text.
+var typedefs = map[string]string{}
+
+// enums holds the set of names that are enum tags.
+var enumNames = map[string]bool{}
+
+func collectTypedefs(src string) {
+	// typedef int32_t llama_pos;   /  typedef struct x * y;   / typedef enum {...} name;
+	s := src
+	for i := 0; i < len(s); {
+		j := strings.Index(s[i:], "typedef")
+		if j < 0 {
+			break
+		}
+		j += i
+		// find the terminating ';' at brace depth 0
+		depth := 0
+		k := j
+		for ; k < len(s); k++ {
+			switch s[k] {
+			case '{':
+				depth++
+			case '}':
+				depth--
+			case ';':
+				if depth == 0 {
+					goto done
+				}
+			}
+		}
+	done:
+		if k >= len(s) {
+			break
+		}
+		decl := s[j:k]
+		i = k + 1
+		// remove any {...} body
+		if a := strings.Index(decl, "{"); a >= 0 {
+			b := strings.LastIndex(decl, "}")
+			if b > a {
+				decl = decl[:a] + " " + decl[b+1:]
+			}
+		}
+		decl = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(decl), "typedef"))
+		decl = strings.Join(strings.Fields(decl), " ")
+		if decl == "" || strings.Contains(decl, "(") {
+			// function-pointer typedef -> pointer
+			// name is inside (*name)
+			a := strings.Index(decl, "(*")
+			if a >= 0 {
+				rest := decl[a+2:]
+				b := strings.Index(rest, ")")
+				if b > 0 {
+					typedefs[strings.TrimSpace(rest[:b])] = "void *"
+				}
+			}
+			continue
+		}
+		fields := strings.Fields(decl)
+		if len(fields) < 2 {
+			continue
+		}
+		name := fields[len(fields)-1]
+		under := strings.Join(fields[:len(fields)-1], " ")
+		// handle "typedef struct foo * bar" -> name=bar under="struct foo *"
+		name = strings.TrimPrefix(name, "*")
+		if strings.HasPrefix(fields[len(fields)-1], "*") {
+			under += " *"
+		}
+		if name != "" {
+			typedefs[name] = strings.TrimSpace(under)
+		}
+	}
+}
+
+// baseTypes maps a fully-resolved scalar C type spelling to kind+size (arm64/LP64).
+var baseTypes = map[string]struct {
+	k Kind
+	s int
+}{
+	"void":               {KindVoid, 0},
+	"bool":               {KindUint, 1},
+	"_Bool":              {KindUint, 1},
+	"char":               {KindSint, 1},
+	"signed char":        {KindSint, 1},
+	"unsigned char":      {KindUint, 1},
+	"short":              {KindSint, 2},
+	"unsigned short":     {KindUint, 2},
+	"int":                {KindSint, 4},
+	"unsigned":           {KindUint, 4},
+	"unsigned int":       {KindUint, 4},
+	"long":               {KindSint, 8},
+	"unsigned long":      {KindUint, 8},
+	"long long":          {KindSint, 8},
+	"unsigned long long": {KindUint, 8},
+	"float":              {KindFloat, 4},
+	"double":             {KindDouble, 8},
+	"int8_t":             {KindSint, 1},
+	"uint8_t":            {KindUint, 1},
+	"int16_t":            {KindSint, 2},
+	"uint16_t":           {KindUint, 2},
+	"int32_t":            {KindSint, 4},
+	"uint32_t":           {KindUint, 4},
+	"int64_t":            {KindSint, 8},
+	"uint64_t":           {KindUint, 8},
+	"size_t":             {KindUint, 8},
+	"ssize_t":            {KindSint, 8},
+	"ptrdiff_t":          {KindSint, 8},
+	"intptr_t":           {KindSint, 8},
+	"uintptr_t":          {KindUint, 8},
+	"time_t":             {KindSint, 8},
+	"FILE":               {KindStruct, -1},
+}
+
+// classify resolves a C type text (no declarator name) to kind+size.
+func classify(t string) (Kind, int) {
+	t = strings.TrimSpace(t)
+	t = strings.ReplaceAll(t, "const", " ")
+	t = strings.ReplaceAll(t, "volatile", " ")
+	t = strings.ReplaceAll(t, "restrict", " ")
+	t = strings.Join(strings.Fields(t), " ")
+	if strings.Contains(t, "*") || strings.Contains(t, "[") {
+		return KindPointer, 8
+	}
+	if t == "" {
+		return KindUnknown, -1
+	}
+	// enum X -> 4 bytes (C enums in llama.h/ggml.h all fit in int)
+	if strings.HasPrefix(t, "enum ") {
+		return KindSint, 4
+	}
+	if strings.HasPrefix(t, "struct ") || strings.HasPrefix(t, "union ") {
+		return KindStruct, -1
+	}
+	if bt, ok := baseTypes[t]; ok {
+		return bt.k, bt.s
+	}
+	// resolve typedefs (bounded depth)
+	seen := map[string]bool{}
+	cur := t
+	for i := 0; i < 12; i++ {
+		u, ok := typedefs[cur]
+		if !ok || seen[cur] {
+			break
+		}
+		seen[cur] = true
+		u = strings.Join(strings.Fields(strings.ReplaceAll(u, "const", " ")), " ")
+		if strings.Contains(u, "*") {
+			return KindPointer, 8
+		}
+		if strings.HasPrefix(u, "enum") {
+			return KindSint, 4
+		}
+		if strings.HasPrefix(u, "struct") || strings.HasPrefix(u, "union") {
+			return KindStruct, -1
+		}
+		if bt, ok := baseTypes[u]; ok {
+			return bt.k, bt.s
+		}
+		cur = u
+	}
+	if enumNames[t] {
+		return KindSint, 4
+	}
+	return KindUnknown, -1
+}
+
+// splitTop splits s on top-level commas (respecting parens).
+func splitTop(s string) []string {
+	var out []string
+	depth := 0
+	last := 0
+	for i, c := range s {
+		switch c {
+		case '(', '[':
+			depth++
+		case ')', ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, s[last:i])
+				last = i + 1
+			}
+		}
+	}
+	out = append(out, s[last:])
+	return out
+}
+
+// stripDeclName removes the parameter name from a declaration like "const char * path".
+func stripDeclName(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return p
+	}
+	// array declarator: "int32_t buf[]" -> pointer
+	if i := strings.Index(p, "["); i >= 0 {
+		p = p[:i] + "*"
+	}
+	if strings.Contains(p, "(*") {
+		return "void *"
+	}
+	f := strings.Fields(p)
+	if len(f) == 0 {
+		return p
+	}
+	last := f[len(f)-1]
+	if last == "*" || last == "**" || strings.HasSuffix(last, "*") && strings.Trim(last, "*") == "" {
+		return p // no name, e.g. "const char *"
+	}
+	// last token is either the name, or "*name"
+	if strings.HasPrefix(last, "*") {
+		stars := len(last) - len(strings.TrimLeft(last, "*"))
+		return strings.Join(f[:len(f)-1], " ") + " " + strings.Repeat("*", stars)
+	}
+	// if it is a known single-word type with no other tokens (e.g. "void", "int"), keep it
+	if len(f) == 1 {
+		return p
+	}
+	// "unsigned int" style with no name? handled by baseTypes lookups after dropping last
+	cand := strings.Join(f[:len(f)-1], " ")
+	if _, ok := baseTypes[strings.Join(f, " ")]; ok {
+		return strings.Join(f, " ")
+	}
+	if strings.HasSuffix(cand, "*") {
+		return cand
+	}
+	return cand
+}
+
+func parseHeader(path, apiMacro string) ([]CFunc, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	src := unwrapDeprecated(stripComments(string(raw)))
+	collectTypedefs(src)
+	// collect enum tag names: "enum llama_foo {"
+	for _, m := range findAll(src, "enum ") {
+		rest := src[m+5:]
+		f := strings.Fields(rest)
+		if len(f) > 0 {
+			enumNames[strings.TrimSuffix(f[0], "{")] = true
+		}
+	}
+
+	var out []CFunc
+	for _, idx := range findAll(src, apiMacro) {
+		// must be a token boundary
+		if idx > 0 && isIdentChar(src[idx-1]) {
+			continue
+		}
+		after := idx + len(apiMacro)
+		if after < len(src) && isIdentChar(src[after]) {
+			continue
+		}
+		// find ';' at paren depth 0
+		depth := 0
+		end := -1
+		for k := after; k < len(src); k++ {
+			switch src[k] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			case ';':
+				if depth == 0 {
+					end = k
+				}
+			case '{':
+				if depth == 0 {
+					end = -2
+				}
+			}
+			if end != -1 {
+				break
+			}
+		}
+		if end < 0 {
+			continue
+		}
+		decl := src[after:end]
+		line := 1 + strings.Count(src[:idx], "\n")
+		fn, ok := parseDecl(decl)
+		if !ok {
+			out = append(out, CFunc{Name: "", File: path, Line: line, Raw: squash(decl)})
+			continue
+		}
+		fn.File = path
+		fn.Line = line
+		fn.Raw = squash(decl)
+		out = append(out, fn)
+	}
+	return out, nil
+}
+
+func squash(s string) string { return strings.Join(strings.Fields(s), " ") }
+
+func isIdentChar(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+func findAll(s, sub string) []int {
+	var out []int
+	for i := 0; ; {
+		j := strings.Index(s[i:], sub)
+		if j < 0 {
+			return out
+		}
+		out = append(out, i+j)
+		i += j + len(sub)
+	}
+}
+
+func parseDecl(decl string) (CFunc, bool) {
+	var fn CFunc
+	// find first top-level '('
+	open := -1
+	for i := 0; i < len(decl); i++ {
+		if decl[i] == '(' {
+			open = i
+			break
+		}
+	}
+	if open < 0 {
+		return fn, false
+	}
+	// matching close
+	depth := 0
+	close := -1
+	for i := open; i < len(decl); i++ {
+		if decl[i] == '(' {
+			depth++
+		} else if decl[i] == ')' {
+			depth--
+			if depth == 0 {
+				close = i
+				break
+			}
+		}
+	}
+	if close < 0 {
+		return fn, false
+	}
+	head := strings.TrimSpace(decl[:open])
+	f := strings.Fields(head)
+	if len(f) < 2 {
+		return fn, false
+	}
+	name := f[len(f)-1]
+	if strings.HasPrefix(name, "*") {
+		// "const char *llama_x" style
+		fn.Name = strings.TrimLeft(name, "*")
+		fn.RetRaw = strings.Join(f[:len(f)-1], " ") + " " + strings.Repeat("*", len(name)-len(strings.TrimLeft(name, "*")))
+	} else {
+		fn.Name = name
+		fn.RetRaw = strings.Join(f[:len(f)-1], " ")
+	}
+	if fn.Name == "" || !isIdentChar(fn.Name[0]) {
+		return fn, false
+	}
+	fn.RetKind, fn.RetSize = classify(fn.RetRaw)
+	body := strings.TrimSpace(decl[open+1 : close])
+	if body != "" && body != "void" {
+		for _, p := range splitTop(body) {
+			ps := strings.TrimSpace(p)
+			if ps == "..." {
+				fn.Vararg = true
+				continue
+			}
+			norm := stripDeclName(ps)
+			k, sz := classify(norm)
+			fn.Params = append(fn.Params, CParam{Raw: squash(ps), Norm: squash(norm), Kind: k, Size: sz})
+		}
+	}
+	return fn, true
+}
+
+func (f CFunc) Sig() string {
+	var ps []string
+	for _, p := range f.Params {
+		ps = append(ps, fmt.Sprintf("%s{%s/%d}", p.Norm, p.Kind, p.Size))
+	}
+	return fmt.Sprintf("%s{%s/%d} %s(%s)", f.RetRaw, f.RetKind, f.RetSize, f.Name, strings.Join(ps, ", "))
+}

--- a/cmd/yzma-checker/cstruct.go
+++ b/cmd/yzma-checker/cstruct.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// CField is one member of a C struct.
+type CField struct {
+	Name string
+	Norm string
+	Kind Kind
+	Size int
+	Cnt  int // array count (1 for scalars)
+}
+
+// CStruct is a parsed C struct definition.
+type CStruct struct {
+	Name   string
+	Fields []CField
+	Size   int // -1 if not computable
+	Align  int
+}
+
+var cstructs = map[string]*CStruct{}
+
+// resetCTypes clears the C parser's accumulated state so that more than one
+// audit can run in a single process (the self-test does exactly that).
+func resetCTypes() {
+	clear(cstructs)
+	clear(typedefs)
+	clear(enumNames)
+}
+
+// collectStructs parses "struct NAME { ... };" definitions out of a header.
+func collectStructs(src string) {
+	for _, idx := range findAll(src, "struct ") {
+		if idx > 0 && isIdentChar(src[idx-1]) {
+			continue
+		}
+		rest := src[idx+len("struct "):]
+		f := strings.Fields(rest)
+		if len(f) < 2 {
+			continue
+		}
+		name := f[0]
+		if !strings.HasPrefix(strings.TrimSpace(rest[len(name):]), "{") {
+			continue
+		}
+		open := strings.Index(rest, "{")
+		depth := 0
+		end := -1
+		for i := open; i < len(rest); i++ {
+			if rest[i] == '{' {
+				depth++
+			} else if rest[i] == '}' {
+				depth--
+				if depth == 0 {
+					end = i
+					break
+				}
+			}
+		}
+		if end < 0 {
+			continue
+		}
+		body := rest[open+1 : end]
+		cs := &CStruct{Name: name}
+		for _, stmt := range strings.Split(body, ";") {
+			stmt = strings.TrimSpace(stmt)
+			if stmt == "" {
+				continue
+			}
+			if strings.Contains(stmt, "(") && !strings.Contains(stmt, "(*") {
+				continue // method-ish / macro
+			}
+			// possible comma-separated declarators: "int32_t a, b;"
+			parts := splitTop(stmt)
+			base := ""
+			for pi, p := range parts {
+				p = strings.TrimSpace(p)
+				if p == "" {
+					continue
+				}
+				decl := p
+				if pi > 0 && base != "" {
+					decl = base + " " + p
+				}
+				fname, norm, cnt := splitField(decl)
+				if pi == 0 {
+					base = fieldBaseType(decl)
+				}
+				k, sz := classify(norm)
+				cs.Fields = append(cs.Fields, CField{Name: fname, Norm: squash(norm), Kind: k, Size: sz, Cnt: cnt})
+			}
+		}
+		computeStructSize(cs)
+		if _, exists := cstructs[name]; !exists {
+			cstructs[name] = cs
+		}
+	}
+}
+
+func fieldBaseType(decl string) string {
+	f := strings.Fields(decl)
+	if len(f) < 2 {
+		return ""
+	}
+	return strings.Join(f[:len(f)-1], " ")
+}
+
+// splitField returns (name, normalisedType, arrayCount).
+func splitField(decl string) (string, string, int) {
+	decl = strings.TrimSpace(decl)
+	cnt := 1
+	if i := strings.Index(decl, "["); i >= 0 {
+		j := strings.Index(decl, "]")
+		if j > i {
+			n, err := strconv.Atoi(strings.TrimSpace(decl[i+1 : j]))
+			if err == nil {
+				cnt = n
+			} else {
+				cnt = -1
+			}
+		}
+		decl = decl[:i]
+	}
+	f := strings.Fields(decl)
+	if len(f) == 0 {
+		return "", "", cnt
+	}
+	last := f[len(f)-1]
+	name := strings.TrimLeft(last, "*")
+	stars := len(last) - len(name)
+	norm := strings.Join(f[:len(f)-1], " ")
+	if stars > 0 {
+		norm += " " + strings.Repeat("*", stars)
+	}
+	if norm == "" {
+		norm = decl
+		name = ""
+	}
+	return name, norm, cnt
+}
+
+func computeStructSize(cs *CStruct) {
+	off := 0
+	maxAlign := 1
+	for _, f := range cs.Fields {
+		if f.Size <= 0 || f.Cnt <= 0 {
+			if f.Kind == KindStruct {
+				if sub, ok := cstructs[strings.TrimPrefix(f.Norm, "struct ")]; ok && sub.Size > 0 {
+					al := sub.Align
+					if off%al != 0 {
+						off += al - off%al
+					}
+					off += sub.Size * f.Cnt
+					if al > maxAlign {
+						maxAlign = al
+					}
+					continue
+				}
+			}
+			cs.Size = -1
+			cs.Align = -1
+			return
+		}
+		al := f.Size
+		if al > 8 {
+			al = 8
+		}
+		if off%al != 0 {
+			off += al - off%al
+		}
+		off += f.Size * f.Cnt
+		if al > maxAlign {
+			maxAlign = al
+		}
+	}
+	if off%maxAlign != 0 {
+		off += maxAlign - off%maxAlign
+	}
+	cs.Size = off
+	cs.Align = maxAlign
+}
+
+// cTypeSize resolves a possibly-struct C type text to a byte size (-1 unknown).
+func cTypeSize(norm string) int {
+	k, sz := classify(norm)
+	if k != KindStruct {
+		return sz
+	}
+	n := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(strings.ReplaceAll(norm, "const", "")), "struct"))
+	if cs, ok := cstructs[strings.TrimSpace(n)]; ok {
+		return cs.Size
+	}
+	// maybe a typedef to a struct
+	if u, ok := typedefs[strings.TrimSpace(n)]; ok {
+		un := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(u), "struct"))
+		if cs, ok := cstructs[un]; ok {
+			return cs.Size
+		}
+	}
+	return -1
+}

--- a/cmd/yzma-checker/go.mod
+++ b/cmd/yzma-checker/go.mod
@@ -1,0 +1,15 @@
+// This is a NESTED module on purpose.
+//
+// Keeping its own go.mod means the golang.org/x/tools dependency never reaches
+// the root yzma module, and `go build ./...` / `go vet ./...` / `go test ./...`
+// at the yzma repo root skip this directory entirely.
+module github.com/hybridgroup/yzma/cmd/yzma-checker
+
+go 1.26
+
+require golang.org/x/tools v0.48.0
+
+require (
+	golang.org/x/mod v0.38.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
+)

--- a/cmd/yzma-checker/go.sum
+++ b/cmd/yzma-checker/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
+golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.48.0 h1:3+hClM1aLL5mjMKm5ovokw9epgRXPuu2tILgismM6RE=
+golang.org/x/tools v0.48.0/go.mod h1:08xX0orndb/F7jJxGDicx061tyd5pcMto75YMAXr6lk=

--- a/cmd/yzma-checker/goside.go
+++ b/cmd/yzma-checker/goside.go
@@ -1,0 +1,476 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// FfiType is a resolved libffi type descriptor.
+type FfiType struct {
+	Name  string // e.g. TypeUint64, or the Go var name for struct descriptors
+	Kind  Kind
+	Size  int
+	Elems []FfiType // for structs
+}
+
+func (t FfiType) String() string { return fmt.Sprintf("%s{%s/%d}", t.Name, t.Kind, t.Size) }
+
+var ffiScalars = map[string]FfiType{
+	"TypeVoid":       {"TypeVoid", KindVoid, 0, nil},
+	"TypeUint8":      {"TypeUint8", KindUint, 1, nil},
+	"TypeSint8":      {"TypeSint8", KindSint, 1, nil},
+	"TypeUint16":     {"TypeUint16", KindUint, 2, nil},
+	"TypeSint16":     {"TypeSint16", KindSint, 2, nil},
+	"TypeUint32":     {"TypeUint32", KindUint, 4, nil},
+	"TypeSint32":     {"TypeSint32", KindSint, 4, nil},
+	"TypeUint64":     {"TypeUint64", KindUint, 8, nil},
+	"TypeSint64":     {"TypeSint64", KindSint, 8, nil},
+	"TypeFloat":      {"TypeFloat", KindFloat, 4, nil},
+	"TypeDouble":     {"TypeDouble", KindDouble, 8, nil},
+	"TypePointer":    {"TypePointer", KindPointer, 8, nil},
+	"TypeLongdouble": {"TypeLongdouble", KindUnknown, 16, nil},
+}
+
+// Binding is one yzma ffi.Fun: its Prep spec plus every Call site.
+type Binding struct {
+	GoVar   string // Go package-level var name
+	CName   string // C symbol
+	PrepPos token.Position
+	Ret     FfiType
+	Args    []FfiType
+	NFixed  int  // for PrepVar
+	Variadi bool //
+	Calls   []CallSite
+	Pkg     string
+}
+
+// CallSite is one <var>.Call(...) invocation.
+type CallSite struct {
+	Pos     token.Position
+	Fn      string // enclosing Go func
+	RetExpr string
+	RetType types.Type // pointee type of the return buffer, nil if untrackable
+	RetNil  bool
+	Args    []CallArg
+}
+
+// CallArg is one avalue slot at a call site.
+type CallArg struct {
+	Expr    string
+	Pointee types.Type // the Go type libffi will read bytes from
+	Size    int        // -1 if unknown
+	Kind    Kind
+	Note    string
+}
+
+var arm64Sizes = types.SizesFor("gc", "arm64")
+
+func goKindOf(t types.Type) (Kind, int) {
+	if t == nil {
+		return KindUnknown, -1
+	}
+	sz := int(arm64Sizes.Sizeof(t))
+	u := t.Underlying()
+	switch b := u.(type) {
+	case *types.Basic:
+		switch {
+		case b.Info()&types.IsUnsigned != 0:
+			if b.Kind() == types.Uintptr || b.Kind() == types.UnsafePointer {
+				return KindPointer, sz
+			}
+			return KindUint, sz
+		case b.Info()&types.IsInteger != 0:
+			return KindSint, sz
+		case b.Kind() == types.Float32:
+			return KindFloat, sz
+		case b.Kind() == types.Float64:
+			return KindDouble, sz
+		case b.Kind() == types.Bool:
+			return KindUint, sz
+		case b.Kind() == types.UnsafePointer:
+			return KindPointer, sz
+		}
+	case *types.Pointer, *types.Signature, *types.Map, *types.Chan:
+		return KindPointer, sz
+	case *types.Struct:
+		return KindStruct, sz
+	case *types.Slice, *types.Interface:
+		return KindUnknown, sz
+	}
+	return KindUnknown, sz
+}
+
+type analyzer struct {
+	pkg      *packages.Package
+	fset     *token.FileSet
+	ffiAlias map[string]FfiType // package-level Go vars that alias an ffi.Type
+	bindings map[string]*Binding
+	order    []string
+}
+
+func loadPkgs(dir string, patterns ...string) ([]*packages.Package, error) {
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports,
+		Dir: dir,
+	}
+	pkgs, err := packages.Load(cfg, patterns...)
+	if err != nil {
+		return nil, err
+	}
+	return pkgs, nil
+}
+
+// resolveTypeExpr resolves an expression appearing in a Prep type list.
+// Accepted forms: &ffi.TypeX, &localVar, ffi.NewType(...), &someStructTypeVar.
+func (a *analyzer) resolveTypeExpr(e ast.Expr) FfiType {
+	switch x := e.(type) {
+	case *ast.UnaryExpr:
+		if x.Op == token.AND {
+			return a.resolveTypeExpr(x.X)
+		}
+	case *ast.SelectorExpr:
+		if id, ok := x.X.(*ast.Ident); ok && id.Name == "ffi" {
+			if t, ok := ffiScalars[x.Sel.Name]; ok {
+				return t
+			}
+			return FfiType{Name: "ffi." + x.Sel.Name, Kind: KindUnknown, Size: -1}
+		}
+	case *ast.Ident:
+		if t, ok := a.ffiAlias[x.Name]; ok {
+			return t
+		}
+		return FfiType{Name: x.Name + "(unresolved)", Kind: KindUnknown, Size: -1}
+	case *ast.CallExpr:
+		if sel, ok := x.Fun.(*ast.SelectorExpr); ok {
+			if id, ok := sel.X.(*ast.Ident); ok && id.Name == "ffi" && sel.Sel.Name == "NewType" {
+				return a.buildStruct("anon", x.Args)
+			}
+		}
+	}
+	return FfiType{Name: exprStr(e), Kind: KindUnknown, Size: -1}
+}
+
+// buildStruct computes the libffi/C aggregate size of an ffi.NewType(...) descriptor.
+func (a *analyzer) buildStruct(name string, args []ast.Expr) FfiType {
+	st := FfiType{Name: name, Kind: KindStruct}
+	maxAlign := 1
+	off := 0
+	ok := true
+	for _, e := range args {
+		el := a.resolveTypeExpr(e)
+		st.Elems = append(st.Elems, el)
+		if el.Size <= 0 && el.Kind != KindVoid {
+			ok = false
+			continue
+		}
+		al := el.Size
+		if el.Kind == KindStruct {
+			al = structAlign(el)
+		}
+		if al > 8 {
+			al = 16
+		}
+		if al > maxAlign {
+			maxAlign = al
+		}
+		if off%al != 0 {
+			off += al - off%al
+		}
+		off += el.Size
+	}
+	if !ok {
+		st.Size = -1
+		return st
+	}
+	if off%maxAlign != 0 {
+		off += maxAlign - off%maxAlign
+	}
+	st.Size = off
+	return st
+}
+
+func structAlign(t FfiType) int {
+	if t.Kind != KindStruct {
+		if t.Size > 8 {
+			return 16
+		}
+		return t.Size
+	}
+	m := 1
+	for _, e := range t.Elems {
+		a := structAlign(e)
+		if a > m {
+			m = a
+		}
+	}
+	return m
+}
+
+func exprStr(e ast.Expr) string {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name
+	case *ast.SelectorExpr:
+		return exprStr(x.X) + "." + x.Sel.Name
+	case *ast.UnaryExpr:
+		return x.Op.String() + exprStr(x.X)
+	case *ast.CallExpr:
+		var as []string
+		for _, a := range x.Args {
+			as = append(as, exprStr(a))
+		}
+		return exprStr(x.Fun) + "(" + strings.Join(as, ", ") + ")"
+	case *ast.IndexExpr:
+		return exprStr(x.X) + "[" + exprStr(x.Index) + "]"
+	case *ast.BasicLit:
+		return x.Value
+	case *ast.StarExpr:
+		return "*" + exprStr(x.X)
+	case *ast.ParenExpr:
+		return "(" + exprStr(x.X) + ")"
+	case *ast.CompositeLit:
+		return "composite{...}"
+	case *ast.SliceExpr:
+		return exprStr(x.X) + "[:]"
+	}
+	return fmt.Sprintf("%T", e)
+}
+
+// pointeeOf figures out the Go type whose bytes libffi will read for an
+// argument expression passed to Fun.Call.
+func (a *analyzer) pointeeOf(e ast.Expr) (types.Type, string) {
+	// unwrap unsafe.Pointer(x) conversions
+	for {
+		ce, ok := e.(*ast.CallExpr)
+		if !ok || len(ce.Args) != 1 {
+			break
+		}
+		if sel, ok := ce.Fun.(*ast.SelectorExpr); ok {
+			if id, ok := sel.X.(*ast.Ident); ok && id.Name == "unsafe" && sel.Sel.Name == "Pointer" {
+				e = ce.Args[0]
+				continue
+			}
+		}
+		break
+	}
+	if id, ok := e.(*ast.Ident); ok && id.Name == "nil" {
+		return nil, "nil"
+	}
+	t := a.pkg.TypesInfo.TypeOf(e)
+	if t == nil {
+		return nil, "no type info"
+	}
+	if p, ok := t.Underlying().(*types.Pointer); ok {
+		return p.Elem(), ""
+	}
+	if b, ok := t.Underlying().(*types.Basic); ok && b.Kind() == types.UnsafePointer {
+		return nil, "opaque unsafe.Pointer"
+	}
+	if b, ok := t.Underlying().(*types.Basic); ok && b.Kind() == types.Uintptr {
+		return nil, "uintptr (not addressable)"
+	}
+	return nil, "non-pointer " + t.String()
+}
+
+func (a *analyzer) run() {
+	a.ffiAlias = map[string]FfiType{}
+	// pass 1: package-level vars that alias ffi types
+	for _, f := range a.pkg.Syntax {
+		for _, d := range f.Decls {
+			gd, ok := d.(*ast.GenDecl)
+			if !ok || gd.Tok != token.VAR {
+				continue
+			}
+			for _, s := range gd.Specs {
+				vs := s.(*ast.ValueSpec)
+				for i, n := range vs.Names {
+					if i >= len(vs.Values) {
+						continue
+					}
+					v := vs.Values[i]
+					switch x := v.(type) {
+					case *ast.SelectorExpr:
+						if id, ok := x.X.(*ast.Ident); ok && id.Name == "ffi" {
+							if t, ok := ffiScalars[x.Sel.Name]; ok {
+								a.ffiAlias[n.Name] = t
+							}
+						}
+					case *ast.CallExpr:
+						if sel, ok := x.Fun.(*ast.SelectorExpr); ok {
+							if id, ok := sel.X.(*ast.Ident); ok && id.Name == "ffi" && sel.Sel.Name == "NewType" {
+								a.ffiAlias[n.Name] = a.buildStruct(n.Name, x.Args)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	// second resolution pass so aliases referring to other aliases settle
+	for i := 0; i < 3; i++ {
+		for _, f := range a.pkg.Syntax {
+			for _, d := range f.Decls {
+				gd, ok := d.(*ast.GenDecl)
+				if !ok || gd.Tok != token.VAR {
+					continue
+				}
+				for _, s := range gd.Specs {
+					vs := s.(*ast.ValueSpec)
+					for i, n := range vs.Names {
+						if i >= len(vs.Values) {
+							continue
+						}
+						if ce, ok := vs.Values[i].(*ast.CallExpr); ok {
+							if sel, ok := ce.Fun.(*ast.SelectorExpr); ok {
+								if id, ok := sel.X.(*ast.Ident); ok && id.Name == "ffi" && sel.Sel.Name == "NewType" {
+									a.ffiAlias[n.Name] = a.buildStruct(n.Name, ce.Args)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	a.bindings = map[string]*Binding{}
+
+	// pass 2: Prep calls
+	for _, f := range a.pkg.Syntax {
+		ast.Inspect(f, func(n ast.Node) bool {
+			var lhs []ast.Expr
+			var rhs ast.Expr
+			switch x := n.(type) {
+			case *ast.AssignStmt:
+				if len(x.Rhs) == 1 {
+					lhs, rhs = x.Lhs, x.Rhs[0]
+				}
+			default:
+				return true
+			}
+			ce, ok := rhs.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := ce.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			variadic := false
+			nfixed := -1
+			var typeArgs []ast.Expr
+			var nameArg ast.Expr
+			switch sel.Sel.Name {
+			case "Prep", "MustPrep":
+				if len(ce.Args) < 2 {
+					return true
+				}
+				nameArg = ce.Args[0]
+				typeArgs = ce.Args[1:]
+			case "PrepVar", "MustPrepVar":
+				if len(ce.Args) < 3 {
+					return true
+				}
+				variadic = true
+				nameArg = ce.Args[0]
+				if bl, ok := ce.Args[1].(*ast.BasicLit); ok {
+					nfixed, _ = strconv.Atoi(bl.Value)
+				}
+				typeArgs = ce.Args[2:]
+			default:
+				return true
+			}
+			// receiver must be ffi.Lib
+			rt := a.pkg.TypesInfo.TypeOf(sel.X)
+			if rt == nil || !strings.HasSuffix(rt.String(), "ffi.Lib") {
+				return true
+			}
+			bl, ok := nameArg.(*ast.BasicLit)
+			if !ok {
+				return true
+			}
+			cname, _ := strconv.Unquote(bl.Value)
+			// LHS var name (first, skipping err)
+			govar := ""
+			for _, l := range lhs {
+				if id, ok := l.(*ast.Ident); ok && id.Name != "err" && id.Name != "_" {
+					govar = id.Name
+					break
+				}
+			}
+			if govar == "" {
+				govar = cname
+			}
+			b := &Binding{
+				GoVar:   govar,
+				CName:   cname,
+				PrepPos: a.fset.Position(ce.Lparen),
+				Ret:     a.resolveTypeExpr(typeArgs[0]),
+				NFixed:  nfixed,
+				Variadi: variadic,
+				Pkg:     a.pkg.PkgPath,
+			}
+			for _, ta := range typeArgs[1:] {
+				b.Args = append(b.Args, a.resolveTypeExpr(ta))
+			}
+			if _, dup := a.bindings[govar]; !dup {
+				a.order = append(a.order, govar)
+			}
+			a.bindings[govar] = b
+			return true
+		})
+	}
+
+	// pass 3: Call sites
+	for _, f := range a.pkg.Syntax {
+		var curFn string
+		ast.Inspect(f, func(n ast.Node) bool {
+			if fd, ok := n.(*ast.FuncDecl); ok {
+				curFn = fd.Name.Name
+			}
+			ce, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := ce.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Call" {
+				return true
+			}
+			id, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			b, ok := a.bindings[id.Name]
+			if !ok {
+				return true
+			}
+			cs := CallSite{Pos: a.fset.Position(ce.Lparen), Fn: curFn}
+			if len(ce.Args) > 0 {
+				cs.RetExpr = exprStr(ce.Args[0])
+				pt, note := a.pointeeOf(ce.Args[0])
+				cs.RetType = pt
+				if note == "nil" {
+					cs.RetNil = true
+				}
+			}
+			for _, ae := range ce.Args[1:] {
+				pt, note := a.pointeeOf(ae)
+				k, sz := goKindOf(pt)
+				if pt == nil {
+					sz = -1
+					k = KindUnknown
+				}
+				cs.Args = append(cs.Args, CallArg{Expr: exprStr(ae), Pointee: pt, Size: sz, Kind: k, Note: note})
+			}
+			b.Calls = append(b.Calls, cs)
+			return true
+		})
+	}
+}

--- a/cmd/yzma-checker/main.go
+++ b/cmd/yzma-checker/main.go
@@ -1,0 +1,511 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var (
+	yzmaDir  = flag.String("yzma", "", "yzma tree to audit (default: walk up for a yzma checkout, else `go list -m`)")
+	llamaCpp = flag.String("llama", "", "llama.cpp git checkout to read headers from (default: fetch them from upstream)")
+	ref      = flag.String("ref", "auto", `llama.cpp git ref to audit against; "auto" resolves the current llama-cpp-builder release`)
+	hdrDir   = flag.String("hdrs", "", "use pre-extracted headers from this dir instead of git or the network")
+	pkgs     = flag.String("pkgs", yzmaModulePath+"/pkg/llama,"+yzmaModulePath+"/pkg/mtmd",
+		"comma-separated package patterns to audit")
+	verbose = flag.Bool("v", false, "dump every binding with its C signature and call sites")
+)
+
+var skips []string
+
+func noteSkip(format string, a ...any) { skips = append(skips, fmt.Sprintf(format, a...)) }
+
+var structCmp []string
+
+type violation struct {
+	Rule     int
+	Fn       string
+	GoFile   string
+	Detail   string
+	Severity string
+}
+
+func main() {
+	flag.Parse()
+
+	yzmaSrc := "-yzma"
+	if *yzmaDir == "" {
+		dir, src, err := findYzmaRoot()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+
+		*yzmaDir, yzmaSrc = dir, src
+	}
+
+	gitRef, refSrc := *ref, "-ref"
+	if gitRef == "auto" {
+		r, err := resolveRef()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+
+		gitRef, refSrc = r, "current llama-cpp-builder release"
+	}
+
+	headers, hdrSrc, cleanup, err := obtainHeaders(*hdrDir, *llamaCpp, gitRef)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot obtain headers: %v\n", err)
+		os.Exit(2)
+	}
+	defer cleanup()
+
+	*hdrDir = headers
+
+	fmt.Printf("yzma:   %s (%s)\n", *yzmaDir, yzmaSrc)
+	fmt.Printf("ref:    %s (%s)\n", gitRef, refSrc)
+	fmt.Printf("hdrs:   %s\n          %s\n\n", *hdrDir, hdrSrc)
+
+	rep, err := analyse(*yzmaDir, *hdrDir, strings.Split(*pkgs, ","))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	printReport(rep)
+
+	if len(rep.Viols) > 0 {
+		os.Exit(1)
+	}
+}
+
+// report is everything one audit produced. The accounting fields matter as
+// much as Viols: they are what makes "these are the only ones" a measurement
+// rather than an assertion.
+type report struct {
+	Viols      []violation
+	Bindings   []*Binding
+	CFuncs     map[string]CFunc
+	NoC        []string
+	Unresolved []string
+	Skips      []string
+	StructCmp  []string
+
+	TotalDecls, Unparsed            int
+	Matched, NCalls                 int
+	CheckedR1, CheckedR2, CheckedR3 int
+	CleanR1, CleanR2, CleanR3       int
+}
+
+// analyse runs the three rules over the packages named by patterns in the
+// module rooted at yzmaRoot, against the headers in headerDir.
+func analyse(yzmaRoot, headerDir string, patterns []string) (*report, error) {
+	// Parser state is package-level and iterated to a fixpoint, so reset it
+	// to keep repeated calls within one process independent.
+	skips, structCmp = nil, nil
+	resetCTypes()
+
+	// --- C side ---
+	cfuncs := map[string]CFunc{}
+	unparsed := 0
+	totalDecls := 0
+	macros := []string{"LLAMA_API", "GGML_API", "GGML_BACKEND_API", "MTMD_API"}
+	for _, hf := range headerFiles {
+		path := filepath.Join(headerDir, hf.local)
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "SKIP header %s: %v\n", path, err)
+			continue
+		}
+		src := unwrapDeprecated(stripComments(string(raw)))
+		collectTypedefs(src)
+		collectStructs(src)
+		var fns []CFunc
+		for _, mc := range macros {
+			mf, err := parseHeader(path, mc)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "parse %s: %v\n", path, err)
+				continue
+			}
+			fns = append(fns, mf...)
+		}
+		for _, f := range fns {
+			totalDecls++
+			if f.Name == "" {
+				unparsed++
+				fmt.Fprintf(os.Stderr, "UNPARSED %s:%d %s\n", filepath.Base(f.File), f.Line, f.Raw)
+				continue
+			}
+			if _, dup := cfuncs[f.Name]; !dup {
+				cfuncs[f.Name] = f
+			}
+		}
+	}
+	// Second pass: headers are parsed in sequence, so a struct in llama.h can
+	// reference a typedef that only appears in ggml-backend.h. Re-classify every
+	// field now that every typedef and struct is known, then re-lay-out.
+	for pass := 0; pass < 4; pass++ {
+		for _, cs := range cstructs {
+			for i := range cs.Fields {
+				cs.Fields[i].Kind, cs.Fields[i].Size = classify(cs.Fields[i].Norm)
+			}
+			computeStructSize(cs)
+		}
+	}
+	// re-classify now that all typedefs/structs are known
+	for n, f := range cfuncs {
+		f.RetKind, f.RetSize = classify(f.RetRaw)
+		for i := range f.Params {
+			f.Params[i].Kind, f.Params[i].Size = classify(f.Params[i].Norm)
+		}
+		cfuncs[n] = f
+	}
+
+	// --- Go side ---
+	loaded, err := loadPkgs(yzmaRoot, patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("load %s: %w", strings.Join(patterns, ", "), err)
+	}
+	var all []*Binding
+	for _, p := range loaded {
+		if len(p.Errors) > 0 {
+			for _, e := range p.Errors {
+				fmt.Fprintf(os.Stderr, "pkgerr %s: %v\n", p.PkgPath, e)
+			}
+		}
+		if p.Syntax == nil {
+			continue
+		}
+		a := &analyzer{pkg: p, fset: p.Fset}
+		a.run()
+		for _, k := range a.order {
+			all = append(all, a.bindings[k])
+		}
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].PrepPos.Filename != all[j].PrepPos.Filename {
+			return all[i].PrepPos.Filename < all[j].PrepPos.Filename
+		}
+		return all[i].PrepPos.Line < all[j].PrepPos.Line
+	})
+
+	var viols []violation
+	matched, noC, checkedR1, checkedR2, checkedR3 := 0, 0, 0, 0, 0
+	cleanR1, cleanR2, cleanR3 := 0, 0, 0
+	var noCList []string
+	nCalls := 0
+	unresolvedArgs := 0
+	var unresolvedList []string
+
+	for _, b := range all {
+		short := shortPos(b.PrepPos)
+		cf, ok := cfuncs[b.CName]
+		if !ok {
+			noC++
+			noCList = append(noCList, fmt.Sprintf("%s (%s)", b.CName, short))
+		} else {
+			matched++
+		}
+
+		// ---------- Rule 1: cif vs C prototype ----------
+		if ok {
+			checkedR1++
+			var probs []string
+			if !cf.Vararg && len(b.Args) != len(cf.Params) {
+				probs = append(probs, fmt.Sprintf("arity: cif has %d args, C has %d", len(b.Args), len(cf.Params)))
+			}
+			// return type
+			if p := cmpTypes(b.Ret, cf.RetRaw, cf.RetKind, cf.RetSize, "ret"); p != "" {
+				probs = append(probs, p)
+			}
+			n := len(b.Args)
+			if n > len(cf.Params) {
+				n = len(cf.Params)
+			}
+			for i := 0; i < n; i++ {
+				if p := cmpTypes(b.Args[i], cf.Params[i].Norm, cf.Params[i].Kind, cf.Params[i].Size, fmt.Sprintf("arg%d", i)); p != "" {
+					probs = append(probs, p)
+				}
+			}
+			if len(probs) > 0 {
+				viols = append(viols, violation{1, b.CName, short, strings.Join(probs, "; "), sev(probs)})
+			} else {
+				cleanR1++
+			}
+		}
+
+		// ---------- Rules 2 & 3: call sites ----------
+		for _, cs := range b.Calls {
+			nCalls++
+			csp := shortPos(cs.Pos)
+			// Rule 3: return buffer
+			checkedR3++
+			r3 := checkRet(b.Ret, cs)
+			if strings.HasPrefix(r3, "SKIP: ") {
+				noteSkip("RULE3 %s (%s): %s", b.CName, csp, strings.TrimPrefix(r3, "SKIP: "))
+				r3 = ""
+			}
+			if r3 != "" {
+				viols = append(viols, violation{3, b.CName, csp, r3 + " [in " + cs.Fn + "]", "latent-corruption"})
+			} else {
+				cleanR3++
+			}
+			// Rule 2: argument widths
+			var probs []string
+			na := len(cs.Args)
+			if na != len(b.Args) && !b.Variadi {
+				probs = append(probs, fmt.Sprintf("call passes %d avalues, cif expects %d (runtime panic)", na, len(b.Args)))
+			}
+			m := na
+			if len(b.Args) < m {
+				m = len(b.Args)
+			}
+			for i := 0; i < m; i++ {
+				ca, ct := cs.Args[i], b.Args[i]
+				if ca.Pointee == nil {
+					unresolvedArgs++
+					unresolvedList = append(unresolvedList,
+						fmt.Sprintf("%s arg%d %s: %s (%s)", b.CName, i, ca.Expr, ca.Note, csp))
+					continue
+				}
+				checkedR2++
+				if ct.Size <= 0 && ct.Kind != KindVoid {
+					noteSkip("RULE2 %s arg%d: cif descriptor %s size unknown - NOT VERIFIED", b.CName, i, ct.Name)
+					continue
+				}
+				if ca.Size != ct.Size {
+					probs = append(probs, fmt.Sprintf("arg%d: cif %s wants %dB, Go %s is %dB (%s)",
+						i, ct.Name, ct.Size, ca.Pointee.String(), ca.Size, ca.Expr))
+					continue
+				}
+				if !kindCompat(ct.Kind, ca.Kind) {
+					probs = append(probs, fmt.Sprintf("arg%d: cif kind %s vs Go kind %s (%s / %s)",
+						i, ct.Kind, ca.Kind, ca.Expr, ca.Pointee.String()))
+				}
+				cleanR2++
+			}
+			if len(probs) > 0 {
+				viols = append(viols, violation{2, b.CName, csp, strings.Join(probs, "; ") + " [in " + cs.Fn + "]", "memory-read-overrun"})
+			}
+		}
+		if *verbose {
+			fmt.Printf("BINDING %-45s %s\n  cif ret=%s args=%v\n", b.CName, short, b.Ret, b.Args)
+			if ok {
+				fmt.Printf("  C   %s:%d %s\n", filepath.Base(cf.File), cf.Line, cf.Sig())
+			} else {
+				fmt.Printf("  C   <NOT FOUND IN HEADERS>\n")
+			}
+			for _, cs := range b.Calls {
+				fmt.Printf("  call %s ret=%s args=%v\n", shortPos(cs.Pos), cs.RetExpr, argSummary(cs.Args))
+			}
+		}
+	}
+
+	sort.SliceStable(viols, func(i, j int) bool { return viols[i].Rule < viols[j].Rule })
+
+	return &report{
+		Viols:      viols,
+		Bindings:   all,
+		CFuncs:     cfuncs,
+		NoC:        noCList,
+		Unresolved: unresolvedList,
+		Skips:      skips,
+		StructCmp:  structCmp,
+		TotalDecls: totalDecls,
+		Unparsed:   unparsed,
+		Matched:    matched,
+		NCalls:     nCalls,
+		CheckedR1:  checkedR1,
+		CheckedR2:  checkedR2,
+		CheckedR3:  checkedR3,
+		CleanR1:    cleanR1,
+		CleanR2:    cleanR2,
+		CleanR3:    cleanR3,
+	}, nil
+}
+
+func printReport(r *report) {
+	fmt.Println("================ VIOLATIONS ================")
+	for _, v := range r.Viols {
+		fmt.Printf("RULE%d %-14s %-42s %s\n        %s\n", v.Rule, v.Severity, v.Fn, v.GoFile, v.Detail)
+	}
+	fmt.Println("================ UNRESOLVED ARG EXPRS ================")
+	for _, u := range r.Unresolved {
+		fmt.Println("  ", u)
+	}
+	fmt.Println("================ BINDINGS WITH NO C DECL ================")
+	for _, u := range r.NoC {
+		fmt.Println("  ", u)
+	}
+	fmt.Println("================ NOT VERIFIED (skips) ================")
+	for _, k := range r.Skips {
+		fmt.Println("  ", k)
+	}
+	fmt.Printf("(%d skips)\n", len(r.Skips))
+	fmt.Println("================ STRUCT-BY-VALUE COMPARISONS ================")
+	for _, k := range r.StructCmp {
+		fmt.Println("  ", k)
+	}
+	fmt.Printf("(%d struct-by-value slots compared)\n", len(r.StructCmp))
+	fmt.Println("================ SUMMARY ================")
+	fmt.Printf("C declarations found:      %d (unparsed: %d)\n", r.TotalDecls, r.Unparsed)
+	fmt.Printf("distinct C functions:      %d\n", len(r.CFuncs))
+	fmt.Printf("yzma bindings (Prep):      %d\n", len(r.Bindings))
+	fmt.Printf("  matched to a C decl:     %d\n", r.Matched)
+	fmt.Printf("  no C decl in headers:    %d\n", len(r.NoC))
+	fmt.Printf("Call sites analysed:       %d\n", r.NCalls)
+	fmt.Printf("Rule1 checked/clean:       %d / %d\n", r.CheckedR1, r.CleanR1)
+	fmt.Printf("Rule2 arg slots checked:   %d / %d clean (unresolvable exprs: %d)\n", r.CheckedR2, r.CleanR2, len(r.Unresolved))
+	fmt.Printf("Rule3 return bufs checked: %d / %d clean\n", r.CheckedR3, r.CleanR3)
+	nr := map[int]int{}
+	for _, v := range r.Viols {
+		nr[v.Rule]++
+	}
+	fmt.Printf("violations: rule1=%d rule2=%d rule3=%d\n", nr[1], nr[2], nr[3])
+}
+
+func argSummary(as []CallArg) string {
+	var s []string
+	for _, a := range as {
+		if a.Pointee == nil {
+			s = append(s, a.Expr+"=?"+a.Note)
+		} else {
+			s = append(s, fmt.Sprintf("%s:%s/%dB", a.Expr, a.Pointee.String(), a.Size))
+		}
+	}
+	return strings.Join(s, ", ")
+}
+
+func sev(p []string) string {
+	for _, s := range p {
+		if strings.Contains(s, "arity") {
+			return "ABI-BREAK"
+		}
+	}
+	return "type-mismatch"
+}
+
+// cmpTypes compares a cif descriptor against the C type it must model.
+func cmpTypes(t FfiType, cRaw string, cKind Kind, cSize int, slot string) string {
+	if cKind == KindStruct {
+		cSize = cTypeSize(cRaw)
+		if cSize < 0 {
+			noteSkip("%s: C struct %q size unknown - NOT VERIFIED", slot, squash(cRaw))
+			return ""
+		}
+		if t.Kind != KindStruct {
+			return fmt.Sprintf("%s: C passes struct %s (%dB) by value but cif says %s", slot, squash(cRaw), cSize, t.Name)
+		}
+		structCmp = append(structCmp, fmt.Sprintf("%s %s: cif %s=%dB vs C %s=%dB", slot, "structcmp", t.Name, t.Size, squash(cRaw), cSize))
+		if t.Size >= 0 && t.Size != cSize {
+			return fmt.Sprintf("%s: struct descriptor %s is %dB, C %s is %dB", slot, t.Name, t.Size, squash(cRaw), cSize)
+		}
+		return ""
+	}
+	if cKind == KindUnknown || cSize < 0 {
+		noteSkip("%s: C type %q unclassifiable - NOT VERIFIED", slot, squash(cRaw))
+		return ""
+	}
+	if t.Size < 0 {
+		noteSkip("%s: cif descriptor %q size unknown - NOT VERIFIED", slot, t.Name)
+		return ""
+	}
+	if cKind == KindVoid {
+		if t.Kind != KindVoid {
+			return fmt.Sprintf("%s: C returns void but cif says %s", slot, t.Name)
+		}
+		return ""
+	}
+	if t.Kind == KindVoid {
+		return fmt.Sprintf("%s: C is %s (%s/%dB) but cif says TypeVoid", slot, squash(cRaw), cKind, cSize)
+	}
+	if t.Size != cSize {
+		return fmt.Sprintf("%s: C %s is %dB but cif %s is %dB", slot, squash(cRaw), cSize, t.Name, t.Size)
+	}
+	if !kindCompat(t.Kind, cKind) {
+		return fmt.Sprintf("%s: C %s is %s but cif %s is %s", slot, squash(cRaw), cKind, t.Name, t.Kind)
+	}
+	return ""
+}
+
+// kindCompat: same-width integer signedness is ABI-identical on arm64, so only
+// flag cross-class confusion (int vs float vs pointer vs struct).
+func kindCompat(a, b Kind) bool {
+	cls := func(k Kind) int {
+		switch k {
+		case KindSint, KindUint:
+			return 1
+		case KindPointer:
+			return 1 // pointer and 8-byte int are ABI-identical in integer regs
+		case KindFloat, KindDouble:
+			return 2
+		case KindStruct:
+			return 3
+		case KindVoid:
+			return 4
+		}
+		return 0
+	}
+	ca, cb := cls(a), cls(b)
+	if ca == 0 || cb == 0 {
+		return true
+	}
+	return ca == cb
+}
+
+// checkRet implements Rule 3.
+func checkRet(ret FfiType, cs CallSite) string {
+	switch ret.Kind {
+	case KindVoid:
+		if !cs.RetNil && cs.RetExpr != "" {
+			return fmt.Sprintf("cif return type is TypeVoid but call passes a return buffer %q: libffi writes nothing, the Go variable keeps its zero value", cs.RetExpr)
+		}
+		return ""
+	case KindSint, KindUint, KindPointer:
+		if cs.RetNil || cs.RetExpr == "" {
+			return "" // discarding a value is safe
+		}
+		if cs.RetType == nil {
+			return "SKIP: integer return buffer " + cs.RetExpr + " type not resolvable"
+		}
+		_, sz := goKindOf(cs.RetType)
+		if sz < 8 {
+			return fmt.Sprintf("integer return buffer %s is %s (%dB); libffi always stores a full 8-byte ffi_arg, overwriting %d adjacent byte(s) - must be ffi.Arg",
+				cs.RetExpr, cs.RetType.String(), sz, 8-sz)
+		}
+		return ""
+	case KindFloat, KindDouble:
+		if cs.RetNil || cs.RetType == nil {
+			return ""
+		}
+		k, sz := goKindOf(cs.RetType)
+		if ret.Kind == KindFloat && (k != KindFloat || sz != 4) {
+			return fmt.Sprintf("float return buffer %s is %s (%dB); must be float32 (ffi.Arg is WRONG for floats)", cs.RetExpr, cs.RetType.String(), sz)
+		}
+		if ret.Kind == KindDouble && (k != KindDouble || sz != 8) {
+			return fmt.Sprintf("double return buffer %s is %s; must be float64", cs.RetExpr, cs.RetType.String())
+		}
+		return ""
+	case KindStruct:
+		if cs.RetNil || cs.RetType == nil || ret.Size < 0 {
+			return ""
+		}
+		_, sz := goKindOf(cs.RetType)
+		if sz != ret.Size {
+			return fmt.Sprintf("struct return buffer %s is %s (%dB) but cif struct descriptor %s is %dB", cs.RetExpr, cs.RetType.String(), sz, ret.Name, ret.Size)
+		}
+		return ""
+	}
+	return ""
+}
+
+func shortPos(p token.Position) string {
+	d := filepath.Base(filepath.Dir(p.Filename))
+	return fmt.Sprintf("%s/%s:%d", d, filepath.Base(p.Filename), p.Line)
+}

--- a/cmd/yzma-checker/main_test.go
+++ b/cmd/yzma-checker/main_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The checker's own correctness gate.
+//
+// It used to be "a run must re-derive these two live defects in yzma", which
+// stopped working the moment the defects were fixed: a tool that reports
+// nothing is indistinguishable from a tool that checks nothing. Instead the
+// gate now runs the full pipeline over testdata/fixture, a miniature binding
+// package carrying one planted defect per rule per direction plus one clean
+// binding. Both halves matter — every plant must be found, and the clean
+// binding must never be reported.
+
+func fixtureReport(t *testing.T) *report {
+	t.Helper()
+
+	rep, err := analyse("testdata/fixture", "testdata/fixture/hdrs", []string{"yzma-checker-fixture/bindings"})
+	if err != nil {
+		t.Fatalf("analyse fixture: %v", err)
+	}
+
+	return rep
+}
+
+func TestFixtureFindsEveryPlantedDefect(t *testing.T) {
+	rep := fixtureReport(t)
+
+	tests := []struct {
+		name  string
+		rule  int
+		fn    string
+		match string
+	}{
+		{
+			name: "rule1 pointer return bound as void",
+			rule: 1, fn: "fx_get_thing",
+			match: "cif says TypeVoid",
+		},
+		{
+			name: "rule2 size_t slot fed a 4-byte Go value",
+			rule: 2, fn: "fx_desc",
+			match: "wants 8B, Go int32 is 4B",
+		},
+		{
+			name: "rule3 float return read through ffi.Arg",
+			rule: 3, fn: "fx_score",
+			match: "must be float32",
+		},
+		{
+			name: "rule3 integer return into a 4-byte buffer",
+			rule: 3, fn: "fx_mode_from_str",
+			match: "must be ffi.Arg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, v := range rep.Viols {
+				if v.Rule == tt.rule && v.Fn == tt.fn && strings.Contains(v.Detail, tt.match) {
+					return
+				}
+			}
+
+			t.Errorf("planted RULE%d defect in %s was not reported (want detail containing %q)\ngot:\n%s",
+				tt.rule, tt.fn, tt.match, dumpViolations(rep))
+		})
+	}
+}
+
+func TestFixtureDoesNotReportTheCleanBinding(t *testing.T) {
+	rep := fixtureReport(t)
+
+	for _, v := range rep.Viols {
+		if v.Fn == "fx_clean" {
+			t.Errorf("clean binding reported as a violation: RULE%d %s", v.Rule, v.Detail)
+		}
+	}
+
+	// Exactly the four plants, with fx_get_thing counted twice: a void return
+	// descriptor is both a wrong cif (rule 1) and a return buffer libffi never
+	// writes (rule 3), which is how the real ggml_backend_cpu_buffer_type
+	// defect presented.
+	if got, want := len(rep.Viols), 5; got != want {
+		t.Errorf("fixture produced %d violations, want %d:\n%s", got, want, dumpViolations(rep))
+	}
+}
+
+// TestFixtureAccounting guards the counters the report leans on to claim
+// coverage. A rule that silently stops checking would still print "0
+// violations", so the checked counts are part of the contract.
+func TestFixtureAccounting(t *testing.T) {
+	rep := fixtureReport(t)
+
+	if got, want := len(rep.Bindings), 5; got != want {
+		t.Errorf("bindings found = %d, want %d", got, want)
+	}
+
+	if got, want := rep.Matched, 5; got != want {
+		t.Errorf("bindings matched to a C decl = %d, want %d", got, want)
+	}
+
+	if len(rep.NoC) != 0 {
+		t.Errorf("fixture bindings with no C decl: %v", rep.NoC)
+	}
+
+	if len(rep.Unresolved) != 0 {
+		t.Errorf("unresolvable arg exprs in fixture: %v", rep.Unresolved)
+	}
+
+	if rep.Unparsed != 0 {
+		t.Errorf("unparsed C declarations = %d, want 0", rep.Unparsed)
+	}
+
+	if len(rep.Skips) != 0 {
+		t.Errorf("fixture produced %d skip(s), so its coverage is not total: %v", len(rep.Skips), rep.Skips)
+	}
+
+	if rep.CheckedR1 == 0 || rep.CheckedR2 == 0 || rep.CheckedR3 == 0 {
+		t.Errorf("a rule checked nothing: r1=%d r2=%d r3=%d", rep.CheckedR1, rep.CheckedR2, rep.CheckedR3)
+	}
+}
+
+// TestAnalyseIsRepeatable pins the parser-state reset. The C typedef, struct
+// and enum tables are package-level and iterated to a fixpoint, so a leak
+// between runs would make results depend on call order.
+func TestAnalyseIsRepeatable(t *testing.T) {
+	first := dumpViolations(fixtureReport(t))
+	second := dumpViolations(fixtureReport(t))
+
+	if first != second {
+		t.Errorf("two identical runs disagreed:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func dumpViolations(r *report) string {
+	if len(r.Viols) == 0 {
+		return "  (none)"
+	}
+
+	var b strings.Builder
+	for _, v := range r.Viols {
+		b.WriteString("  RULE")
+		b.WriteString(string(rune('0' + v.Rule)))
+		b.WriteString(" ")
+		b.WriteString(v.Fn)
+		b.WriteString(": ")
+		b.WriteString(v.Detail)
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/cmd/yzma-checker/sources.go
+++ b/cmd/yzma-checker/sources.go
@@ -1,0 +1,297 @@
+package main
+
+// Resolution of the two inputs the audit needs: the yzma tree to analyse and
+// the llama.cpp headers to analyse it against. Everything here is designed so
+// that a bare `go run .` inside a yzma checkout works with no arguments and no
+// assumptions about the surrounding filesystem.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// yzmaModulePath is the module the checker audits. A directory is accepted as
+// a yzma checkout when its go.mod declares this module.
+const yzmaModulePath = "github.com/hybridgroup/yzma"
+
+// llamaRepo is the upstream llama.cpp repository headers are fetched from when
+// no local checkout is available.
+const llamaRepo = "ggml-org/llama.cpp"
+
+// versionURLs are the endpoints yzma's own installer consults to decide which
+// llama.cpp build to download, in the order it tries them. Auditing against
+// the same ref keeps the checker aligned with the library yzma installs.
+var versionURLs = []string{
+	"https://hybridgroup.github.io/llama-cpp-builder/version.json",
+	"https://hybridgroup.github.io/llama-cpp-builder/previous.json",
+}
+
+// headerFiles maps the local basename the parser expects to the path inside
+// the llama.cpp tree. These are every header that declares a symbol yzma binds.
+var headerFiles = []struct{ local, inTree string }{
+	{"llama.h", "include/llama.h"},
+	{"ggml.h", "ggml/include/ggml.h"},
+	{"ggml-backend.h", "ggml/include/ggml-backend.h"},
+	{"ggml-cpu.h", "ggml/include/ggml-cpu.h"},
+	{"mtmd.h", "tools/mtmd/mtmd.h"},
+	{"mtmd-helper.h", "tools/mtmd/mtmd-helper.h"},
+}
+
+// findYzmaRoot locates the yzma tree to audit.
+//
+// It first walks up from the working directory and from the program's own
+// directory, which covers running inside a yzma checkout. Failing that it asks
+// the go tool which yzma the surrounding module compiles against, so the
+// checker is also usable from a consumer's repo without pointing -yzma at
+// anything by hand.
+func findYzmaRoot() (string, string, error) {
+	starts := []string{mustAbs(".")}
+	if exe, err := os.Executable(); err == nil {
+		starts = append(starts, filepath.Dir(exe))
+	}
+
+	for _, start := range starts {
+		for d := start; ; {
+			if isYzmaModule(d) {
+				return d, "checkout", nil
+			}
+
+			parent := filepath.Dir(d)
+			if parent == d {
+				break
+			}
+
+			d = parent
+		}
+	}
+
+	if dir, err := goListYzma("."); err == nil {
+		return dir, "module cache (via go list)", nil
+	}
+
+	return "", "", fmt.Errorf("cannot locate a %s checkout; pass -yzma <dir>", yzmaModulePath)
+}
+
+func isYzmaModule(dir string) bool {
+	b, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return false
+	}
+
+	for line := range strings.SplitSeq(string(b), "\n") {
+		if strings.TrimSpace(line) == "module "+yzmaModulePath {
+			return true
+		}
+	}
+
+	return false
+}
+
+// goListYzma reports the yzma module directory the module rooted at dir
+// resolves, which is the tree that actually compiles for that consumer.
+func goListYzma(dir string) (string, error) {
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", yzmaModulePath)
+	cmd.Dir = dir
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	got := strings.TrimSpace(string(out))
+	if got == "" {
+		return "", fmt.Errorf("go list -m %s returned no directory", yzmaModulePath)
+	}
+
+	return got, nil
+}
+
+// resolveRef reports the llama.cpp ref to audit against, asking the same
+// endpoints yzma's installer uses so the audit tracks the build yzma ships.
+func resolveRef() (string, error) {
+	var errs []string
+
+	for _, u := range versionURLs {
+		tag, err := fetchTag(u)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", u, err))
+			continue
+		}
+
+		return tag, nil
+	}
+
+	return "", fmt.Errorf("cannot determine the current llama.cpp release (%s); pass -ref explicitly",
+		strings.Join(errs, "; "))
+}
+
+func fetchTag(url string) (string, error) {
+	body, err := httpGet(url)
+	if err != nil {
+		return "", err
+	}
+
+	var v struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(body, &v); err != nil {
+		return "", err
+	}
+
+	if v.TagName == "" {
+		return "", fmt.Errorf("no tag_name in response")
+	}
+
+	return v.TagName, nil
+}
+
+// obtainHeaders materialises the six headers for ref into a directory and
+// reports it, along with a human-readable description of where they came from.
+//
+// Sources are tried in order of how much the caller has pinned down: an
+// explicit directory, then a local git checkout, then upstream over HTTP.
+func obtainHeaders(hdrDir, llamaDir, ref string) (dir, source string, cleanup func(), err error) {
+	noop := func() {}
+
+	if hdrDir != "" {
+		if err := checkHeaderDir(hdrDir); err != nil {
+			return "", "", noop, err
+		}
+
+		return hdrDir, "pre-extracted (-hdrs)", noop, nil
+	}
+
+	if llamaDir != "" {
+		dir, err := extractHeaders(llamaDir, ref)
+		if err != nil {
+			return "", "", noop, err
+		}
+
+		return dir, fmt.Sprintf("git show %s: in %s", ref, llamaDir), func() { os.RemoveAll(dir) }, nil
+	}
+
+	dir, cached, err := downloadHeaders(ref)
+	if err != nil {
+		return "", "", noop, fmt.Errorf("%w\n"+
+			"Pass -llama with a llama.cpp checkout or -hdrs with pre-extracted headers to work offline.", err)
+	}
+
+	src := "downloaded from " + llamaRepo + "@" + ref
+	if cached {
+		src = "cache of " + llamaRepo + "@" + ref
+	}
+
+	return dir, src, noop, nil
+}
+
+func checkHeaderDir(dir string) error {
+	var missing []string
+
+	for _, h := range headerFiles {
+		if _, err := os.Stat(filepath.Join(dir, h.local)); err != nil {
+			missing = append(missing, h.local)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("%s is missing required header(s): %s", dir, strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+// extractHeaders materialises the headers for ref out of a llama.cpp checkout
+// into a scratch dir, using `git show` so the checkout's own worktree state
+// (which may be at a different tag) is irrelevant.
+func extractHeaders(llamaDir, ref string) (string, error) {
+	if _, err := os.Stat(filepath.Join(llamaDir, ".git")); err != nil {
+		return "", fmt.Errorf("%s is not a git checkout: %w", llamaDir, err)
+	}
+
+	dir, err := os.MkdirTemp("", "yzma-checker-hdrs-")
+	if err != nil {
+		return "", err
+	}
+
+	for _, h := range headerFiles {
+		out, err := exec.Command("git", "-C", llamaDir, "show", ref+":"+h.inTree).Output()
+		if err != nil {
+			os.RemoveAll(dir)
+			return "", fmt.Errorf("git show %s:%s in %s: %w", ref, h.inTree, llamaDir, err)
+		}
+
+		if err := os.WriteFile(filepath.Join(dir, h.local), out, 0o600); err != nil {
+			os.RemoveAll(dir)
+			return "", err
+		}
+	}
+
+	return dir, nil
+}
+
+// downloadHeaders fetches the headers for ref from upstream into a persistent
+// cache, so only the first run for a given ref needs the network. It reports
+// whether the cache already held a complete set.
+func downloadHeaders(ref string) (string, bool, error) {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		base = os.TempDir()
+	}
+
+	dir := filepath.Join(base, "yzma-checker", "headers", ref)
+	if checkHeaderDir(dir) == nil {
+		return dir, true, nil
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", false, err
+	}
+
+	for _, h := range headerFiles {
+		path := filepath.Join(dir, h.local)
+		if _, err := os.Stat(path); err == nil {
+			continue
+		}
+
+		url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s", llamaRepo, ref, h.inTree)
+
+		body, err := httpGet(url)
+		if err != nil {
+			return "", false, fmt.Errorf("fetch %s: %w", url, err)
+		}
+
+		if err := os.WriteFile(path, body, 0o600); err != nil {
+			return "", false, err
+		}
+	}
+
+	return dir, false, nil
+}
+
+func httpGet(url string) ([]byte, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %s", resp.Status)
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+}
+
+func mustAbs(p string) string {
+	a, _ := filepath.Abs(p)
+	return a
+}

--- a/cmd/yzma-checker/testdata/fixture/bindings/bindings.go
+++ b/cmd/yzma-checker/testdata/fixture/bindings/bindings.go
@@ -1,0 +1,102 @@
+// Package bindings is a fixture for the checker's self-test. It is a
+// deliberately miniature imitation of yzma's binding style: package-level
+// ffi.Fun vars filled in by lib.Prep, called with unsafe.Pointer avalues.
+//
+// Four of the five bindings below are wrong, one per rule per direction, and
+// the fifth is clean. testdata is invisible to the go tool, so nothing here is
+// ever built as part of the checker.
+package bindings
+
+import (
+	"unsafe"
+
+	"github.com/jupiterrider/ffi"
+)
+
+// Mode mirrors a 4-byte enum-like Go type, as yzma's LoadMode is.
+type Mode int32
+
+var ffiTypeSize = ffi.TypeUint64
+
+var (
+	getThingFunc   ffi.Fun
+	descFunc       ffi.Fun
+	scoreFunc      ffi.Fun
+	modeFromStrFun ffi.Fun
+	cleanFunc      ffi.Fun
+)
+
+func load(lib ffi.Lib) error {
+	var err error
+
+	// RULE 1: C returns a pointer, the cif says void.
+	if getThingFunc, err = lib.Prep("fx_get_thing", &ffi.TypeVoid); err != nil {
+		return err
+	}
+
+	if descFunc, err = lib.Prep("fx_desc", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize); err != nil {
+		return err
+	}
+
+	if scoreFunc, err = lib.Prep("fx_score", &ffi.TypeFloat, &ffi.TypePointer, &ffi.TypeSint32); err != nil {
+		return err
+	}
+
+	if modeFromStrFun, err = lib.Prep("fx_mode_from_str", &ffi.TypeSint32, &ffi.TypePointer); err != nil {
+		return err
+	}
+
+	if cleanFunc, err = lib.Prep("fx_clean", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypeSint32, &ffiTypeSize); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetThing exercises RULE 1 only: the binding is void-returning, so libffi
+// writes nothing into ret.
+func GetThing() uintptr {
+	var ret uintptr
+	getThingFunc.Call(unsafe.Pointer(&ret))
+
+	return ret
+}
+
+// Desc exercises RULE 2: bLen is 4 bytes behind an 8-byte size_t slot.
+func Desc(thing uintptr) string {
+	buf := make([]byte, 128)
+	b := unsafe.SliceData(buf)
+	bLen := int32(len(buf))
+
+	var result ffi.Arg
+	descFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&thing), unsafe.Pointer(&b), &bLen)
+
+	return string(buf[:int32(result)])
+}
+
+// Score exercises RULE 3 for floats: an ffi.Arg is the wrong return buffer.
+func Score(thing uintptr, token int32) float32 {
+	var score ffi.Arg
+	scoreFunc.Call(unsafe.Pointer(&score), unsafe.Pointer(&thing), unsafe.Pointer(&token))
+
+	return float32(score)
+}
+
+// ModeFromStr exercises RULE 3 for integers: a 4-byte return buffer is
+// written past, because libffi always stores a full 8-byte ffi_arg.
+func ModeFromStr(s *byte) Mode {
+	var result Mode
+	modeFromStrFun.Call(unsafe.Pointer(&result), unsafe.Pointer(&s))
+
+	return result
+}
+
+// Clean violates nothing and must never appear in the report.
+func Clean(thing uintptr, a int32, n uint64) int32 {
+	var result ffi.Arg
+	cleanFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&thing), &a, &n)
+
+	return int32(result)
+}
+
+var _ = load

--- a/cmd/yzma-checker/testdata/fixture/go.mod
+++ b/cmd/yzma-checker/testdata/fixture/go.mod
@@ -1,0 +1,9 @@
+// Fixture module for the yzma-checker self-test. It lives under testdata so
+// the go tool never builds it as part of the checker.
+module yzma-checker-fixture
+
+go 1.26
+
+require github.com/jupiterrider/ffi v0.7.0
+
+require github.com/ebitengine/purego v0.10.0 // indirect

--- a/cmd/yzma-checker/testdata/fixture/go.sum
+++ b/cmd/yzma-checker/testdata/fixture/go.sum
@@ -1,0 +1,4 @@
+github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
+github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/jupiterrider/ffi v0.7.0 h1:RKsl6Ascal+3kyAqR5Qcbp83LceQMLc1VZbPfHWoNzs=
+github.com/jupiterrider/ffi v0.7.0/go.mod h1:9dauhpOfNqrqk28fxuu0kkdeFtT9Qr4vbfigiuIXN7c=

--- a/cmd/yzma-checker/testdata/fixture/hdrs/ggml-backend.h
+++ b/cmd/yzma-checker/testdata/fixture/hdrs/ggml-backend.h
@@ -1,0 +1,1 @@
+// intentionally empty: the fixture declares everything in llama.h

--- a/cmd/yzma-checker/testdata/fixture/hdrs/ggml-cpu.h
+++ b/cmd/yzma-checker/testdata/fixture/hdrs/ggml-cpu.h
@@ -1,0 +1,1 @@
+// intentionally empty: the fixture declares everything in llama.h

--- a/cmd/yzma-checker/testdata/fixture/hdrs/ggml.h
+++ b/cmd/yzma-checker/testdata/fixture/hdrs/ggml.h
@@ -1,0 +1,1 @@
+// intentionally empty: the fixture declares everything in llama.h

--- a/cmd/yzma-checker/testdata/fixture/hdrs/llama.h
+++ b/cmd/yzma-checker/testdata/fixture/hdrs/llama.h
@@ -1,0 +1,22 @@
+// Fixture header for the checker's self-test. Not a real llama.cpp header.
+//
+// Each declaration below exists so that a matching Go binding in
+// ../bindings/bindings.go either violates exactly one rule or is clean.
+
+// LLAMA_API is deliberately left undefined: the parser scans for the macro
+// token, so a #define line would itself be picked up as a declaration.
+
+// Pointer return. Binding it with a void return descriptor is RULE 1.
+LLAMA_API struct fx_thing * fx_get_thing(void);
+
+// size_t buf_size. Passing the address of a 4-byte Go value is RULE 2.
+LLAMA_API int32_t fx_desc(struct fx_thing * t, char * buf, size_t buf_size);
+
+// float return. Reading it through an ffi.Arg is RULE 3.
+LLAMA_API float fx_score(struct fx_thing * t, int32_t token);
+
+// int return. A 4-byte return buffer is RULE 3 in the other direction.
+LLAMA_API int fx_mode_from_str(const char * s);
+
+// Fully clean control: every width matches on both sides.
+LLAMA_API int32_t fx_clean(struct fx_thing * t, int32_t a, size_t n);

--- a/cmd/yzma-checker/testdata/fixture/hdrs/mtmd-helper.h
+++ b/cmd/yzma-checker/testdata/fixture/hdrs/mtmd-helper.h
@@ -1,0 +1,1 @@
+// intentionally empty: the fixture declares everything in llama.h

--- a/cmd/yzma-checker/testdata/fixture/hdrs/mtmd.h
+++ b/cmd/yzma-checker/testdata/fixture/hdrs/mtmd.h
@@ -1,0 +1,1 @@
+// intentionally empty: the fixture declares everything in llama.h


### PR DESCRIPTION
Checks all 265 bindings against the llama.cpp headers for the build yzma installs. purego/libffi gives no compile-time signal, so three rules are verified from the AST, with widths resolved via go/types:

1. the cif matches the C prototype, parameter for parameter
2. the Go variable is exactly as wide as the cif claims
3. return buffers match the return kind: ffi.Arg for integers and pointers, float32 for floats, nothing at all for TypeVoid

Runs with no arguments: walks up for the yzma go.mod, resolves the ref from the llama-cpp-builder endpoint the installer uses, fetches headers from ggml-org/llama.cpp into a cache. -llama and -hdrs are the offline paths. From a consumer's module root it audits the yzma that module compiles against. Exits non-zero on a violation.

Correctness gate is testdata/fixture: one planted defect per rule per direction plus a clean control. go test asserts every plant is found and the control never is. A failing go test means the run is untrustworthy.

Nested module, so golang.org/x/tools stays out of the root module.

Not covered: the 4 PrepCif/NewCallback descriptors, struct field order (only total sizes are compared), and pointer lifetime.