### PR TITLE
download: install the llama.cpp version pinned by this yzma release

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -364,7 +364,10 @@ Notes:
 - Resolvers must not download anything themselves — return URLs and let `Install` fetch
   them, so `.tar.gz` and `.zip` archives are unpacked the same way as the built-in builds.
 - `Version` may be `""` or `"latest"`; `Install` resolves it to a release tag before
-  calling the resolver, so `t.Version` is always concrete.
+  calling the resolver, so `t.Version` is always concrete. `""` takes
+  `download.DefaultVersion`, the llama.cpp release this yzma release was tested with.
+  A development build of yzma leaves that empty, so `""` then gets the most recent
+  nightly build. `"latest"` always gets the most recent nightly build.
 - A tagged release such as `v0.3.0` has no binaries on the llama.cpp release page, so
   `Install` also sets `t.UpstreamVersion` to the nightly build tag that holds them.
 - Anything [go-getter](https://github.com/hashicorp/go-getter) supports works as a URL,

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Sometimes there are breaking changes to `llama.cpp` that require an update to `y
 | ------- | --------- |
 | v0.3.0 | v1.25.0   |
 
+A tagged release of `yzma` installs its own `llama.cpp` release by default, so `yzma install` without the `-version` flag gets the version in this table. Use `-version latest` to get the most recent nightly build instead. A build from the `main` branch always uses the most recent nightly build.
+
 Here are some of the known compatible versions for the nightly builds of `llama.cpp`:
 
 | llama.cpp | yzma    |

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -42,7 +42,7 @@ USAGE:
    yzma install [command options]
 
 OPTIONS:
-   --version value, -v value    version of llama.cpp to install (leave empty for latest)
+   --version value, -v value    version of llama.cpp to install (leave empty for the version this yzma release uses)
    --lib value, -l value        path to llama.cpp compiled library files [$YZMA_LIB]
    --processor value, -p value  processor to use (cpu, cuda, metal, vulkan) (default: "cpu")
    --upgrade, -u                upgrade existing installation (default: false)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -17,7 +17,7 @@ var InstallCmd = &cli.Command{
 		&cli.StringFlag{
 			Name:    "version",
 			Aliases: []string{"v"},
-			Usage:   "version of llama.cpp to install (leave empty for latest)",
+			Usage:   "version of llama.cpp to install (leave empty for the version this yzma release uses)",
 			Value:   "",
 		},
 		&cli.StringFlag{
@@ -75,9 +75,12 @@ func runInstall(c *cli.Context) error {
 
 	quiet := c.Bool("quiet")
 	if !quiet {
-		if version == "" || version == "latest" {
+		switch {
+		case version == "" && download.DefaultVersion != "":
+			fmt.Println("installing llama.cpp version", download.DefaultVersion, "to", libPath)
+		case version == "" || version == "latest":
 			fmt.Println("installing latest llama.cpp version to", libPath)
-		} else {
+		default:
 			fmt.Println("installing llama.cpp version", version, "to", libPath)
 		}
 	} else {

--- a/examples/installer/flags.go
+++ b/examples/installer/flags.go
@@ -23,7 +23,7 @@ installer -version [version] -lib [llama.cpp .so file path] -processor [cpu, cud
 
 func handleFlags() error {
 	help = flag.String("help", "", "show help")
-	version = flag.String("version", "", "version of llama.cpp to install (leave empty for latest)")
+	version = flag.String("version", "", "version of llama.cpp to install (leave empty for the version this yzma release uses)")
 	libPath = flag.String("lib", "", "path to llama.cpp compiled library files (leave empty to use YZMA_LIB env var)")
 	processor = flag.String("processor", "", "processor to use (cpu, cuda, metal, vulkan)")
 	upgrade = flag.Bool("upgrade", false, "upgrade existing installation")

--- a/examples/installer/main.go
+++ b/examples/installer/main.go
@@ -29,9 +29,12 @@ func main() {
 		}
 	}
 
-	if *version == "" || *version == "latest" {
+	switch {
+	case *version == "" && download.DefaultVersion != "":
+		fmt.Println("installing llama.cpp version", download.DefaultVersion, "to", *libPath)
+	case *version == "" || *version == "latest":
 		fmt.Println("installing latest llama.cpp version to", *libPath)
-	} else {
+	default:
 		fmt.Println("installing llama.cpp version", *version, "to", *libPath)
 	}
 	if err := download.Get(runtime.GOARCH, runtime.GOOS, *processor, *version, *libPath); err != nil {

--- a/pkg/download/doc.go
+++ b/pkg/download/doc.go
@@ -15,5 +15,8 @@
 //
 //	err := download.Install(ctx, target, libPath, download.ProgressTracker, resolver)
 //
+// An empty [Target.Version] takes [DefaultVersion], the llama.cpp release this yzma
+// release was tested with. "latest" always gets the most recent nightly build.
+//
 // See INSTALL.md for the longer version.
 package download

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -14,7 +14,8 @@ type Target struct {
 	OS        OS
 	Processor Processor
 
-	// Version is the llama.cpp release tag, e.g. "b7974" or "v0.3.0". "" or "latest"
+	// Version is the llama.cpp release tag, e.g. "b7974" or "v0.3.0". "" takes
+	// [DefaultVersion], or the newest release if that is empty. "latest" always
 	// resolves to the newest release.
 	Version string
 
@@ -209,10 +210,16 @@ func defaultResolve(target Target) ([]string, error) {
 }
 
 // Install downloads the llama.cpp binaries for target into dest. A nil resolver means
-// [DefaultResolver].
+// [DefaultResolver]. An empty [Target.Version] takes [DefaultVersion].
 func Install(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver) error {
 	if resolver == nil {
 		resolver = DefaultResolver
+	}
+
+	// An empty version takes the release pinned by this yzma release. "latest" always
+	// asks for the newest build, so it skips the pin.
+	if target.Version == "" && DefaultVersion != "" {
+		target.Version = DefaultVersion
 	}
 
 	autoVersion := target.Version == "" || target.Version == "latest"

--- a/pkg/download/resolver_test.go
+++ b/pkg/download/resolver_test.go
@@ -159,3 +159,133 @@ func TestInstallNightlyTagSkipsNightlyTagLookup(t *testing.T) {
 		t.Fatalf("Install() failed: %v", err)
 	}
 }
+
+// A pinned version must not ask the version server which build is the newest.
+func TestInstallUsesDefaultVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request for %s", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	originalCurrent := currentVersionURL
+	currentVersionURL = server.URL + "/llama-cpp-builder/version.json"
+	defer func() { currentVersionURL = originalCurrent }()
+
+	originalDefault := DefaultVersion
+	DefaultVersion = "b7974"
+	defer func() { DefaultVersion = originalDefault }()
+
+	var got []string
+	originalGet := getFunc
+	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+		got = append(got, url)
+		return nil
+	}
+	defer func() { getFunc = originalGet }()
+
+	target := Target{Arch: AMD64, OS: Linux, Processor: CPU}
+	if err := Install(context.Background(), target, t.TempDir(), nil, nil); err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+
+	want := "https://github.com/ggml-org/llama.cpp/releases/download/b7974/llama-b7974-bin-ubuntu-x64.tar.gz"
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("downloaded %v, want [%s]", got, want)
+	}
+}
+
+// An explicit version wins over the pinned one.
+func TestInstallExplicitVersionOverridesDefault(t *testing.T) {
+	originalDefault := DefaultVersion
+	DefaultVersion = "v0.3.0"
+	defer func() { DefaultVersion = originalDefault }()
+
+	var got []string
+	originalGet := getFunc
+	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+		got = append(got, url)
+		return nil
+	}
+	defer func() { getFunc = originalGet }()
+
+	target := Target{Arch: AMD64, OS: Linux, Processor: CPU, Version: "b7974"}
+	if err := Install(context.Background(), target, t.TempDir(), nil, nil); err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+
+	want := "https://github.com/ggml-org/llama.cpp/releases/download/b7974/llama-b7974-bin-ubuntu-x64.tar.gz"
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("downloaded %v, want [%s]", got, want)
+	}
+}
+
+// "latest" asks for the newest build even when a version is pinned.
+func TestInstallLatestSkipsDefaultVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"tag_name": "b8000"}`))
+	}))
+	defer server.Close()
+
+	originalCurrent := currentVersionURL
+	currentVersionURL = server.URL + "/llama-cpp-builder/version.json"
+	defer func() { currentVersionURL = originalCurrent }()
+
+	originalDefault := DefaultVersion
+	DefaultVersion = "b7974"
+	defer func() { DefaultVersion = originalDefault }()
+
+	var got []string
+	originalGet := getFunc
+	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+		got = append(got, url)
+		return nil
+	}
+	defer func() { getFunc = originalGet }()
+
+	target := Target{Arch: AMD64, OS: Linux, Processor: CPU, Version: "latest"}
+	if err := Install(context.Background(), target, t.TempDir(), nil, nil); err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+
+	want := "https://github.com/ggml-org/llama.cpp/releases/download/b8000/llama-b8000-bin-ubuntu-x64.tar.gz"
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("downloaded %v, want [%s]", got, want)
+	}
+}
+
+// A pinned version is already published, so a missing file is a real error and must
+// not fall back to the previous build.
+func TestInstallDefaultVersionDoesNotFallBack(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request for %s", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	originalCurrent := currentVersionURL
+	originalPrev := previousVersionURL
+	currentVersionURL = server.URL + "/llama-cpp-builder/version.json"
+	previousVersionURL = server.URL + "/llama-cpp-builder/previous.json"
+	defer func() {
+		currentVersionURL = originalCurrent
+		previousVersionURL = originalPrev
+	}()
+
+	originalDefault := DefaultVersion
+	DefaultVersion = "b7974"
+	defer func() { DefaultVersion = originalDefault }()
+
+	originalGet := getFunc
+	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+		return ErrFileNotFound
+	}
+	defer func() { getFunc = originalGet }()
+
+	target := Target{Arch: AMD64, OS: Linux, Processor: CPU}
+	err := Install(context.Background(), target, t.TempDir(), nil, nil)
+	if !errors.Is(err, ErrFileNotFound) {
+		t.Fatalf("Install() error = %v, want %v", err, ErrFileNotFound)
+	}
+}

--- a/pkg/download/version.go
+++ b/pkg/download/version.go
@@ -1,0 +1,9 @@
+package download
+
+// DefaultVersion is the llama.cpp release that this yzma release installs when no
+// version is asked for. An empty value means the most recent nightly build, which
+// is the state on the main branch between yzma releases.
+//
+// Set it to the llama.cpp tag for the release in the same commit that bumps
+// version.go, then set it back to "" after the release is tagged.
+var DefaultVersion = ""


### PR DESCRIPTION
A tagged release of yzma now installs a known llama.cpp release by default. This makes an install from a tagged release repeatable, instead of always taking the most recent nightly build.

### Changes

- `pkg/download/version.go` adds `DefaultVersion`, the llama.cpp tag for this yzma release. Set it in the release commit that bumps `version.go`, then set it back to `""` after the release is tagged. It is empty on `main`, so a development build keeps the current behavior.
- `Install` maps an empty `Target.Version` to `DefaultVersion` before the lookup of the most recent build. This also applies to `yzma install -upgrade` without `-version`.
- An explicit `-version` wins. `-version latest` always asks for the most recent nightly build.
- A pinned version is already published, so a missing file stays an error. There is no fallback to the previous build, which could quietly install a version that does not match.
- The install message names the pinned version. Docs and the installer example follow.

### Tests

New cases in `pkg/download/resolver_test.go` for the pin, the explicit version, `latest`, and the missing fallback. `go build ./...`, `go vet ./...`, and `go test ./pkg/download/` pass.