### PR TITLE
llama, mtmd: follow the upstream llama.cpp b10655 ABI changes

### DIFF
--- a/examples/describe/describe.go
+++ b/examples/describe/describe.go
@@ -57,7 +57,7 @@ func describe(tmpFile string) error {
 	output := mtmd.InputChunksInit()
 	input := mtmd.NewInputText(chatTemplate(true), true, true)
 
-	bitmap := mtmd.BitmapInitFromFile(mtmdCtx, tmpFile, false)
+	bitmap := mtmd.BitmapInitFromFile(mtmdCtx, tmpFile, false, mtmd.InitOptDefault())
 	defer mtmd.BitmapFree(bitmap.Bitmap)
 
 	mtmd.Tokenize(mtmdCtx, output, input, []mtmd.Bitmap{bitmap.Bitmap})

--- a/examples/vlm/main.go
+++ b/examples/vlm/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	output := mtmd.InputChunksInit()
 	input := mtmd.NewInputText(chatTemplate(true), true, true)
-	bitmap := mtmd.BitmapInitFromFile(mtmdCtx, *imageFile, false)
+	bitmap := mtmd.BitmapInitFromFile(mtmdCtx, *imageFile, false, mtmd.InitOptDefault())
 	defer mtmd.BitmapFree(bitmap.Bitmap)
 
 	mtmd.Tokenize(mtmdCtx, output, input, []mtmd.Bitmap{bitmap.Bitmap})

--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -21,10 +21,10 @@ const (
 
 	// Session constants
 	SessionMagic   = FileMagicGGSN
-	SessionVersion = 9
+	SessionVersion = 10
 
 	StateSeqMagic   = FileMagicGGSQ
-	StateSeqVersion = 2
+	StateSeqVersion = 3
 
 	// maximum token value
 	MaxToken = 0x7fffffff
@@ -184,6 +184,14 @@ const (
 	LoadModeDirectIO  LoadMode = 4  // use direct I/O if available
 )
 
+type TensorReadLazy int32
+
+const (
+	TensorReadLazyOff  TensorReadLazy = 0 // always read the whole tensor up front
+	TensorReadLazyAuto TensorReadLazy = 1 // lazy only for marked tensors larger than 4 GiB (requires mmap)
+	TensorReadLazyOn   TensorReadLazy = 2 // read the rows of tensors marked by the arch on demand (requires mmap)
+)
+
 type GpuBackend int32
 
 const (
@@ -328,22 +336,23 @@ type ProgressCallback func(progress float32, userData uintptr) uint8
 
 // ModelParams allows configuration of the model and how it's loaded
 type ModelParams struct {
-	Devices                  uintptr   // ggml_backend_dev_t * - NULL-terminated list of devices
-	TensorBuftOverrides      uintptr   // const struct llama_model_tensor_buft_override *
-	NGpuLayers               int32     // number of layers to store in VRAM
-	SplitMode                SplitMode // how to split the model across multiple GPUs
-	LoadMode                 LoadMode  // how to load the model
-	MainGpu                  int32     // the GPU that is used for the entire model
-	TensorSplit              *float32  // proportion of the model to offload to each GPU
-	ProgressCallback         uintptr   // llama_progress_callback function pointer
-	ProgressCallbackUserData uintptr   // context pointer passed to the progress callback
-	KvOverrides              uintptr   // const struct llama_model_kv_override *
-	VocabOnly                uint8     // only load the vocabulary, no weights (bool as uint8)
-	CheckTensors             uint8     // validate model tensor data (bool as uint8)
-	UseExtraBufts            uint8     // use extra buffer types (bool as uint8)
-	NoHost                   uint8     // bypass host buffer allowing extra buffers to be used (bool as uint8)
-	NoAlloc                  uint8     // only load metadata and simulate memory allocations (bool as uint8)
-	LoadMTP                  uint8     // whether to load MTP layers (bool as uint8)
+	Devices                  uintptr        // ggml_backend_dev_t * - NULL-terminated list of devices
+	TensorBuftOverrides      uintptr        // const struct llama_model_tensor_buft_override *
+	NGpuLayers               int32          // number of layers to store in VRAM
+	SplitMode                SplitMode      // how to split the model across multiple GPUs
+	LoadMode                 LoadMode       // how to load the model
+	TensorReadLazy           TensorReadLazy // on-demand reading of tensors marked by the arch
+	MainGpu                  int32          // the GPU that is used for the entire model
+	TensorSplit              *float32       // proportion of the model to offload to each GPU
+	ProgressCallback         uintptr        // llama_progress_callback function pointer
+	ProgressCallbackUserData uintptr        // context pointer passed to the progress callback
+	KvOverrides              uintptr        // const struct llama_model_kv_override *
+	VocabOnly                uint8          // only load the vocabulary, no weights (bool as uint8)
+	CheckTensors             uint8          // validate model tensor data (bool as uint8)
+	UseExtraBufts            uint8          // use extra buffer types (bool as uint8)
+	NoHost                   uint8          // bypass host buffer allowing extra buffers to be used (bool as uint8)
+	NoAlloc                  uint8          // only load metadata and simulate memory allocations (bool as uint8)
+	LoadMTP                  uint8          // whether to load MTP layers (bool as uint8)
 }
 
 // ContextParams controls the parameters available for the model context

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -14,7 +14,7 @@ var (
 
 	// ffiTypeModelParams represents the C struct llama_model_params
 	ffiTypeModelParams = ffi.NewType(&ffi.TypePointer, &ffi.TypePointer, &ffi.TypeSint32,
-		&ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypeSint32,
+		&ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypeSint32,
 		&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer,
 		&ffi.TypeUint8, &ffi.TypeUint8,
 		&ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8)

--- a/pkg/mtmd/bitmap.go
+++ b/pkg/mtmd/bitmap.go
@@ -22,9 +22,22 @@ type BitmapWrapper struct {
 	VideoContext VideoContext
 }
 
+// InitOpt contains the options for BitmapInitFromFile and BitmapInitFromBuf.
+// Use InitOptDefault to obtain a copy with sensible defaults.
+//
+//	struct mtmd_helper_init_opt {
+//	    struct mtmd_helper_video_init_params video_params;
+//	};
+type InitOpt struct {
+	VideoParams VideoInitParams
+}
+
 var (
 	// ffiTypeBitmapWrapper represents the C struct mtmd_helper_bitmap_wrapper as an FFI type.
 	ffiTypeBitmapWrapper = ffi.NewType(&ffi.TypePointer, &ffi.TypePointer)
+
+	// ffiTypeInitOpt mirrors struct mtmd_helper_init_opt
+	ffiTypeInitOpt = ffi.NewType(&ffiTypeVideoInitParams)
 )
 
 var (
@@ -37,10 +50,13 @@ var (
 	// MTMD_API size_t                mtmd_bitmap_get_n_bytes(const mtmd_bitmap * bitmap);
 	bitmapGetNBytesFunc ffi.Fun
 
-	// MTMD_API mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_file(mtmd_context * ctx, const char * fname);
+	// MTMD_API struct mtmd_helper_init_opt mtmd_helper_init_opt_default(void);
+	initOptDefaultFunc ffi.Fun
+
+	// MTMD_API mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_file(mtmd_context * ctx, const char * fname, bool placeholder, struct mtmd_helper_init_opt opt);
 	bitmapInitFromFileFunc ffi.Fun
 
-	// MTMD_API mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_buf(mtmd_context * ctx, const unsigned char * buf, size_t len);
+	// MTMD_API mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_buf(mtmd_context * ctx, const unsigned char * buf, size_t len, bool placeholder, struct mtmd_helper_init_opt opt);
 	bitmapInitFromBufFunc ffi.Fun
 
 	// MTMD_API uint32_t mtmd_bitmap_get_nx(const mtmd_bitmap * bitmap);
@@ -83,11 +99,15 @@ func loadBitmapFuncs(lib ffi.Lib) error {
 		return loadError("mtmd_bitmap_get_n_bytes", err)
 	}
 
-	if bitmapInitFromFileFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_file", &ffiTypeBitmapWrapper, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint8); err != nil {
+	if initOptDefaultFunc, err = lib.Prep("mtmd_helper_init_opt_default", &ffiTypeInitOpt); err != nil {
+		return loadError("mtmd_helper_init_opt_default", err)
+	}
+
+	if bitmapInitFromFileFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_file", &ffiTypeBitmapWrapper, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint8, &ffiTypeInitOpt); err != nil {
 		return loadError("mtmd_helper_bitmap_init_from_file", err)
 	}
 
-	if bitmapInitFromBufFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_buf", &ffiTypeBitmapWrapper, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize, &ffi.TypeUint8); err != nil {
+	if bitmapInitFromBufFunc, err = lib.Prep("mtmd_helper_bitmap_init_from_buf", &ffiTypeBitmapWrapper, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize, &ffi.TypeUint8, &ffiTypeInitOpt); err != nil {
 		return loadError("mtmd_helper_bitmap_init_from_buf", err)
 	}
 
@@ -149,9 +169,18 @@ func BitmapGetNBytes(bitmap Bitmap) uint64 {
 	return uint64(result)
 }
 
+// InitOptDefault returns the default options for BitmapInitFromFile and BitmapInitFromBuf.
+func InitOptDefault() InitOpt {
+	var opt InitOpt
+	initOptDefaultFunc.Call(unsafe.Pointer(&opt))
+
+	return opt
+}
+
 // BitmapInitFromFile initializes a BitmapWrapper from a file.
 // If placeholder is true, the bitmap will have dimensions but no pixel data, suitable for counting tokens without preprocessing.
-func BitmapInitFromFile(ctx Context, fname string, placeholder bool) BitmapWrapper {
+// The opt parameter controls how a video file is read. Use InitOptDefault to obtain the defaults.
+func BitmapInitFromFile(ctx Context, fname string, placeholder bool, opt InitOpt) BitmapWrapper {
 	var bitmap BitmapWrapper
 	if ctx == 0 {
 		return bitmap
@@ -166,14 +195,15 @@ func BitmapInitFromFile(ctx Context, fname string, placeholder bool) BitmapWrapp
 		ph = 1
 	}
 	file := &[]byte(fname + "\x00")[0]
-	bitmapInitFromFileFunc.Call(unsafe.Pointer(&bitmap), unsafe.Pointer(&ctx), unsafe.Pointer(&file), unsafe.Pointer(&ph))
+	bitmapInitFromFileFunc.Call(unsafe.Pointer(&bitmap), unsafe.Pointer(&ctx), unsafe.Pointer(&file), unsafe.Pointer(&ph), unsafe.Pointer(&opt))
 
 	return bitmap
 }
 
 // BitmapInitFromBuf initializes a BitmapWrapper from a buffer of bytes.
 // If placeholder is true, the bitmap will have dimensions but no pixel data, suitable for counting tokens without preprocessing.
-func BitmapInitFromBuf(ctx Context, buf *byte, len uint64, placeholder bool) BitmapWrapper {
+// The opt parameter controls how a video buffer is read. Use InitOptDefault to obtain the defaults.
+func BitmapInitFromBuf(ctx Context, buf *byte, len uint64, placeholder bool, opt InitOpt) BitmapWrapper {
 	var bitmap BitmapWrapper
 	if ctx == 0 {
 		return bitmap
@@ -182,7 +212,7 @@ func BitmapInitFromBuf(ctx Context, buf *byte, len uint64, placeholder bool) Bit
 	if placeholder {
 		ph = 1
 	}
-	bitmapInitFromBufFunc.Call(unsafe.Pointer(&bitmap), unsafe.Pointer(&ctx), unsafe.Pointer(&buf), &len, unsafe.Pointer(&ph))
+	bitmapInitFromBufFunc.Call(unsafe.Pointer(&bitmap), unsafe.Pointer(&ctx), unsafe.Pointer(&buf), &len, unsafe.Pointer(&ph), unsafe.Pointer(&opt))
 
 	return bitmap
 }

--- a/pkg/mtmd/bitmap_test.go
+++ b/pkg/mtmd/bitmap_test.go
@@ -269,7 +269,7 @@ func TestBitmapInitFromFile(t *testing.T) {
 	defer llama.ModelFree(model)
 	defer Free(ctx)
 
-	bitmap := BitmapInitFromFile(ctx, "../../images/domestic_llama.jpg", false)
+	bitmap := BitmapInitFromFile(ctx, "../../images/domestic_llama.jpg", false, InitOptDefault())
 	defer BitmapFree(bitmap.Bitmap)
 
 	if bitmap.Bitmap == Bitmap(0) {
@@ -294,7 +294,7 @@ func TestBitmapInitFromFilePlaceholder(t *testing.T) {
 	defer llama.ModelFree(model)
 	defer Free(ctx)
 
-	bitmap := BitmapInitFromFile(ctx, "../../images/domestic_llama.jpg", true)
+	bitmap := BitmapInitFromFile(ctx, "../../images/domestic_llama.jpg", true, InitOptDefault())
 	defer BitmapFree(bitmap.Bitmap)
 
 	if bitmap.Bitmap == Bitmap(0) {
@@ -314,7 +314,7 @@ func TestBitmapInitFromFilePlaceholder(t *testing.T) {
 
 func TestBitmapInitFromFileZeroCtx(t *testing.T) {
 	// BitmapInitFromFile should return a zero Bitmap when ctx is 0.
-	bitmap := BitmapInitFromFile(Context(0), "../../images/domestic_llama.jpg", false)
+	bitmap := BitmapInitFromFile(Context(0), "../../images/domestic_llama.jpg", false, InitOpt{})
 	if bitmap.Bitmap != Bitmap(0) {
 		t.Fatal("BitmapInitFromFile should return zero Bitmap for zero context")
 	}
@@ -328,7 +328,7 @@ func TestBitmapInitFromFileNonExistent(t *testing.T) {
 	defer llama.ModelFree(model)
 	defer Free(ctx)
 
-	bitmap := BitmapInitFromFile(ctx, "/nonexistent/path/image.jpg", false)
+	bitmap := BitmapInitFromFile(ctx, "/nonexistent/path/image.jpg", false, InitOptDefault())
 	if bitmap.Bitmap != Bitmap(0) {
 		BitmapFree(bitmap.Bitmap)
 		t.Fatal("BitmapInitFromFile should return zero Bitmap for non-existent file")
@@ -348,7 +348,7 @@ func TestBitmapInitFromBuf(t *testing.T) {
 		t.Fatalf("could not read image file: %v", err)
 	}
 
-	bitmap := BitmapInitFromBuf(ctx, &fileBytes[0], uint64(len(fileBytes)), false)
+	bitmap := BitmapInitFromBuf(ctx, &fileBytes[0], uint64(len(fileBytes)), false, InitOptDefault())
 	defer BitmapFree(bitmap.Bitmap)
 
 	if bitmap.Bitmap == Bitmap(0) {
@@ -375,7 +375,7 @@ func TestBitmapInitFromBufPlaceholder(t *testing.T) {
 		t.Fatalf("could not read image file: %v", err)
 	}
 
-	bitmap := BitmapInitFromBuf(ctx, &fileBytes[0], uint64(len(fileBytes)), true)
+	bitmap := BitmapInitFromBuf(ctx, &fileBytes[0], uint64(len(fileBytes)), true, InitOptDefault())
 	defer BitmapFree(bitmap.Bitmap)
 
 	if bitmap.Bitmap == Bitmap(0) {
@@ -395,7 +395,7 @@ func TestBitmapInitFromBufPlaceholder(t *testing.T) {
 
 func TestBitmapInitFromBufZeroCtx(t *testing.T) {
 	fileBytes := []byte{0xFF, 0xD8, 0xFF} // minimal JPEG header bytes
-	bitmap := BitmapInitFromBuf(Context(0), &fileBytes[0], uint64(len(fileBytes)), false)
+	bitmap := BitmapInitFromBuf(Context(0), &fileBytes[0], uint64(len(fileBytes)), false, InitOpt{})
 	if bitmap.Bitmap != Bitmap(0) {
 		t.Fatal("BitmapInitFromBuf should return zero Bitmap for zero context")
 	}


### PR DESCRIPTION
llama_model_params has a new tensor_read_lazy member between load_mode and main_gpu. Add the TensorReadLazy type and the struct field.

The mtmd bitmap file and buffer helpers have a new mtmd_helper_init_opt argument. Add the InitOpt type and InitOptDefault, and pass the option through BitmapInitFromFile and BitmapInitFromBuf.