### PR TITLE
download: support the new llama.cpp tagged releases

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -365,6 +365,8 @@ Notes:
   them, so `.tar.gz` and `.zip` archives are unpacked the same way as the built-in builds.
 - `Version` may be `""` or `"latest"`; `Install` resolves it to a release tag before
   calling the resolver, so `t.Version` is always concrete.
+- A tagged release such as `v0.3.0` has no binaries on the llama.cpp release page, so
+  `Install` also sets `t.UpstreamVersion` to the nightly build tag that holds them.
 - Anything [go-getter](https://github.com/hashicorp/go-getter) supports works as a URL,
   including `file://` and S3/GCS.
 

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -45,6 +46,17 @@ var (
 	// This is necessary because the build server for the current version might be building the latest version
 	// and might not have it available yet, while the previous version is likely to be available and can be used as a fallback.
 	previousVersionURL = "https://hybridgroup.github.io/llama-cpp-builder/previous.json"
+
+	// nightlyPattern is the format of a llama.cpp nightly build tag, for example "b10620".
+	nightlyPattern = regexp.MustCompile(`^b[0-9]+$`)
+
+	// releasePattern is the format of a llama.cpp tagged release, for example "v0.3.0".
+	releasePattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+`)
+
+	// nightlyTagURL is the URL of the asset in a tagged llama.cpp release that gives
+	// the nightly build tag. A tagged release has no binaries of its own.
+	// https://github.com/ggml-org/llama.cpp/releases
+	nightlyTagURL = "https://github.com/ggml-org/llama.cpp/releases/download/%s/nightly-tag.txt"
 )
 
 // LlamaLatestVersion fetches the latest release tag of llama.cpp from the version URL.
@@ -88,6 +100,10 @@ func getLatestVersion() (string, error) {
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", err
+	}
+
+	if err := VersionIsValid(result.TagName); err != nil {
+		return "", fmt.Errorf("%w: %s", err, result.TagName)
 	}
 
 	return result.TagName, nil
@@ -136,6 +152,10 @@ func getPreviousVersion() (string, error) {
 		return "", err
 	}
 
+	if err := VersionIsValid(result.TagName); err != nil {
+		return "", fmt.Errorf("%w: %s", err, result.TagName)
+	}
+
 	return result.TagName, nil
 }
 
@@ -166,7 +186,8 @@ var getFunc = get
 // arch can be one of the following values: "amd64", "arm64".
 // os can be one of the following values: "linux", "darwin", "windows", "bookworm", "trixie".
 // processor can be one of the following values: "cpu", "cuda", "metal", "rocm", "vulkan".
-// version should be the desired `b1234` formatted llama.cpp version. If an empty
+// version should be the desired llama.cpp version, either a `b1234` nightly build
+// or a `v1.2.3` tagged release. If an empty
 // string ("") or "latest" is provided, the latest release will be downloaded,
 // with an automatic fallback to the previous version if the latest is still building.
 // dest in the destination directory for the downloaded binaries.
@@ -179,7 +200,8 @@ func Get(architecture string, operatingSystem string, processor string, version 
 // arch can be one of the following values: "amd64", "arm64".
 // os can be one of the following values: "linux", "darwin", "windows", "bookworm", "trixie".
 // processor can be one of the following values: "cpu", "cuda", "metal", "rocm", "vulkan".
-// version should be the desired `b1234` formatted llama.cpp version. If an empty
+// version should be the desired llama.cpp version, either a `b1234` nightly build
+// or a `v1.2.3` tagged release. If an empty
 // string ("") or "latest" is provided, the latest release will be downloaded,
 // with an automatic fallback to the previous version if the latest is still building.
 // dest in the destination directory for the downloaded binaries.
@@ -192,21 +214,12 @@ func GetWithProgress(architecture string, operatingSystem string, processor stri
 // arch can be one of the following values: "amd64", "arm64".
 // os can be one of the following values: "linux", "darwin", "windows", "bookworm", "trixie".
 // processor can be one of the following values: "cpu", "cuda", "metal", "rocm", "vulkan".
-// version should be the desired `b1234` formatted llama.cpp version. If an empty
+// version should be the desired llama.cpp version, either a `b1234` nightly build
+// or a `v1.2.3` tagged release. If an empty
 // string ("") or "latest" is provided, the latest release will be downloaded,
 // with an automatic fallback to the previous version if the latest is still building.
 // dest in the destination directory for the downloaded binaries.
 func GetWithContext(ctx context.Context, architecture string, operatingSystem string, processor string, version string, dest string, progress getter.ProgressTracker) error {
-	autoVersion := false
-	if version == "" || version == "latest" {
-		autoVersion = true
-		var err error
-		version, err = LlamaLatestVersion()
-		if err != nil {
-			return err
-		}
-	}
-
 	arch, err := ParseArch(architecture)
 	if err != nil {
 		return ErrUnknownArch
@@ -222,34 +235,7 @@ func GetWithContext(ctx context.Context, architecture string, operatingSystem st
 		return ErrUnknownProcessor
 	}
 
-	if err := VersionIsValid(version); err != nil {
-		return ErrInvalidVersion
-	}
-
-	location, filename, err := getDownloadLocationAndFilename(arch, os, prcssr, version, dest)
-	if err != nil {
-		return err
-	}
-
-	url := fmt.Sprintf("%s/%s", location, filename)
-	err = getFunc(ctx, url, dest, progress)
-
-	if err != nil && autoVersion && errors.Is(err, ErrFileNotFound) {
-		prevVersion, prevErr := LlamaPreviousVersion()
-		if prevErr != nil {
-			return err
-		}
-
-		location, filename, prevErr = getDownloadLocationAndFilename(arch, os, prcssr, prevVersion, dest)
-		if prevErr != nil {
-			return err
-		}
-
-		url = fmt.Sprintf("%s/%s", location, filename)
-		return getFunc(ctx, url, dest, progress)
-	}
-
-	return err
+	return Install(ctx, Target{Arch: arch, OS: os, Processor: prcssr, Version: version}, dest, progress, nil)
 }
 
 func get(ctx context.Context, url, dest string, progress getter.ProgressTracker) error {
@@ -420,11 +406,54 @@ func removeExisting(target string) error {
 
 // VersionIsValid checks if the provided version string is valid.
 func VersionIsValid(version string) error {
-	if !strings.HasPrefix(version, "b") {
+	if !nightlyPattern.MatchString(version) && !releasePattern.MatchString(version) {
 		return ErrInvalidVersion
 	}
 
 	return nil
+}
+
+// IsTaggedRelease tells if version is a tagged llama.cpp release such as "v0.3.0",
+// which needs [LlamaNightlyTag] to find the build with the binaries.
+func IsTaggedRelease(version string) bool {
+	return releasePattern.MatchString(version)
+}
+
+// LlamaNightlyTag returns the nightly build tag that has the binaries for a llama.cpp
+// version. A nightly tag such as "b10620" gives itself. A tagged release such as
+// "v0.3.0" has no binaries of its own, so the nightly build tag comes from the
+// nightly-tag.txt asset of that release.
+func LlamaNightlyTag(version string) (string, error) {
+	if nightlyPattern.MatchString(version) {
+		return version, nil
+	}
+
+	if err := VersionIsValid(version); err != nil {
+		return "", err
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(fmt.Sprintf(nightlyTagURL, version))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("received status code %d for nightly tag of %s", resp.StatusCode, version)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64))
+	if err != nil {
+		return "", err
+	}
+
+	tag := strings.TrimSpace(string(body))
+	if !nightlyPattern.MatchString(tag) {
+		return "", fmt.Errorf("%w: %s", ErrInvalidVersion, tag)
+	}
+
+	return tag, nil
 }
 
 // LibraryName returns the name for the llama.cpp library for any given OS.

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -992,3 +992,51 @@ func TestExtractTarGzUpgradeRepointsSymlink(t *testing.T) {
 		t.Fatalf("superseded library was modified: %q", content)
 	}
 }
+
+func TestVersionIsValid(t *testing.T) {
+	valid := []string{"b7974", "v0.3.0", "v1.2.3-rc1"}
+	for _, version := range valid {
+		if err := VersionIsValid(version); err != nil {
+			t.Errorf("VersionIsValid(%q) = %v, want nil", version, err)
+		}
+	}
+
+	invalid := []string{"", "nogood", "b", "banana", "0.3.0", "latest"}
+	for _, version := range invalid {
+		if err := VersionIsValid(version); err == nil {
+			t.Errorf("VersionIsValid(%q) accepted an invalid version", version)
+		}
+	}
+}
+
+func TestLlamaNightlyTag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.3.0/nightly-tag.txt" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Write([]byte("b10621\n"))
+	}))
+	defer server.Close()
+
+	originalURL := nightlyTagURL
+	nightlyTagURL = server.URL + "/%s/nightly-tag.txt"
+	defer func() { nightlyTagURL = originalURL }()
+
+	tag, err := LlamaNightlyTag("v0.3.0")
+	if err != nil {
+		t.Fatalf("LlamaNightlyTag() failed: %v", err)
+	}
+	if tag != "b10621" {
+		t.Fatalf("LlamaNightlyTag() = %q, want b10621", tag)
+	}
+
+	// A nightly tag needs no lookup.
+	if tag, err = LlamaNightlyTag("b7974"); err != nil || tag != "b7974" {
+		t.Fatalf("LlamaNightlyTag() = %q, %v, want b7974, nil", tag, err)
+	}
+
+	if _, err = LlamaNightlyTag("v9.9.9"); err == nil {
+		t.Fatal("LlamaNightlyTag() accepted a release with no nightly tag asset")
+	}
+}

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -14,9 +14,14 @@ type Target struct {
 	OS        OS
 	Processor Processor
 
-	// Version is the llama.cpp release tag, e.g. "b7974". "" or "latest" resolves to
-	// the newest release.
+	// Version is the llama.cpp release tag, e.g. "b7974" or "v0.3.0". "" or "latest"
+	// resolves to the newest release.
 	Version string
+
+	// UpstreamVersion is the nightly build tag that has the llama.cpp binaries for
+	// Version. A tagged release has no binaries of its own, so [Install] fills this
+	// in with [LlamaNightlyTag]. Empty means use Version.
+	UpstreamVersion string
 }
 
 // Resolver reports the release assets to install for a Target, as URLs downloaded in
@@ -40,42 +45,49 @@ var DefaultResolver Resolver = ResolverFunc(defaultResolve)
 func defaultResolve(target Target) ([]string, error) {
 	arch, os, prcssr, version := target.Arch, target.OS, target.Processor, target.Version
 
-	var extra []string
-	var location, filename string
-	location = fmt.Sprintf("https://github.com/ggml-org/llama.cpp/releases/download/%s", version)
+	// The llama.cpp releases hold the binaries under the nightly build tag, while the
+	// llama-cpp-builder releases use the requested tag.
+	upstream := target.UpstreamVersion
+	if upstream == "" {
+		upstream = version
+	}
+	builderLocation := fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
 
-	location = fmt.Sprintf("https://github.com/ggml-org/llama.cpp/releases/download/%s", version)
+	var extra []string
+	var filename string
+	location := fmt.Sprintf("https://github.com/ggml-org/llama.cpp/releases/download/%s", upstream)
+	tag := upstream
 
 	switch os {
 	case Linux:
 		switch prcssr {
 		case CPU:
 			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cpu-arm64.tar.gz", version)
+				location, tag = builderLocation, version
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cpu-arm64.tar.gz", tag)
 				break
 			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-x64.tar.gz", version)
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-x64.tar.gz", tag)
 		case CUDA:
-			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+			location, tag = builderLocation, version
 			if arch == ARM64 {
 				// defaults to CUDA 12 assuming that is running Jetson Orin.
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-arm64.tar.gz", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-arm64.tar.gz", tag)
 			} else {
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-13-x64.tar.gz", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-13-x64.tar.gz", tag)
 			}
 		case Vulkan:
 			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-arm64.tar.gz", version)
+				location, tag = builderLocation, version
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-arm64.tar.gz", tag)
 				break
 			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.tar.gz", version)
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.tar.gz", tag)
 		case ROCm:
 			if arch != AMD64 {
 				return nil, errors.New("precompiled binaries for Linux ARM64 ROCm are not available")
 			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-rocm-7.2-x64.tar.gz", version)
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-rocm-7.2-x64.tar.gz", tag)
 		default:
 			return nil, ErrUnknownProcessor
 		}
@@ -84,18 +96,18 @@ func defaultResolve(target Target) ([]string, error) {
 		switch prcssr {
 		case CPU:
 			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cpu-arm64.tar.gz", version)
+				location, tag = builderLocation, version
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cpu-arm64.tar.gz", tag)
 				break
 			}
 
 			// no AMD64 for bookworm
 			return nil, ErrUnknownProcessor
 		case CUDA:
-			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+			location, tag = builderLocation, version
 			if arch == ARM64 {
 				// Jetson Orin.
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-arm64.tar.gz", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-arm64.tar.gz", tag)
 				break
 			}
 
@@ -103,8 +115,8 @@ func defaultResolve(target Target) ([]string, error) {
 			return nil, ErrUnknownProcessor
 		case Vulkan:
 			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-arm64.tar.gz", version)
+				location, tag = builderLocation, version
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-arm64.tar.gz", tag)
 				break
 			}
 
@@ -118,26 +130,26 @@ func defaultResolve(target Target) ([]string, error) {
 		switch prcssr {
 		case CPU:
 			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-trixie-cpu-arm64.tar.gz", version)
+				location, tag = builderLocation, version
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-trixie-cpu-arm64.tar.gz", tag)
 				break
 			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-x64.tar.gz", version)
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-x64.tar.gz", tag)
 		case CUDA:
-			location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
+			location, tag = builderLocation, version
 			if arch == ARM64 {
 				// not yet
 				return nil, ErrUnknownProcessor
 			} else {
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-13-x64.tar.gz", version)
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-cuda-13-x64.tar.gz", tag)
 			}
 		case Vulkan:
 			if arch == ARM64 {
-				location = fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s", version)
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-trixie-vulkan-arm64.tar.gz", version)
+				location, tag = builderLocation, version
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-trixie-vulkan-arm64.tar.gz", tag)
 				break
 			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.tar.gz", version)
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.tar.gz", tag)
 		default:
 			return nil, ErrUnknownProcessor
 		}
@@ -148,12 +160,12 @@ func defaultResolve(target Target) ([]string, error) {
 			if arch != ARM64 {
 				return nil, errors.New("precompiled binaries for macOS non-ARM64 CPU/Metal are not available")
 			}
-			filename = fmt.Sprintf("llama-%s-bin-macos-arm64.tar.gz", version)
+			filename = fmt.Sprintf("llama-%s-bin-macos-arm64.tar.gz", tag)
 		case CPU:
 			if arch == ARM64 {
-				filename = fmt.Sprintf("llama-%s-bin-macos-arm64.tar.gz", version)
+				filename = fmt.Sprintf("llama-%s-bin-macos-arm64.tar.gz", tag)
 			} else {
-				filename = fmt.Sprintf("llama-%s-bin-macos-x64.tar.gz", version)
+				filename = fmt.Sprintf("llama-%s-bin-macos-x64.tar.gz", tag)
 			}
 		default:
 			return nil, ErrUnknownProcessor
@@ -163,9 +175,9 @@ func defaultResolve(target Target) ([]string, error) {
 		switch prcssr {
 		case CPU:
 			if arch == ARM64 {
-				filename = fmt.Sprintf("llama-%s-bin-win-cpu-arm64.zip", version)
+				filename = fmt.Sprintf("llama-%s-bin-win-cpu-arm64.zip", tag)
 			} else {
-				filename = fmt.Sprintf("llama-%s-bin-win-cpu-x64.zip", version)
+				filename = fmt.Sprintf("llama-%s-bin-win-cpu-x64.zip", tag)
 			}
 		case CUDA:
 			if arch == ARM64 {
@@ -174,17 +186,17 @@ func defaultResolve(target Target) ([]string, error) {
 			// also requires the CUDA RT files
 			cudart := "cudart-llama-bin-win-cuda-13.3-x64.zip"
 			extra = append(extra, fmt.Sprintf("%s/%s", location, cudart))
-			filename = fmt.Sprintf("llama-%s-bin-win-cuda-13.3-x64.zip", version)
+			filename = fmt.Sprintf("llama-%s-bin-win-cuda-13.3-x64.zip", tag)
 		case Vulkan:
 			if arch == ARM64 {
 				return nil, errors.New("precompiled binaries for Windows ARM64 Vulkan are not available")
 			}
-			filename = fmt.Sprintf("llama-%s-bin-win-vulkan-x64.zip", version)
+			filename = fmt.Sprintf("llama-%s-bin-win-vulkan-x64.zip", tag)
 		case ROCm:
 			if arch != AMD64 {
 				return nil, errors.New("precompiled binaries for Windows ARM64 ROCm are not available")
 			}
-			filename = fmt.Sprintf("llama-%s-bin-win-hip-radeon-x64.zip", version)
+			filename = fmt.Sprintf("llama-%s-bin-win-hip-radeon-x64.zip", tag)
 		default:
 			return nil, ErrUnknownProcessor
 		}
@@ -215,6 +227,17 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 		return ErrInvalidVersion
 	}
 
+	// Only a tagged release needs a lookup on the llama.cpp release page. A nightly
+	// tag names its own assets, so it stays on the llama-cpp-builder site, which does
+	// not rate limit like the GitHub API.
+	if target.UpstreamVersion == "" && IsTaggedRelease(target.Version) {
+		upstream, err := LlamaNightlyTag(target.Version)
+		if err != nil {
+			return err
+		}
+		target.UpstreamVersion = upstream
+	}
+
 	err := installAssets(ctx, target, dest, progress, resolver)
 
 	// The newest release may still be building for this platform.
@@ -224,6 +247,13 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 			return err
 		}
 		target.Version = previous
+		target.UpstreamVersion = ""
+		if IsTaggedRelease(previous) {
+			target.UpstreamVersion, prevErr = LlamaNightlyTag(previous)
+			if prevErr != nil {
+				return err
+			}
+		}
 		return installAssets(ctx, target, dest, progress, resolver)
 	}
 

--- a/pkg/download/resolver_test.go
+++ b/pkg/download/resolver_test.go
@@ -3,6 +3,8 @@ package download
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -30,13 +32,13 @@ func TestInstallUsesResolver(t *testing.T) {
 		t.Fatalf("Install() failed: %v", err)
 	}
 	// Order matters: an auxiliary runtime lands before the libraries linking it.
-	want := []string{"https://example.com/runtime.zip", "https://example.com/llama.tar.gz"}
-	if len(got) != len(want) {
-		t.Fatalf("downloaded %v, want %v", got, want)
+	wantURLs := []string{"https://example.com/runtime.zip", "https://example.com/llama.tar.gz"}
+	if len(got) != len(wantURLs) {
+		t.Fatalf("downloaded %v, want %v", got, wantURLs)
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("downloaded %v, want %v", got, want)
+	for i := range wantURLs {
+		if got[i] != wantURLs[i] {
+			t.Fatalf("downloaded %v, want %v", got, wantURLs)
 		}
 	}
 }
@@ -107,5 +109,53 @@ func TestDefaultResolverUnknownProcessor(t *testing.T) {
 	_, err := DefaultResolver.Resolve(Target{Arch: ARM64, OS: Windows, Processor: CUDA, Version: "b7974"})
 	if err == nil {
 		t.Fatal("Resolve() accepted a target with no published build")
+	}
+}
+
+// A tagged release has no binaries of its own, so the llama.cpp assets come from the
+// nightly build tag while the llama-cpp-builder assets keep the release tag.
+func TestDefaultResolverTaggedRelease(t *testing.T) {
+	target := Target{Arch: AMD64, OS: Linux, Processor: CPU, Version: "v0.3.0", UpstreamVersion: "b10621"}
+	urls, err := DefaultResolver.Resolve(target)
+	if err != nil {
+		t.Fatalf("Resolve() failed: %v", err)
+	}
+	want := "https://github.com/ggml-org/llama.cpp/releases/download/b10621/llama-b10621-bin-ubuntu-x64.tar.gz"
+	if urls[0] != want {
+		t.Errorf("Resolve() = %q, want %q", urls[0], want)
+	}
+
+	target.Arch = ARM64
+	urls, err = DefaultResolver.Resolve(target)
+	if err != nil {
+		t.Fatalf("Resolve() failed: %v", err)
+	}
+	want = "https://github.com/hybridgroup/llama-cpp-builder/releases/download/v0.3.0/llama-v0.3.0-bin-ubuntu-cpu-arm64.tar.gz"
+	if urls[0] != want {
+		t.Errorf("Resolve() = %q, want %q", urls[0], want)
+	}
+}
+
+// A nightly tag must not go to the llama.cpp release page, which sometimes rate limits.
+func TestInstallNightlyTagSkipsNightlyTagLookup(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request for %s", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	originalURL := nightlyTagURL
+	nightlyTagURL = server.URL + "/%s/nightly-tag.txt"
+	defer func() { nightlyTagURL = originalURL }()
+
+	originalGet := getFunc
+	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+		return nil
+	}
+	defer func() { getFunc = originalGet }()
+
+	target := Target{Arch: AMD64, OS: Linux, Processor: CPU, Version: "b7974"}
+	if err := Install(context.Background(), target, t.TempDir(), nil, nil); err != nil {
+		t.Fatalf("Install() failed: %v", err)
 	}
 }


### PR DESCRIPTION
llama.cpp now publishes tagged releases such as v0.3.0 next to the b12345 nightly builds. A tagged release has no binaries, so its nightly-tag.txt asset gives the build with them. The llama-cpp-builder releases keep the requested tag.