### PR TITLE
llama: address the FFI type-contract review follow-ups

### DIFF
--- a/pkg/llama/batch.go
+++ b/pkg/llama/batch.go
@@ -1,10 +1,28 @@
 package llama
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 
 	"github.com/jupiterrider/ffi"
+)
+
+// Errors reported by [Batch.Add] and [Batch.SetLogit]. They are distinguished so
+// a caller can tell an expected condition (a full batch, which just means it is
+// time to decode) from a programming error, without matching on message text.
+var (
+	// ErrBatchFull means the batch already holds its allocated n_tokens.
+	ErrBatchFull = errors.New("batch is full")
+	// ErrTooManySeqIDs means more sequence IDs were given than the n_seq_max
+	// the batch was allocated with.
+	ErrTooManySeqIDs = errors.New("too many sequence IDs for batch")
+	// ErrBatchNotWritable means the batch owns no writable arrays: it is the
+	// zero value, came from [BatchGetOne], or is an embedding batch whose
+	// token array was never allocated.
+	ErrBatchNotWritable = errors.New("batch owns no writable token arrays")
+	// ErrBatchIndexRange means the index does not address a token in the batch.
+	ErrBatchIndexRange = errors.New("batch index out of range")
 )
 
 var (
@@ -56,16 +74,21 @@ func loadBatchFuncs(lib ffi.Lib) error {
 // All members are left uninitialized.
 func BatchInit(nTokens int32, embd int32, nSeqMax int32) Batch {
 	var batch Batch
-	batchInitFunc.Call(unsafe.Pointer(&batch), &nTokens, &embd, &nSeqMax)
+	batchInitFunc.Call(unsafe.Pointer(&batch.BatchData), &nTokens, &embd, &nSeqMax)
 	batch.capTokens = nTokens
 	batch.capSeq = nSeqMax
+
+	// llama.cpp zeroes n_tokens here, but llama.h documents the members as
+	// left uninitialized. Add and SetLogit bound themselves against NTokens,
+	// so it is set explicitly rather than relying on that.
+	batch.NTokens = 0
 
 	return batch
 }
 
 // BatchFree frees a Batch of tokens allocated with BatchInit.
 func BatchFree(batch Batch) error {
-	batchFreeFunc.Call(nil, unsafe.Pointer(&batch))
+	batchFreeFunc.Call(nil, unsafe.Pointer(&batch.BatchData))
 
 	return nil
 }
@@ -73,6 +96,12 @@ func BatchFree(batch Batch) error {
 // BatchGetOne returns Batch for single sequence of tokens.
 // The sequence ID will be fixed to 0.
 // The position of the tokens will be tracked automatically by [Decode].
+//
+// The returned batch borrows the caller's tokens and owns no writable arrays of
+// its own: llama_batch_get_one leaves pos, n_seq_id, seq_id and logits NULL. It
+// can be passed to [Decode] or [Encode], but [Batch.Add] and [Batch.SetLogit]
+// report [ErrBatchNotWritable] on it. Use [BatchInit] for a batch you intend to
+// fill in yourself.
 func BatchGetOne(tokens []Token) Batch {
 	var batch Batch
 	if len(tokens) == 0 {
@@ -81,7 +110,7 @@ func BatchGetOne(tokens []Token) Batch {
 	toks := unsafe.SliceData(tokens)
 	nTokens := int32(len(tokens))
 
-	batchGetOneFunc.Call(unsafe.Pointer(&batch), unsafe.Pointer(&toks), &nTokens)
+	batchGetOneFunc.Call(unsafe.Pointer(&batch.BatchData), unsafe.Pointer(&toks), &nTokens)
 
 	return batch
 }
@@ -93,12 +122,29 @@ func (b *Batch) Clear() error {
 	return nil
 }
 
+// writable reports whether the batch owns the arrays Add and SetLogit write to.
+// A zero Batch and one from [BatchGetOne] do not, and llama_batch_init leaves
+// token NULL when it was asked for an embedding batch, so each pointer has to be
+// checked rather than inferred from capTokens alone.
+func (b *Batch) writable() bool {
+	return b.capTokens > 0 &&
+		b.Token != nil && b.Pos != nil && b.NSeqId != nil && b.SeqId != nil && b.Logits != nil
+}
+
 // SetLogit sets whether to compute logits for the token at index idx in the batch.
-// It returns an error if idx is outside the batch capacity to avoid writing past
-// the C-allocated array.
+//
+// idx must address a token already in the batch, that is, it must be less than
+// NTokens. llama_decode only reads logit flags over [0, n_tokens), so a flag set
+// beyond that would be silently dropped rather than honoured; the tighter bound
+// reports the caller's index error instead. Writes are also confined to the
+// C-allocated array, which is what makes the bound a safety property and not
+// just a diagnostic.
 func (b *Batch) SetLogit(idx int32, logits bool) error {
-	if idx < 0 || idx >= b.capTokens {
-		return fmt.Errorf("llama: SetLogit index %d out of range [0,%d)", idx, b.capTokens)
+	if !b.writable() {
+		return ErrBatchNotWritable
+	}
+	if idx < 0 || idx >= b.NTokens {
+		return fmt.Errorf("%w: index %d not in [0,%d)", ErrBatchIndexRange, idx, b.NTokens)
 	}
 
 	logitPtr := &unsafe.Slice((*int8)(b.Logits), int(b.capTokens))[idx]
@@ -112,16 +158,23 @@ func (b *Batch) SetLogit(idx int32, logits bool) error {
 }
 
 // Add adds a token to the batch with the given position, sequence IDs, and logits flag.
-// It returns an error (without writing) if the batch is already full or if seqIDs is
-// longer than the n_seq_max the batch was allocated with, to avoid heap corruption.
+//
+// It writes nothing and returns an error if the batch is already full
+// ([ErrBatchFull]), if seqIDs is longer than the n_seq_max the batch was
+// allocated with ([ErrTooManySeqIDs]), or if the batch owns no writable arrays
+// ([ErrBatchNotWritable]), each of which would otherwise corrupt memory.
 func (b *Batch) Add(token Token, pos Pos, seqIDs []SeqId, logits bool) error {
+	if !b.writable() {
+		return ErrBatchNotWritable
+	}
+
 	i := b.NTokens
 
 	if i < 0 || i >= b.capTokens {
-		return fmt.Errorf("llama: batch full: cannot add token at index %d (capacity %d)", i, b.capTokens)
+		return fmt.Errorf("%w: index %d, capacity %d", ErrBatchFull, i, b.capTokens)
 	}
 	if int32(len(seqIDs)) > b.capSeq {
-		return fmt.Errorf("llama: too many sequence IDs %d for token (n_seq_max %d)", len(seqIDs), b.capSeq)
+		return fmt.Errorf("%w: %d sequence IDs for a batch with n_seq_max %d", ErrTooManySeqIDs, len(seqIDs), b.capSeq)
 	}
 
 	// Set token and position
@@ -140,6 +193,8 @@ func (b *Batch) Add(token Token, pos Pos, seqIDs []SeqId, logits bool) error {
 		}
 	}
 
+	// SetLogit bounds idx against NTokens, so the count has to reflect the
+	// token just written before the flag for it can be set.
 	b.NTokens++
 
 	return b.SetLogit(i, logits)

--- a/pkg/llama/batch_test.go
+++ b/pkg/llama/batch_test.go
@@ -1,6 +1,7 @@
 package llama
 
 import (
+	"errors"
 	"testing"
 	"unsafe"
 )
@@ -150,16 +151,98 @@ func TestBatchSetLogitOutOfRange(t *testing.T) {
 	testSetup(t)
 	defer testCleanup(t)
 
-	batch := BatchInit(2, 0, 1)
+	batch := BatchInit(4, 0, 1)
 	defer BatchFree(batch)
 
-	if err := batch.SetLogit(-1, true); err == nil {
-		t.Error("SetLogit(-1) did not return an error")
+	// An empty batch has no token at any index, so every index is rejected.
+	if err := batch.SetLogit(0, true); !errors.Is(err, ErrBatchIndexRange) {
+		t.Errorf("SetLogit(0) on an empty batch = %v, want ErrBatchIndexRange", err)
 	}
-	if err := batch.SetLogit(2, true); err == nil {
-		t.Error("SetLogit at capacity did not return an error")
+
+	if err := batch.Add(1, 0, []SeqId{0}, true); err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+	if err := batch.Add(2, 1, []SeqId{0}, true); err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+
+	if err := batch.SetLogit(-1, true); !errors.Is(err, ErrBatchIndexRange) {
+		t.Errorf("SetLogit(-1) = %v, want ErrBatchIndexRange", err)
 	}
 	if err := batch.SetLogit(0, true); err != nil {
 		t.Errorf("SetLogit(0) returned error: %v", err)
+	}
+	if err := batch.SetLogit(1, true); err != nil {
+		t.Errorf("SetLogit(1) returned error: %v", err)
+	}
+
+	// Index 2 is inside the allocation but past the two tokens actually in the
+	// batch. llama_decode only reads logit flags over [0, n_tokens), so a flag
+	// set here would be dropped; it is a caller index bug, not a write to
+	// honour silently.
+	if err := batch.SetLogit(2, true); !errors.Is(err, ErrBatchIndexRange) {
+		t.Errorf("SetLogit past NTokens = %v, want ErrBatchIndexRange", err)
+	}
+	if err := batch.SetLogit(4, true); !errors.Is(err, ErrBatchIndexRange) {
+		t.Errorf("SetLogit at capacity = %v, want ErrBatchIndexRange", err)
+	}
+}
+
+// TestBatchNotWritable pins that the batches which own no writable arrays are
+// refused rather than dereferenced: llama_batch_get_one leaves pos, n_seq_id,
+// seq_id and logits NULL, and llama_batch_init leaves token NULL when it is
+// asked for an embedding batch.
+func TestBatchNotWritable(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	t.Run("zero_value", func(t *testing.T) {
+		var batch Batch
+		if err := batch.Add(1, 0, []SeqId{0}, true); !errors.Is(err, ErrBatchNotWritable) {
+			t.Errorf("Add = %v, want ErrBatchNotWritable", err)
+		}
+		if err := batch.SetLogit(0, true); !errors.Is(err, ErrBatchNotWritable) {
+			t.Errorf("SetLogit = %v, want ErrBatchNotWritable", err)
+		}
+	})
+
+	t.Run("get_one", func(t *testing.T) {
+		tokens := []Token{1, 2, 3}
+		batch := BatchGetOne(tokens)
+		if batch.NTokens != 3 {
+			t.Fatalf("BatchGetOne NTokens = %d, want 3", batch.NTokens)
+		}
+		if err := batch.Add(4, 3, []SeqId{0}, true); !errors.Is(err, ErrBatchNotWritable) {
+			t.Errorf("Add = %v, want ErrBatchNotWritable", err)
+		}
+		if err := batch.SetLogit(2, true); !errors.Is(err, ErrBatchNotWritable) {
+			t.Errorf("SetLogit = %v, want ErrBatchNotWritable", err)
+		}
+	})
+
+	t.Run("embedding_batch", func(t *testing.T) {
+		batch := BatchInit(4, 8, 1)
+		defer BatchFree(batch)
+
+		if batch.Token != nil {
+			t.Skip("llama_batch_init allocated token for an embedding batch")
+		}
+		if err := batch.Add(1, 0, []SeqId{0}, true); !errors.Is(err, ErrBatchNotWritable) {
+			t.Errorf("Add = %v, want ErrBatchNotWritable", err)
+		}
+	})
+}
+
+// TestBatchDataLayout pins the invariant the libffi descriptor depends on: the
+// struct handed to C is BatchData, and it must stay exactly the seven C fields.
+// Batch itself carries Go-only bookkeeping and is deliberately larger.
+func TestBatchDataLayout(t *testing.T) {
+	const cBatchSize = 56 // int32 + 6 pointers, LP64, with tail padding
+
+	if got := unsafe.Sizeof(BatchData{}); got != cBatchSize {
+		t.Errorf("sizeof(BatchData) = %d, want %d: it must mirror C llama_batch exactly", got, cBatchSize)
+	}
+	if got := unsafe.Offsetof(Batch{}.BatchData); got != 0 {
+		t.Errorf("BatchData is at offset %d in Batch, want 0", got)
 	}
 }

--- a/pkg/llama/context.go
+++ b/pkg/llama/context.go
@@ -374,7 +374,7 @@ func Encode(ctx Context, batch Batch) (int32, error) {
 		return 0, errInvalidContext
 	}
 	var result ffi.Arg
-	encodeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), unsafe.Pointer(&batch))
+	encodeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), unsafe.Pointer(&batch.BatchData))
 
 	return int32(result), nil
 }
@@ -385,7 +385,7 @@ func Decode(ctx Context, batch Batch) (int32, error) {
 		return 0, errInvalidContext
 	}
 	var result ffi.Arg
-	decodeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), unsafe.Pointer(&batch))
+	decodeFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), unsafe.Pointer(&batch.BatchData))
 
 	return int32(result), nil
 }

--- a/pkg/llama/context.go
+++ b/pkg/llama/context.go
@@ -13,6 +13,7 @@ var ffiTypeContextParams = ffi.NewType(
 	&ffi.TypeUint32, &ffi.TypeUint32,
 	&ffi.TypeUint32, &ffi.TypeUint32,
 	&ffi.TypeUint32, &ffi.TypeUint32,
+	&ffi.TypeUint32,
 	&ffi.TypeSint32, &ffi.TypeSint32,
 	&ffi.TypeSint32,
 	&ffi.TypeSint32, &ffi.TypeSint32,

--- a/pkg/llama/context_test.go
+++ b/pkg/llama/context_test.go
@@ -14,6 +14,65 @@ func TestContextDefaultParams(t *testing.T) {
 	}
 }
 
+// TestContextDefaultParamsLayout checks that the fields land where C put them.
+//
+// A field missing from the middle of ContextParams shifts everything after it
+// while leaving sizeof() unchanged, because the lost bytes are reabsorbed by the
+// alignment padding in front of the first pointer. That is what happened when
+// b10375 added n_outputs_max_per_seq: the struct stayed 160 bytes, so the FFI
+// auditor stayed green, and the only visible symptom was that PoolingType and
+// Embeddings quietly stopped taking effect. Ranges rather than exact values, so
+// an upstream default tweak does not fail this but a shifted field does.
+func TestContextDefaultParamsLayout(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	params := ContextDefaultParams()
+
+	// The uint32 block at the front. A shift here shows up as a wild n_ctx.
+	if params.NCtx == 0 || params.NCtx > 1<<22 {
+		t.Errorf("NCtx is %d, want a plausible context size", params.NCtx)
+	}
+	if params.NBatch == 0 || params.NBatch > 1<<22 {
+		t.Errorf("NBatch is %d, want a plausible batch size", params.NBatch)
+	}
+	if params.NSeqMax == 0 || params.NSeqMax > 1<<16 {
+		t.Errorf("NSeqMax is %d, want a plausible sequence count", params.NSeqMax)
+	}
+
+	// The enum block, which is what a missing uint32 in front of it displaces.
+	if params.RopeScalingType < RopeScalingTypeUnspecified || params.RopeScalingType > RopeScalingTypeMaxValue {
+		t.Errorf("RopeScalingType is %d, want a valid RopeScalingType", params.RopeScalingType)
+	}
+	if params.PoolingType < PoolingTypeUnspecified || params.PoolingType > PoolingTypeRank {
+		t.Errorf("PoolingType is %d, want a valid PoolingType", params.PoolingType)
+	}
+	if params.AttentionType < AttentionTypeUnspecified || params.AttentionType > AttentionTypeNonCausal {
+		t.Errorf("AttentionType is %d, want a valid AttentionType", params.AttentionType)
+	}
+	if params.FlashAttentionType < FlashAttentionTypeAuto || params.FlashAttentionType > FlashAttentionTypeEnabled {
+		t.Errorf("FlashAttentionType is %d, want a valid FlashAttentionType", params.FlashAttentionType)
+	}
+
+	// The trailing bool block. These are 0 or 1 in C; anything else means the
+	// booleans are being read out of a neighbouring field.
+	for _, b := range []struct {
+		name string
+		val  uint8
+	}{
+		{"Embeddings", params.Embeddings},
+		{"Offload_kqv", params.Offload_kqv},
+		{"NoPerf", params.NoPerf},
+		{"OpOffload", params.OpOffload},
+		{"SwaFull", params.SwaFull},
+		{"KVUnified", params.KVUnified},
+	} {
+		if b.val > 1 {
+			t.Errorf("%s is %d, want 0 or 1", b.name, b.val)
+		}
+	}
+}
+
 func TestInitModel(t *testing.T) {
 	modelFile := testModelFileName(t)
 

--- a/pkg/llama/draft.go
+++ b/pkg/llama/draft.go
@@ -1,6 +1,7 @@
 package llama
 
 import (
+	"fmt"
 	"unsafe"
 
 	"github.com/jupiterrider/ffi"
@@ -39,7 +40,14 @@ type DraftResult struct {
 //   - outTokens: pre-allocated output buffer for draft tokens (len >= nDraft)
 //   - outDists: pre-allocated output buffer for sparse distributions (len >= nDraft, nil for greedy)
 //
-// Returns the number of tokens drafted and the updated nPast position.
+// Returns the number of tokens drafted, the updated nPast position, and an
+// error if the batch could not be filled at all.
+//
+// A non-nil error means the batch is unusable for drafting, which is a caller
+// misconfiguration rather than a model outcome: it is not a single-token batch
+// from [BatchInit], so no draft can ever be produced from it and every call will
+// fail the same way. Reaching the end of generation, a decode failure, or nDraft
+// tokens is ordinary and reported through drafted with a nil error.
 func DraftGenerate(
 	ctx Context,
 	batch *Batch,
@@ -52,9 +60,9 @@ func DraftGenerate(
 	greedy bool,
 	outTokens []Token,
 	outDists [][]DraftCandidate,
-) (drafted int, finalPast Pos) {
+) (drafted int, finalPast Pos, err error) {
 	if ctx == 0 || sampler == 0 || nDraft <= 0 {
-		return 0, nPast
+		return 0, nPast, nil
 	}
 
 	var (
@@ -67,12 +75,15 @@ func DraftGenerate(
 	for range nDraft {
 		// Clear and add single token to batch.
 		batch.NTokens = 0
-		if err := batch.Add(lastToken, nPast, seqIDs, true); err != nil {
-			break
+		if addErr := batch.Add(lastToken, nPast, seqIDs, true); addErr != nil {
+			// The batch is the caller's, unchanged across iterations, so a
+			// failure here fails identically every time. Reporting it beats
+			// returning an empty draft that reads as "the model had nothing".
+			return drafted, nPast, fmt.Errorf("draft batch: %w", addErr)
 		}
 
 		// Decode single token.
-		decodeFunc.Call(unsafe.Pointer(&decodeResult), unsafe.Pointer(&ctx), unsafe.Pointer(batch))
+		decodeFunc.Call(unsafe.Pointer(&decodeResult), unsafe.Pointer(&ctx), unsafe.Pointer(&batch.BatchData))
 		if int32(decodeResult) != 0 {
 			break
 		}
@@ -129,5 +140,5 @@ func DraftGenerate(
 		lastToken = token
 	}
 
-	return drafted, nPast
+	return drafted, nPast, nil
 }

--- a/pkg/llama/draft_test.go
+++ b/pkg/llama/draft_test.go
@@ -1,6 +1,9 @@
 package llama
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestDraftGenerateGuards(t *testing.T) {
 	nPast := Pos(7)
@@ -22,11 +25,16 @@ func TestDraftGenerateGuards(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			batch := Batch{}
-			drafted, finalPast := DraftGenerate(
+			drafted, finalPast, err := DraftGenerate(
 				tt.ctx, &batch, Vocab(1), tt.sampler,
 				Token(1), nPast, []SeqId{0}, tt.nDraft,
 				true, outTokens, outDists,
 			)
+			// These are guard conditions, not batch failures: the loop is
+			// never entered, so there is nothing to report.
+			if err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
 			if drafted != 0 {
 				t.Fatalf("drafted = %d, want 0", drafted)
 			}
@@ -35,6 +43,26 @@ func TestDraftGenerateGuards(t *testing.T) {
 			}
 		})
 	}
+
+	// A batch that owns no writable arrays can never produce a draft, so it is
+	// reported rather than passed off as a model that generated nothing.
+	t.Run("unwritable_batch", func(t *testing.T) {
+		batch := Batch{}
+		drafted, finalPast, err := DraftGenerate(
+			Context(1), &batch, Vocab(1), Sampler(1),
+			Token(1), nPast, []SeqId{0}, 2,
+			true, outTokens, outDists,
+		)
+		if !errors.Is(err, ErrBatchNotWritable) {
+			t.Fatalf("err = %v, want ErrBatchNotWritable", err)
+		}
+		if drafted != 0 {
+			t.Fatalf("drafted = %d, want 0", drafted)
+		}
+		if finalPast != nPast {
+			t.Fatalf("finalPast = %d, want %d", finalPast, nPast)
+		}
+	})
 
 	if outTokens[0] != 111 || outTokens[1] != 222 {
 		t.Fatal("outTokens was unexpectedly modified")
@@ -84,11 +112,14 @@ func TestDraftGenerateGreedy(t *testing.T) {
 	const nDraft = 2
 	outTokens := make([]Token, nDraft)
 
-	drafted, finalPast := DraftGenerate(
+	drafted, finalPast, err := DraftGenerate(
 		ctx, &batch, vocab, sampler,
 		lastToken, nPast, []SeqId{0}, nDraft,
 		true, outTokens, nil,
 	)
+	if err != nil {
+		t.Fatalf("DraftGenerate failed: %v", err)
+	}
 
 	if drafted < 0 || drafted > nDraft {
 		t.Fatalf("drafted = %d, want 0..%d", drafted, nDraft)
@@ -154,11 +185,14 @@ func TestDraftGenerateNonGreedy(t *testing.T) {
 		outDists[i] = make([]DraftCandidate, 0, 16)
 	}
 
-	drafted, finalPast := DraftGenerate(
+	drafted, finalPast, err := DraftGenerate(
 		ctx, &batch, vocab, chain,
 		lastToken, nPast, []SeqId{0}, nDraft,
 		false, outTokens, outDists,
 	)
+	if err != nil {
+		t.Fatalf("DraftGenerate failed: %v", err)
+	}
 
 	if drafted < 0 || drafted > nDraft {
 		t.Fatalf("drafted = %d, want 0..%d", drafted, nDraft)

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -282,8 +282,15 @@ type TokenDataArray struct {
 	Sorted   uint8      // whether the array is sorted by probability (bool as uint8)
 }
 
-// Batch represents a batch of tokens or embeddings
-type Batch struct {
+// BatchData is the Go mirror of the C struct llama_batch, field for field.
+//
+// It is a separate type because its address is what crosses the libffi
+// boundary: llama_batch is passed by value to llama_encode, llama_decode and
+// llama_batch_free, and returned by value from llama_batch_init and
+// llama_batch_get_one, all against a descriptor built from exactly these seven
+// fields. Nothing may be added to it. Go-only bookkeeping belongs in the
+// enclosing [Batch], which is never handed to libffi.
+type BatchData struct {
 	NTokens int32    // number of tokens
 	Token   *Token   // tokens
 	Embd    *float32 // embeddings (if using embeddings instead of tokens)
@@ -291,10 +298,17 @@ type Batch struct {
 	NSeqId  *int32   // number of sequence IDs per token
 	SeqId   **SeqId  // sequence IDs
 	Logits  *int8    // whether to compute logits for each token
+}
+
+// Batch represents a batch of tokens to be processed by [Decode] or [Encode].
+// The C fields are promoted from the embedded [BatchData], so batch.NTokens and
+// the other members are read and written as before.
+type Batch struct {
+	BatchData
 
 	// capTokens and capSeq record the capacities passed to BatchInit so
-	// Add/SetLogit can bounds-check writes into the C arrays. They are not
-	// part of the C llama_batch struct and are appended after the FFI fields.
+	// Add/SetLogit can bounds-check writes into the C arrays. They are
+	// deliberately outside BatchData, which must stay byte-exact.
 	capTokens int32 // max tokens (n_tokens from BatchInit)
 	capSeq    int32 // max sequence IDs per token (n_seq_max from BatchInit)
 }

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -176,11 +176,12 @@ const (
 type LoadMode int32
 
 const (
-	LoadModeNone      LoadMode = 0 // no special loading mode
-	LoadModeMmap      LoadMode = 1 // memory map the model
-	LoadModeMlock     LoadMode = 2 // force system to keep model in RAM rather than swapping or compressing
-	LoadModeMmapMlock LoadMode = 3 // mmap + mlock
-	LoadModeDirectIO  LoadMode = 4 // use direct I/O if available
+	LoadModeAuto      LoadMode = -1 // auto-detect based on device capabilities
+	LoadModeNone      LoadMode = 0  // no special loading mode
+	LoadModeMmap      LoadMode = 1  // memory map the model
+	LoadModeMlock     LoadMode = 2  // force system to keep model in RAM rather than swapping or compressing
+	LoadModeMmapMlock LoadMode = 3  // mmap + mlock
+	LoadModeDirectIO  LoadMode = 4  // use direct I/O if available
 )
 
 type GpuBackend int32

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -361,6 +361,7 @@ type ContextParams struct {
 	NSeqMax            uint32             // max number of sequences
 	NRsSeq             uint32             // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
 	NOutputsMax        uint32             // max outputs in a ubatch (0 = n_batch)
+	NOutputsMaxPerSeq  uint32             // max outputs per sequence (0 = n_outputs_max)
 	NThreads           int32              // number of threads to use for generation
 	NThreadsBatch      int32              // number of threads to use for batch processing
 	CtxType            ContextType        // context type (e.g. MTP)

--- a/pkg/llama/lora.go
+++ b/pkg/llama/lora.go
@@ -123,12 +123,19 @@ func AdapterLoraFree(adapter AdapterLora) error {
 
 // AdapterMetaValStr gets metadata value as a string by key name.
 // The buffer grows as needed, so values of any length are returned in full.
+//
+// A key holding an interior NUL is rejected: it cannot be represented as a C
+// string, and passing the resulting nil pointer through to llama.cpp would be
+// dereferenced there rather than reported back.
 func AdapterMetaValStr(adapter AdapterLora, key string) (string, bool) {
 	if adapter == 0 {
 		return "", false
 	}
 
-	keyPtr, _ := utils.BytePtrFromString(key)
+	keyPtr, err := utils.BytePtrFromString(key)
+	if err != nil {
+		return "", false
+	}
 
 	return metaStr(32768, func(b *byte, bLen uint64) int32 {
 		var result ffi.Arg

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -378,6 +378,9 @@ func ModelFree(model Model) error {
 	if model == 0 {
 		return errors.New("invalid model")
 	}
+	// Drop the cached vocabulary size before the handle goes away, so a
+	// later model allocated at the same address starts from a fresh bound.
+	forgetVocabSize(ModelGetVocab(model))
 	modelFreeFunc.Call(nil, unsafe.Pointer(&model))
 	return nil
 }
@@ -760,12 +763,19 @@ func metaStr(size int, call func(b *byte, bLen uint64) int32) (string, bool) {
 // ModelMetaValStr gets metadata value as a string by key name.
 // Returns the string and true on success, or "" and false on failure.
 // The buffer grows as needed, so values of any length are returned in full.
+//
+// A key holding an interior NUL is rejected: it cannot be represented as a C
+// string, and passing the resulting nil pointer through to llama.cpp would be
+// dereferenced there rather than reported back.
 func ModelMetaValStr(model Model, key string) (string, bool) {
 	if model == 0 {
 		return "", false
 	}
 
-	keyPtr, _ := utils.BytePtrFromString(key)
+	keyPtr, err := utils.BytePtrFromString(key)
+	if err != nil {
+		return "", false
+	}
 
 	return metaStr(32768, func(b *byte, bLen uint64) int32 {
 		var result ffi.Arg

--- a/pkg/llama/model_test.go
+++ b/pkg/llama/model_test.go
@@ -76,7 +76,7 @@ func TestModelDefaultParamsLayout(t *testing.T) {
 	if params.SplitMode < SplitModeNone || params.SplitMode > SplitModeRow {
 		t.Errorf("SplitMode is %d, want a valid SplitMode", params.SplitMode)
 	}
-	if params.LoadMode < LoadModeNone || params.LoadMode > LoadModeDirectIO {
+	if params.LoadMode < LoadModeAuto || params.LoadMode > LoadModeDirectIO {
 		t.Errorf("LoadMode is %d, want a valid LoadMode", params.LoadMode)
 	}
 	if params.MainGpu < 0 {

--- a/pkg/llama/model_test.go
+++ b/pkg/llama/model_test.go
@@ -564,10 +564,13 @@ func TestModelMetaValStrByIndex(t *testing.T) {
 	}
 	t.Logf("ModelMetaValStrByIndex returned: %s", val)
 
-	// Enumerate every entry. The C side returns the would-be length, so an
-	// oversized value must be reported as a failure rather than panic on the
-	// copy or come back carrying its NUL terminator. Chat templates are the
-	// keys long enough to reach that path.
+	// Enumerate every entry, checking that each round trip is well formed and
+	// that no value comes back carrying its NUL terminator.
+	//
+	// This does not exercise the grow-and-retry path: reaching it needs a value
+	// over 32 KiB, which the small test model has none of, so these assertions
+	// hold against a truncating implementation too. TestMetaStr drives that path
+	// directly and is what pins it.
 	for i := range count {
 		key, ok := ModelMetaKeyByIndex(model, i)
 		if !ok {

--- a/pkg/llama/sampling.go
+++ b/pkg/llama/sampling.go
@@ -409,8 +409,11 @@ func SamplerInitLogitBias(nVocab int32, nLogitBias int32, logitBias *LogitBias) 
 }
 
 // SamplerInitPenalties initializes a new penalties sampler.
-// lastN is the number of last tokens to penalize, and must not be negative:
-// llama.cpp clamps negative values to 0, so resolve -1 to the context size first.
+//
+// lastN is the number of last tokens to penalize. 0 disables the penalty, and
+// so does any negative value: llama_sampler_init_penalties clamps a negative
+// penalty_last_n to 0. It is passed through unchanged rather than resolved to
+// the context size, which is what the C API means by it.
 func SamplerInitPenalties(nVocab int32, lastN int32, repeat float32, freq float32, present float32) Sampler {
 	var p Sampler
 	samplerInitPenaltiesFunc.Call(unsafe.Pointer(&p), &nVocab, &lastN, &repeat, &freq, &present)
@@ -679,9 +682,15 @@ var (
 	}
 )
 
-// resolvePenaltyLastN maps the documented -1 ("context size") value to nCtx, since
-// llama.cpp clamps any negative penalty_last_n to 0 (= penalty disabled) instead.
-func resolvePenaltyLastN(lastN, nCtx int32) int32 {
+// resolveDryPenaltyLastN maps the documented -1 ("context size") value to nCtx
+// for the DRY sampler, which is what llama.cpp's own callers do before the call.
+//
+// It deliberately does not apply to the penalties sampler. There, -1 has always
+// meant "disabled": llama_sampler_init_penalties clamps a negative
+// penalty_last_n to 0, and the header documents only "0 = disable penalty".
+// Resolving it to the context size instead would turn repetition penalties on
+// for anyone who had them off, and size a ring buffer from n_ctx_train besides.
+func resolveDryPenaltyLastN(lastN, nCtx int32) int32 {
 	if lastN < 0 {
 		return max(nCtx, 0)
 	}
@@ -731,7 +740,7 @@ func NewSampler(model Model, samplers []SamplerType, params *SamplerParams) Samp
 
 		case SamplerTypeDry:
 			dry := SamplerInitDry(vocab, params.DryMultiplier, params.DryBase, params.DryAllowedLength,
-				resolvePenaltyLastN(params.DryPenaltyLastN, nCtxTrain), params.DrySequenceBreakers)
+				resolveDryPenaltyLastN(params.DryPenaltyLastN, nCtxTrain), params.DrySequenceBreakers)
 			SamplerChainAdd(sampler, dry)
 
 		case SamplerTypeTopK:
@@ -762,7 +771,7 @@ func NewSampler(model Model, samplers []SamplerType, params *SamplerParams) Samp
 			// TODO: add implementation
 
 		case SamplerTypePenalties:
-			penalties := SamplerInitPenalties(nTokens, resolvePenaltyLastN(params.PenaltyLastN, nCtxTrain),
+			penalties := SamplerInitPenalties(nTokens, params.PenaltyLastN,
 				params.PenaltyRepeat, params.PenaltyFreq, params.PenaltyPresent)
 			SamplerChainAdd(sampler, penalties)
 
@@ -840,7 +849,7 @@ func DefaultSamplerParams() *SamplerParams {
 		DynatempRange: 0.0,
 		// controls how entropy maps to temperature in dynamic temperature sampler
 		DynatempExponent: 1.0,
-		// last n tokens to penalize (0 = disable penalty, -1 = trained context size)
+		// last n tokens to penalize (0 or negative = disable penalty)
 		PenaltyLastN: 64,
 		// 1.0 = disabled
 		PenaltyRepeat: 1.0,

--- a/pkg/llama/sampling_test.go
+++ b/pkg/llama/sampling_test.go
@@ -258,7 +258,7 @@ func TestSamplerInitDry2(t *testing.T) {
 	SamplerFree(sampler)
 }
 
-func TestResolvePenaltyLastN(t *testing.T) {
+func TestResolveDryPenaltyLastN(t *testing.T) {
 	tests := []struct {
 		lastN, nCtx, want int32
 	}{
@@ -269,8 +269,8 @@ func TestResolvePenaltyLastN(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := resolvePenaltyLastN(tt.lastN, tt.nCtx); got != tt.want {
-			t.Errorf("resolvePenaltyLastN(%d, %d) = %d, want %d", tt.lastN, tt.nCtx, got, tt.want)
+		if got := resolveDryPenaltyLastN(tt.lastN, tt.nCtx); got != tt.want {
+			t.Errorf("resolveDryPenaltyLastN(%d, %d) = %d, want %d", tt.lastN, tt.nCtx, got, tt.want)
 		}
 	}
 }
@@ -744,4 +744,44 @@ func TestSamplerGetSeed(t *testing.T) {
 		t.Errorf("SamplerGetSeed = %d, want %d", gotSeed, seed)
 	}
 	t.Logf("SamplerGetSeed returned: %d", gotSeed)
+}
+
+// TestPenaltyLastNPassedThrough pins that NewSampler hands PenaltyLastN to
+// llama.cpp unchanged. llama_sampler_init_penalties clamps a negative
+// penalty_last_n to 0, so -1 means "penalty disabled"; resolving it to the
+// trained context size instead would silently switch repetition penalties on
+// for anyone who had them off.
+func TestPenaltyLastNPassedThrough(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	modelFile := testModelFileName(t)
+	model, err := ModelLoadFromFile(modelFile, ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer ModelFree(model)
+
+	nCtxTrain := ModelNCtxTrain(model)
+	if nCtxTrain <= 0 {
+		t.Skip("model reports no trained context size")
+	}
+
+	// resolveDryPenaltyLastN is the DRY-only mapping. Applying it to the
+	// penalties sampler is what this test exists to rule out, so assert the
+	// two disagree for -1: if they ever agree, the distinction was lost.
+	if resolveDryPenaltyLastN(-1, nCtxTrain) == -1 {
+		t.Fatalf("resolveDryPenaltyLastN(-1, %d) = -1, expected it to resolve to the context size", nCtxTrain)
+	}
+
+	for _, lastN := range []int32{-1, 0, 64} {
+		params := DefaultSamplerParams()
+		params.PenaltyLastN = lastN
+
+		sampler := NewSampler(model, []SamplerType{SamplerTypePenalties}, params)
+		if sampler == Sampler(0) {
+			t.Fatalf("NewSampler returned nil for PenaltyLastN=%d", lastN)
+		}
+		SamplerFree(sampler)
+	}
 }

--- a/pkg/llama/vocab.go
+++ b/pkg/llama/vocab.go
@@ -1,6 +1,7 @@
 package llama
 
 import (
+	"sync"
 	"unsafe"
 
 	"github.com/hybridgroup/yzma/pkg/utils"
@@ -407,13 +408,43 @@ func VocabFIMSep(vocab Vocab) Token {
 	return Token(token)
 }
 
+// vocabSizes memoises llama_vocab_n_tokens per vocabulary handle.
+//
+// The size is fixed for the life of the model, while validToken sits on the
+// per-token path of every decode loop through TokenToPiece and VocabIsEOG.
+// Calling across libffi for it each time would double the boundary crossings of
+// token streaming to re-derive a constant. Entries are dropped by [ModelFree].
+var vocabSizes sync.Map // Vocab -> int32
+
+// vocabSize returns the number of tokens in the vocabulary, from cache when it
+// has been seen before. A non-positive result is not cached, so a handle that
+// was not ready yet is retried rather than pinned at zero.
+func vocabSize(vocab Vocab) int32 {
+	if n, ok := vocabSizes.Load(vocab); ok {
+		return n.(int32)
+	}
+
+	n := VocabNTokens(vocab)
+	if n > 0 {
+		vocabSizes.Store(vocab, n)
+	}
+
+	return n
+}
+
+// forgetVocabSize drops the memoised size for a vocabulary, so that a handle
+// reused by a later model cannot inherit the previous model's bound.
+func forgetVocabSize(vocab Vocab) {
+	vocabSizes.Delete(vocab)
+}
+
 // validToken reports whether the token can be looked up in the vocabulary.
 // The llama_vocab_get_* accessors resolve tokens through id_to_token.at(id),
 // which throws std::out_of_range for an unknown id. That exception cannot
 // unwind through the Go stack across libffi, so an out of range token aborts
 // the process instead of returning an error.
 func validToken(vocab Vocab, token Token) bool {
-	return vocab != 0 && token >= 0 && token < Token(VocabNTokens(vocab))
+	return vocab != 0 && token >= 0 && token < Token(vocabSize(vocab))
 }
 
 // VocabIsEOG checks if a token is an end-of-generation token in the vocabulary.


### PR DESCRIPTION
Follow-up to #282, addressing the review findings on it. Five commits, one per area.

`cmd/yzma-checker` goes from six violations on `pkg/llama` to clean:

```
Rule1 checked/clean:       265 / 265
Rule2 arg slots checked:   514 / 514 clean (unresolvable exprs: 0)
Rule3 return bufs checked: 276 / 276 clean
violations: rule1=0 rule2=0 rule3=0        (0 skips)
```

### What changed

**Batch layout and guards** (`ea43cef`). `capTokens`/`capSeq` grew the Go `Batch` to 64 bytes against a 56-byte descriptor, which is benign at runtime but left the auditor permanently red, so the next real `llama_batch` change would have read as the same noise. The C mirror moves into `BatchData`, embedded at offset 0; the C fields stay promoted. `Add`/`SetLogit` also checked indices but not the pointers they write through, so embedding batches (`token` is NULL when `embd != 0`) and `BatchGetOne` batches (`pos`/`n_seq_id`/`seq_id`/`logits` all NULL) still faulted instead of returning the promised error. `SetLogit` now bounds against `NTokens`, not the allocation — `llama_decode` only reads flags over `[0, n_tokens)`, so a flag set beyond that was dropped, not honoured.

**Draft** (`2f3fabe`). `DraftGenerate` had no error channel and swallowed the new `Add` error with a bare `break`, so an unusable batch was indistinguishable from a model that drafted nothing — on every call, forever.

**Sampling** (`bd8099f`). `resolvePenaltyLastN` mapped `-1` to `n_ctx_train` for both samplers. Correct for DRY; wrong for penalties, where llama.cpp clamps a negative `penalty_last_n` to 0 and the b10375 header documents only `0 = disable penalty`. It silently switched repetition penalties on for anyone who had them off.

**Hardening** (`6568d74`). `validToken` put an extra FFI crossing on the per-token path of every decode loop; it is now memoised per vocabulary and dropped by `ModelFree`. `ModelMetaValStr`/`AdapterMetaValStr` discarded the `BytePtrFromString` error and passed a nil `const char *` into llama.cpp. The metadata enumeration loop's claim to cover the oversized-value path is dropped — it needs a >32 KiB value the test model does not have, so it held against the truncating code too.

**LoadModeAuto** (`81c3ee4`). Not from the review: b10375 added `LLAMA_LOAD_MODE_AUTO = -1` and made it the default, failing `TestModelDefaultParamsLayout` on `main` today. Worth noting the auditor is structurally blind to this — it compares struct sizes and signatures, not enum value sets.

### Breaking

- `DraftGenerate` returns an `error`
- `Batch` embeds `BatchData` (composite literals need `Batch{BatchData: BatchData{...}}`)
- `SamplerParams.PenaltyLastN == -1` now disables the penalty rather than resolving to the trained context size

### Not included

A runtime guard for the penalties/DRY ABI break (`README` documents b10258-b10272 as unsupported, but `lib.Prep` resolves by symbol name, so a stale `.so` loads and runs with a shifted frame). There is no version API to gate on: `ggml_commit()` reports `unknown` on these builds and `ggml_version()` is a ggml semver, not a build number.

### Testing

`go test -p 1 ./pkg/...` passes except `TestGetEmbeddingsSeq`, which fails identically on `origin/main` and is untouched here. `cmd/yzma-checker`'s own fixture gate passes. Each commit builds and vets independently.
