### PR TITLE
ci: run the FFI checker in GitHub Actions

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -1,0 +1,53 @@
+name: FFI Checker
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          cache-dependency-path: |
+            go.sum
+            cmd/yzma-checker/go.sum
+      # A checker that reports nothing is the same as a checker that checks
+      # nothing. The fixture has one planted defect for each rule in each
+      # direction, and the checker must find all of them.
+      - name: Run the correctness gate
+        working-directory: cmd/yzma-checker
+        run: go test ./...
+
+  audit:
+    # If the gate fails, do not use what the audit reports.
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          cache-dependency-path: |
+            go.sum
+            cmd/yzma-checker/go.sum
+      # No arguments are necessary. The checker finds the yzma tree, gets the
+      # current llama-cpp-builder release, and then gets the headers for it.
+      # One runner is sufficient, because the checker makes the layout of each
+      # Go structure for amd64 and arm64 on all hosts.
+      - name: Audit the FFI boundary
+        working-directory: cmd/yzma-checker
+        run: go run .

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,12 @@ test:
 	export YZMA_TEST_SPLIT_MODELS="$(MODELS_DIR)/stories15M-q8_0-00001-of-00003.gguf,$(MODELS_DIR)/stories15M-q8_0-00002-of-00003.gguf,$(MODELS_DIR)/stories15M-q8_0-00003-of-00003.gguf" && \
 	go test -count=1 ./...
 
+# make check-ffi to audit the FFI bindings against the headers of the current
+# llama.cpp release. The gate runs first: if it fails, do not use what the
+# audit reports.
+check-ffi:
+	cd cmd/yzma-checker && go test ./... && go run .
+
 roadmap:
 	@echo "Checked items (have wrapper):"
 	@grep -E '^\s*[-*]\s*\[x\]' ROADMAP.md | wc -l

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -72,3 +72,13 @@ yzma install -l /path/to/lib -v b1234 -p cuda -u
 ## Other commands
 
 See the `yzma help` command for more information about the other things you can do with the `yzma` CLI tool.
+
+## `yzma-checker`
+
+The `yzma-checker` directory holds a separate developer tool, not a subcommand of the `yzma` CLI. It compares the FFI parameter and return types of each yzma binding, and the values of the constants yzma mirrors, with the llama.cpp headers. It is a nested Go module, so `go build ./...` and `go test ./...` at the repo root do not include it.
+
+```shell
+make check-ffi
+```
+
+See [yzma-checker/README.md](./yzma-checker/README.md) for what it verifies and how.

--- a/cmd/yzma-checker/README.md
+++ b/cmd/yzma-checker/README.md
@@ -37,7 +37,21 @@ out:
 The banner prints all three, so a run is self-documenting. Only the first run
 for a given ref needs the network; after that the header cache serves it.
 
-It exits non-zero when it reports a violation, so it can be wired into CI as-is.
+It exits non-zero when it reports a violation, so it can be wired into CI as-is,
+and it is: `.github/workflows/checker.yml` runs the correctness gate below and
+then this audit, on each pull request and each push to `main`. `make check-ffi`
+runs the same two steps in the same order locally.
+
+There is no schedule, because upstream drift does not wait for a pull request
+and does not need one: `llama-cpp-builder` dispatches that workflow, together
+with the three platform workflows, each time it publishes a new llama.cpp
+release. So the audit runs against a new ref when the ref appears, which is what
+a nightly schedule would be an approximation of.
+
+Note the two failure exits are different. **1** is a violation, and is a
+statement about the bindings. **2** is the audit not running at all — no yzma
+tree, no ref, no headers — which on a runner is most likely the network, and
+says nothing about the code.
 
 ### Auditing a consumer's yzma
 
@@ -1054,3 +1068,7 @@ in that derivation would be invisible here.
 This directory has its own `go.mod` so the `golang.org/x/tools` dependency never
 reaches the root yzma module. `go build ./...`, `go vet ./...` and
 `go test ./...` at the repo root skip it entirely.
+
+Which is also why the gate is its own CI job rather than part of the root test
+run: the workflow that skips this directory cannot be the one that proves the
+tool still works.


### PR DESCRIPTION
Adds `.github/workflows/checker.yml`, a `check-ffi` make target, and the
docs that make the tool findable from the repo root.

### Why

The platform workflows already run against the most recent llama.cpp, so
a break at run time is found. A shift in a constant value is not: when
llama.cpp adds an enum member, each mirrored value after it moves, both
sides still compile, each width and each offset still matches, and no
test can see it. `GGML_TYPE_COUNT` moving from 40 to 43 is that event,
and #289 is the same class one layer down.

`cmd/yzma-checker` is also a nested module, so `go test ./...` at the
repo root skips it. Its correctness gate never ran in CI.

### The two jobs

`gate` runs the fixture tests. It uses no network and does not depend on
llama.cpp, so a new release cannot make it fail. `audit` needs `gate`,
which puts in the workflow what the README already says: if the gate
fails, do not use what the audit reports.

The job is cheap. The checker needs no llama.cpp libraries, no models
and no ffmpeg. One runner is sufficient, because the checker makes the
layout of each Go structure for amd64 and arm64 on all hosts.

### No schedule

llama-cpp-builder dispatches the yzma workflows on each new llama.cpp
release, so a schedule would repeat a signal that is already there. That
job names each workflow file, so it needs one more step before the audit
runs on a release: hybridgroup/llama-cpp-builder#28.

### Verification

`make check-ffi` is clean on this branch against b10405: 265 bindings,
173 constants and 47 structure layouts compared, 0 violations, 0 skips.
