### PR TITLE
fix(ggml): ggml_backend_cpu_buffer_type returns a pointer, not void

### DIFF
--- a/pkg/llama/ggml_base.go
+++ b/pkg/llama/ggml_base.go
@@ -25,7 +25,7 @@ var (
 func loadGGMLBase(lib ffi.Lib) error {
 	var err error
 
-	if ggmlBackendCpuBufferType, err = lib.Prep("ggml_backend_cpu_buffer_type", &ffi.TypeVoid); err != nil {
+	if ggmlBackendCpuBufferType, err = lib.Prep("ggml_backend_cpu_buffer_type", &ffi.TypePointer); err != nil {
 		return loadError("ggml_backend_cpu_buffer_type", err)
 	}
 


### PR DESCRIPTION
ggml_backend_cpu_buffer_type` is prepped with a void return type, so libffi never writes a return value and `GGMLBackendCpuBufferType()` always returns `0` — on every platform, regardless of which backends are registered.

The C signature, quoted in the comment directly above the declaration, is:

```c
GGML_API ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void);
```

but the binding declares:

```go
lib.Prep("ggml_backend_cpu_buffer_type", &ffi.TypeVoid)
```

Every other pointer-returning binding in the package uses `&ffi.TypePointer` (`ggml_backend_dev_get`, `ggml_backend_dev_by_type`, `ggml_backend_reg_get`, `ggml_backend_dev_name`, ...). `&ffi.TypeVoid` is used for genuinely void functions such as `ggml_backend_dev_memory`, `ggml_backend_load_all`, and `ggml_backend_unload`. This appears to be the only such mismatch in the package — I scanned all 192 `Prep` call sites against their documented C signatures and this was the single one.

### Verification

I called the C function directly via `ctypes` against ggml 0.12.0 to confirm the zero does not come from ggml:

```
dev_count BEFORE      : 0
cpu_buffer_type BEFORE: 125802164252992   <- valid non-NULL pointer
ggml_backend_load(cascadelake) -> ...
dev_count AFTER       : 1
cpu_buffer_type AFTER : 125802164252992
```

The function returns a valid pointer even before any backend is registered, so the zero originates in the binding.

### Impact

`buildExpertOffloadOverrides`-style code cannot construct a `TensorBuftOverride`, which makes MoE expert offload to the CPU backend (llama.cpp `--cpu-moe` / `--n-cpu-moe`) unusable through yzma. Any caller that checks the result for `0` fails closed; any caller that does not will pass a NULL buffer type into `llama_model_params`.

Fix is one word: `&ffi.TypeVoid` -> `&ffi.TypePointer`.