### PR TITLE
llama: bind the ggml type sizing functions for GGUF sizing

### DIFF
--- a/pkg/llama/ggml.go
+++ b/pkg/llama/ggml.go
@@ -130,6 +130,12 @@ const (
 	GGMLTypeCOUNT GGMLType = 43
 )
 
+// String returns the name of the tensor type, for example "q4_K".
+// The llama.cpp libraries must be loaded before you call it.
+func (t GGMLType) String() string {
+	return GGMLTypeName(t)
+}
+
 var (
 	// GGML_API void ggml_backend_load_all(void);
 	ggmlBackendLoadAllFunc ffi.Fun

--- a/pkg/llama/ggml_base.go
+++ b/pkg/llama/ggml_base.go
@@ -32,6 +32,18 @@ var (
 
 	// GGML_API const char * ggml_backend_reg_name(ggml_backend_reg_t reg);
 	ggmlBackendRegNameFunc ffi.Fun
+
+	// GGML_API int64_t ggml_blck_size(enum ggml_type type);
+	ggmlBlckSizeFunc ffi.Fun
+
+	// GGML_API size_t ggml_type_size(enum ggml_type type);
+	ggmlTypeSizeFunc ffi.Fun
+
+	// GGML_API size_t ggml_row_size(enum ggml_type type, int64_t ne);
+	ggmlRowSizeFunc ffi.Fun
+
+	// GGML_API const char * ggml_type_name(enum ggml_type type);
+	ggmlTypeNameFunc ffi.Fun
 )
 
 func loadGGMLBase(lib ffi.Lib) error {
@@ -63,6 +75,22 @@ func loadGGMLBase(lib ffi.Lib) error {
 
 	if ggmlBackendRegNameFunc, err = lib.Prep("ggml_backend_reg_name", &ffi.TypePointer, &ffi.TypePointer); err != nil {
 		return loadError("ggml_backend_reg_name", err)
+	}
+
+	if ggmlBlckSizeFunc, err = lib.Prep("ggml_blck_size", &ffi.TypeSint64, &ffi.TypeSint32); err != nil {
+		return loadError("ggml_blck_size", err)
+	}
+
+	if ggmlTypeSizeFunc, err = lib.Prep("ggml_type_size", &ffi.TypeUint64, &ffi.TypeSint32); err != nil {
+		return loadError("ggml_type_size", err)
+	}
+
+	if ggmlRowSizeFunc, err = lib.Prep("ggml_row_size", &ffi.TypeUint64, &ffi.TypeSint32, &ffi.TypeSint64); err != nil {
+		return loadError("ggml_row_size", err)
+	}
+
+	if ggmlTypeNameFunc, err = lib.Prep("ggml_type_name", &ffi.TypePointer, &ffi.TypeSint32); err != nil {
+		return loadError("ggml_type_name", err)
 	}
 
 	return nil
@@ -163,6 +191,48 @@ func GGMLBackendRegName(reg GGMLBackendReg) string {
 
 	var ret *byte
 	ggmlBackendRegNameFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&reg))
+
+	return utils.BytePtrToString(ret)
+}
+
+// GGMLBlockSize returns the number of elements in one block of the given type.
+// The type must be one of the GGMLType constants; any other value reads past the
+// end of the type table in C.
+func GGMLBlockSize(t GGMLType) int64 {
+	// libffi always stores a full 8-byte ffi_arg for an integer return, so the
+	// return buffer must be ffi.Arg-wide.
+	var ret ffi.Arg
+	ggmlBlckSizeFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&t))
+
+	return int64(ret)
+}
+
+// GGMLTypeSize returns the size in bytes of one block of the given type.
+// The type must be one of the GGMLType constants; any other value reads past the
+// end of the type table in C.
+func GGMLTypeSize(t GGMLType) uint64 {
+	var ret ffi.Arg
+	ggmlTypeSizeFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&t))
+
+	return uint64(ret)
+}
+
+// GGMLRowSize returns the size in bytes of a row of ne elements of the given type.
+// The type must be one of the GGMLType constants; any other value reads past the
+// end of the type table in C.
+func GGMLRowSize(t GGMLType, ne int64) uint64 {
+	var ret ffi.Arg
+	ggmlRowSizeFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&t), unsafe.Pointer(&ne))
+
+	return uint64(ret)
+}
+
+// GGMLTypeName returns the name of the given type, for example "q4_K".
+// The type must be one of the GGMLType constants; any other value reads past the
+// end of the type table in C.
+func GGMLTypeName(t GGMLType) string {
+	var ret *byte
+	ggmlTypeNameFunc.Call(unsafe.Pointer(&ret), unsafe.Pointer(&t))
 
 	return utils.BytePtrToString(ret)
 }

--- a/pkg/llama/ggml_test.go
+++ b/pkg/llama/ggml_test.go
@@ -354,3 +354,79 @@ func TestMoEExpertTensorPattern(t *testing.T) {
 		t.Error("block pattern should not match another block")
 	}
 }
+
+func TestGGMLTypeSizeAndBlockSize(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	tests := []struct {
+		typ       GGMLType
+		blockSize int64
+		typeSize  uint64
+	}{
+		{GGMLTypeF32, 1, 4},
+		{GGMLTypeF16, 1, 2},
+		{GGMLTypeQ8_0, 32, 34},
+		{GGMLTypeQ4_0, 32, 18},
+	}
+
+	for _, tt := range tests {
+		if got := GGMLBlockSize(tt.typ); got != tt.blockSize {
+			t.Errorf("GGMLBlockSize(%v) = %d, want %d", tt.typ, got, tt.blockSize)
+		}
+
+		if got := GGMLTypeSize(tt.typ); got != tt.typeSize {
+			t.Errorf("GGMLTypeSize(%v) = %d, want %d", tt.typ, got, tt.typeSize)
+		}
+	}
+}
+
+func TestGGMLRowSize(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	types := []GGMLType{GGMLTypeF32, GGMLTypeF16, GGMLTypeQ8_0, GGMLTypeQ4_0, GGMLTypeQ4_K}
+
+	const ne = 4096
+
+	for _, typ := range types {
+		blockSize := GGMLBlockSize(typ)
+		if blockSize <= 0 {
+			t.Fatalf("GGMLBlockSize(%v) = %d, want a positive block size", typ, blockSize)
+		}
+		if ne%blockSize != 0 {
+			t.Fatalf("GGMLBlockSize(%v) = %d, which does not divide %d", typ, blockSize, ne)
+		}
+
+		want := GGMLTypeSize(typ) * uint64(ne) / uint64(blockSize)
+		if got := GGMLRowSize(typ, ne); got != want {
+			t.Errorf("GGMLRowSize(%v, %d) = %d, want %d", typ, ne, got, want)
+		}
+
+		if got := GGMLRowSize(typ, 0); got != 0 {
+			t.Errorf("GGMLRowSize(%v, 0) = %d, want 0", typ, got)
+		}
+	}
+}
+
+func TestGGMLTypeName(t *testing.T) {
+	testSetup(t)
+	defer testCleanup(t)
+
+	if got := GGMLTypeName(GGMLTypeF32); got != "f32" {
+		t.Errorf("GGMLTypeName(GGMLTypeF32) = %q, want %q", got, "f32")
+	}
+
+	if got := GGMLTypeName(GGMLTypeF16); got != "f16" {
+		t.Errorf("GGMLTypeName(GGMLTypeF16) = %q, want %q", got, "f16")
+	}
+
+	name := GGMLTypeName(GGMLTypeQ4_K)
+	if name == "" {
+		t.Error("GGMLTypeName(GGMLTypeQ4_K) returned an empty name")
+	}
+
+	if got := GGMLTypeQ4_K.String(); got != name {
+		t.Errorf("GGMLTypeQ4_K.String() = %q, want %q", got, name)
+	}
+}


### PR DESCRIPTION
Bind the following functions from libggml-base:
- ggml_blck_size
- ggml_type_size
- ggml_row_size
- ggml_type_name

Also add String() to GGMLType. This gives the block size and the byte size of each tensor type from the library, so GGUF sizing does not need hand-written values for each quantization format.