### PR TITLE
llama: bind the ggml backend device accessors for device detection

### DIFF
--- a/cmd/system.go
+++ b/cmd/system.go
@@ -43,9 +43,21 @@ func showSystemInfo(c *cli.Context) error {
 
 	for i := uint64(0); i < llama.GGMLBackendDeviceCount(); i++ {
 		device := llama.GGMLBackendDeviceGet(i)
-		deviceName := llama.GGMLBackendDeviceName(device)
+		if device == 0 {
+			continue
+		}
 
-		fmt.Printf("Device %d: %s\n", i, deviceName)
+		fmt.Printf("Device %d: %s\n", i, llama.GGMLBackendDeviceName(device))
+		fmt.Printf("  Type:        %s\n", llama.GGMLBackendDevType(device))
+		fmt.Printf("  Backend:     %s\n", llama.GGMLBackendRegName(llama.GGMLBackendDeviceBackendReg(device)))
+
+		if desc := llama.GGMLBackendDeviceDescription(device); desc != "" {
+			fmt.Printf("  Description: %s\n", desc)
+		}
+
+		if free, total := llama.GGMLBackendDeviceMemory(device); total > 0 {
+			fmt.Printf("  Memory:      free %d MiB / total %d MiB\n", free/(1024*1024), total/(1024*1024))
+		}
 	}
 
 	fmt.Println()

--- a/examples/systeminfo/main.go
+++ b/examples/systeminfo/main.go
@@ -23,9 +23,21 @@ func main() {
 
 	for i := uint64(0); i < llama.GGMLBackendDeviceCount(); i++ {
 		device := llama.GGMLBackendDeviceGet(i)
-		deviceName := llama.GGMLBackendDeviceName(device)
+		if device == 0 {
+			continue
+		}
 
-		fmt.Printf("Device %d: %s\n", i, deviceName)
+		fmt.Printf("Device %d: %s\n", i, llama.GGMLBackendDeviceName(device))
+		fmt.Printf("  Type:        %s\n", llama.GGMLBackendDevType(device))
+		fmt.Printf("  Backend:     %s\n", llama.GGMLBackendRegName(llama.GGMLBackendDeviceBackendReg(device)))
+
+		if desc := llama.GGMLBackendDeviceDescription(device); desc != "" {
+			fmt.Printf("  Description: %s\n", desc)
+		}
+
+		if free, total := llama.GGMLBackendDeviceMemory(device); total > 0 {
+			fmt.Printf("  Memory:      free %d MiB / total %d MiB\n", free/(1024*1024), total/(1024*1024))
+		}
 	}
 
 	fmt.Println()

--- a/pkg/llama/ggml.go
+++ b/pkg/llama/ggml.go
@@ -2,6 +2,7 @@ package llama
 
 import (
 	"errors"
+	"fmt"
 	"unsafe"
 
 	"github.com/hybridgroup/yzma/pkg/utils"
@@ -24,7 +25,27 @@ const (
 	GGMLBackendDeviceTypeIGPU
 	// accelerator devices intended to be used together with the CPU backend (e.g. BLAS or AMX)
 	GGMLBackendDeviceTypeACCEL
+	// "meta" device that contains several other devices for tensor parallelism
+	GGMLBackendDeviceTypeMETA
 )
+
+// String returns the name of the backend device type.
+func (t GGMLBackendDeviceType) String() string {
+	switch t {
+	case GGMLBackendDeviceTypeCPU:
+		return "CPU"
+	case GGMLBackendDeviceTypeGPU:
+		return "GPU"
+	case GGMLBackendDeviceTypeIGPU:
+		return "IGPU"
+	case GGMLBackendDeviceTypeACCEL:
+		return "ACCEL"
+	case GGMLBackendDeviceTypeMETA:
+		return "META"
+	default:
+		return fmt.Sprintf("GGMLBackendDeviceType(%d)", int32(t))
+	}
+}
 
 const (
 	// GGML_TYPE_F32

--- a/pkg/llama/ggml_base.go
+++ b/pkg/llama/ggml_base.go
@@ -20,6 +20,18 @@ var (
 
 	// GGML_API void ggml_backend_dev_memory(ggml_backend_dev_t device, size_t * free, size_t * total);
 	ggmlBackendDevMemoryFunc ffi.Fun
+
+	// GGML_API const char * ggml_backend_dev_description(ggml_backend_dev_t device);
+	ggmlBackendDevDescriptionFunc ffi.Fun
+
+	// GGML_API enum ggml_backend_dev_type ggml_backend_dev_type(ggml_backend_dev_t device);
+	ggmlBackendDevTypeFunc ffi.Fun
+
+	// GGML_API ggml_backend_reg_t ggml_backend_dev_backend_reg(ggml_backend_dev_t device);
+	ggmlBackendDevBackendRegFunc ffi.Fun
+
+	// GGML_API const char * ggml_backend_reg_name(ggml_backend_reg_t reg);
+	ggmlBackendRegNameFunc ffi.Fun
 )
 
 func loadGGMLBase(lib ffi.Lib) error {
@@ -35,6 +47,22 @@ func loadGGMLBase(lib ffi.Lib) error {
 
 	if ggmlBackendDevMemoryFunc, err = lib.Prep("ggml_backend_dev_memory", &ffi.TypeVoid, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer); err != nil {
 		return loadError("ggml_backend_dev_memory", err)
+	}
+
+	if ggmlBackendDevDescriptionFunc, err = lib.Prep("ggml_backend_dev_description", &ffi.TypePointer, &ffi.TypePointer); err != nil {
+		return loadError("ggml_backend_dev_description", err)
+	}
+
+	if ggmlBackendDevTypeFunc, err = lib.Prep("ggml_backend_dev_type", &ffi.TypeSint32, &ffi.TypePointer); err != nil {
+		return loadError("ggml_backend_dev_type", err)
+	}
+
+	if ggmlBackendDevBackendRegFunc, err = lib.Prep("ggml_backend_dev_backend_reg", &ffi.TypePointer, &ffi.TypePointer); err != nil {
+		return loadError("ggml_backend_dev_backend_reg", err)
+	}
+
+	if ggmlBackendRegNameFunc, err = lib.Prep("ggml_backend_reg_name", &ffi.TypePointer, &ffi.TypePointer); err != nil {
+		return loadError("ggml_backend_reg_name", err)
 	}
 
 	return nil
@@ -86,4 +114,55 @@ func GGMLBackendDeviceName(device GGMLBackendDevice) string {
 
 	name := utils.BytePtrToString(ret)
 	return name
+}
+
+// GGMLBackendDeviceDescription returns the description of the given backend device.
+func GGMLBackendDeviceDescription(device GGMLBackendDevice) string {
+	if device == 0 {
+		return ""
+	}
+
+	var ret *byte
+	ggmlBackendDevDescriptionFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&device))
+
+	return utils.BytePtrToString(ret)
+}
+
+// GGMLBackendDevType returns the type of the given backend device.
+// A device that is not valid gives GGMLBackendDeviceTypeCPU.
+func GGMLBackendDevType(device GGMLBackendDevice) GGMLBackendDeviceType {
+	if device == 0 {
+		return GGMLBackendDeviceTypeCPU
+	}
+
+	// libffi always stores a full 8-byte ffi_arg for an integer return, so
+	// the return buffer must be ffi.Arg-wide, not GGMLBackendDeviceType-wide (int32).
+	var ret ffi.Arg
+	ggmlBackendDevTypeFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&device))
+
+	return GGMLBackendDeviceType(int32(ret))
+}
+
+// GGMLBackendDeviceBackendReg returns the backend registration that owns the given device.
+func GGMLBackendDeviceBackendReg(device GGMLBackendDevice) GGMLBackendReg {
+	if device == 0 {
+		return 0
+	}
+
+	var ret GGMLBackendReg
+	ggmlBackendDevBackendRegFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&device))
+
+	return ret
+}
+
+// GGMLBackendRegName returns the name of the given backend registration.
+func GGMLBackendRegName(reg GGMLBackendReg) string {
+	if reg == 0 {
+		return ""
+	}
+
+	var ret *byte
+	ggmlBackendRegNameFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&reg))
+
+	return utils.BytePtrToString(ret)
 }

--- a/pkg/llama/ggml_test.go
+++ b/pkg/llama/ggml_test.go
@@ -185,6 +185,136 @@ func TestGGMLBackendDeviceMemory(t *testing.T) {
 	t.Logf("Device memory: free=%d, total=%d", free, total)
 }
 
+func TestGGMLBackendDeviceDescription(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	if GGMLBackendDeviceCount() == 0 {
+		t.Skip("No backend devices to get description from")
+	}
+
+	dev := GGMLBackendDeviceGet(0)
+	if dev == 0 {
+		t.Fatal("GGMLBackendDeviceGet(0) returned 0")
+	}
+
+	desc := GGMLBackendDeviceDescription(dev)
+	if desc == "" {
+		t.Fatal("GGMLBackendDeviceDescription returned empty string")
+	}
+	t.Logf("GGMLBackendDeviceDescription returned: %s", desc)
+}
+
+func TestGGMLBackendDevType(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	// A device found by type must report that same type back. This catches a
+	// return buffer that is too narrow and an enum that moved upstream.
+	dev := GGMLBackendDeviceByType(GGMLBackendDeviceTypeCPU)
+	if dev == 0 {
+		t.Fatal("GGMLBackendDeviceByType(GGMLBackendDeviceTypeCPU) returned 0")
+	}
+
+	if got := GGMLBackendDevType(dev); got != GGMLBackendDeviceTypeCPU {
+		t.Fatalf("GGMLBackendDevType = %v, want %v", got, GGMLBackendDeviceTypeCPU)
+	}
+
+	for i := uint64(0); i < GGMLBackendDeviceCount(); i++ {
+		d := GGMLBackendDeviceGet(i)
+		if d == 0 {
+			continue
+		}
+		t.Logf("device %d (%s) type: %v", i, GGMLBackendDeviceName(d), GGMLBackendDevType(d))
+	}
+}
+
+func TestGGMLBackendDeviceBackendReg(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	if GGMLBackendDeviceCount() == 0 {
+		t.Skip("No backend devices to get the registration from")
+	}
+
+	dev := GGMLBackendDeviceGet(0)
+	if dev == 0 {
+		t.Fatal("GGMLBackendDeviceGet(0) returned 0")
+	}
+
+	reg := GGMLBackendDeviceBackendReg(dev)
+	if reg == 0 {
+		t.Fatal("GGMLBackendDeviceBackendReg returned 0")
+	}
+	t.Logf("GGMLBackendDeviceBackendReg returned: %v", reg)
+}
+
+func TestGGMLBackendRegName(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	if GGMLBackendDeviceCount() == 0 {
+		t.Skip("No backend devices to get the registration name from")
+	}
+
+	dev := GGMLBackendDeviceGet(0)
+	if dev == 0 {
+		t.Fatal("GGMLBackendDeviceGet(0) returned 0")
+	}
+
+	reg := GGMLBackendDeviceBackendReg(dev)
+	if reg == 0 {
+		t.Fatal("GGMLBackendDeviceBackendReg returned 0")
+	}
+
+	name := GGMLBackendRegName(reg)
+	if name == "" {
+		t.Fatal("GGMLBackendRegName returned empty string")
+	}
+	t.Logf("GGMLBackendRegName returned: %s", name)
+
+	// the name must round-trip through the lookup it came from
+	if cpu := GGMLBackendRegByName("CPU"); cpu != 0 {
+		if got := GGMLBackendRegName(cpu); got != "CPU" {
+			t.Fatalf("GGMLBackendRegName(GGMLBackendRegByName(\"CPU\")) = %q, want \"CPU\"", got)
+		}
+	}
+}
+
+func TestGGMLBackendDeviceAccessorsNilDevice(t *testing.T) {
+	if desc := GGMLBackendDeviceDescription(0); desc != "" {
+		t.Fatalf("GGMLBackendDeviceDescription(0) = %q, want empty string", desc)
+	}
+
+	if reg := GGMLBackendDeviceBackendReg(0); reg != 0 {
+		t.Fatalf("GGMLBackendDeviceBackendReg(0) = %v, want 0", reg)
+	}
+
+	if name := GGMLBackendRegName(0); name != "" {
+		t.Fatalf("GGMLBackendRegName(0) = %q, want empty string", name)
+	}
+}
+
+func TestGGMLBackendDeviceTypeString(t *testing.T) {
+	tests := []struct {
+		devType GGMLBackendDeviceType
+		want    string
+	}{
+		{GGMLBackendDeviceTypeCPU, "CPU"},
+		{GGMLBackendDeviceTypeGPU, "GPU"},
+		{GGMLBackendDeviceTypeIGPU, "IGPU"},
+		{GGMLBackendDeviceTypeACCEL, "ACCEL"},
+		{GGMLBackendDeviceTypeMETA, "META"},
+		{GGMLBackendDeviceType(99), "GGMLBackendDeviceType(99)"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.devType.String(); got != tt.want {
+			t.Errorf("GGMLBackendDeviceType(%d).String() = %q, want %q", int32(tt.devType), got, tt.want)
+		}
+	}
+}
+
 func TestMoEExpertTensorPattern(t *testing.T) {
 	re := regexp.MustCompile(MoEExpertTensorPattern)
 


### PR DESCRIPTION
Add the following ggml backend functions:
- ggml_backend_dev_description
- ggml_backend_dev_type
- ggml_backend_dev_backend_reg
- ggml_backend_reg_name
 
Also add the missing `GGML_BACKEND_DEVICE_TYPE_META` enum member.

`yzma system` and the systeminfo example now show the type, backend, description, and memory of each device.