### PR TITLE
llama: follow the upstream llama.cpp b10675 ABI change

### DIFF
--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -411,20 +411,21 @@ type ContextParams struct {
 
 // ModelQuantizeParams defines the parameters for model quantize parameters
 type ModelQuantizeParams struct {
-	NThread              int32 // number of threads to use for quantizing
-	Ftype                Ftype // quantize to this llama_ftype
-	OutputTensorType     int32 // output tensor type
-	TokenEmbeddingType   int32 // token embeddings tensor type
-	AllowRequantize      uint8 // allow quantizing non-f32/f16 tensors (bool as uint8)
-	QuantizeOutputTensor uint8 // quantize output.weight (bool as uint8)
-	OnlyCopy             uint8 // only copy tensors - ftype, allow_requantize and quantize_output_tensor are ignored
-	Pure                 uint8 // quantize all tensors to the default type
-	KeepSplit            uint8 // keep split tensors (bool as uint8)
-	DryRun               uint8 // calculate and show the final quantization size without performing quantization (bool as uint8)
-	IMatrix              *byte // pointer to importance matrix data
-	KvOverrides          *byte // pointer to vector containing overrides
-	TensorTypes          *byte // pointer to vector containing tensor types
-	PruneLayers          *byte // pointer to vector containing layer indices to prune
+	NThread              int32  // number of threads to use for quantizing
+	Ftype                Ftype  // quantize to this llama_ftype
+	OutputTensorType     int32  // output tensor type
+	TokenEmbeddingType   int32  // token embeddings tensor type
+	AllowRequantize      uint8  // allow quantizing non-f32/f16 tensors (bool as uint8)
+	QuantizeOutputTensor uint8  // quantize output.weight (bool as uint8)
+	OnlyCopy             uint8  // only copy tensors - ftype, allow_requantize and quantize_output_tensor are ignored
+	Pure                 uint8  // quantize all tensors to the default type
+	KeepSplit            uint8  // keep split tensors (bool as uint8)
+	DryRun               uint8  // calculate and show the final quantization size without performing quantization (bool as uint8)
+	IMatrix              *byte  // pointer to importance matrix data
+	KvOverrides          *byte  // pointer to vector containing overrides
+	TensorTypes          *byte  // pointer to vector containing tensor types
+	PruneLayers          *byte  // pointer to vector containing layer indices to prune
+	MaxBufSize           uint64 // max bytes of tensor rows kept in memory at once, 0 = default (8 GiB)
 }
 
 // Chat message

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -22,7 +22,8 @@ var (
 	// ffiTypeModelQuantizeParams represents the C struct llama_model_quantize_params
 	ffiTypeModelQuantizeParams = ffi.NewType(&ffi.TypeSint32, &ffi.TypeSint32,
 		&ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8, &ffi.TypeUint8,
-		&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer)
+		&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer,
+		&ffiTypeSize)
 )
 
 var (


### PR DESCRIPTION
Upstream llama.cpp b10675 adds a member to the end of `llama_model_quantize_params`.

```c
const int32_t * prune_layers;
size_t max_buf_size;   // max bytes of tensor rows kept in memory at once, 0 = default (8 GiB)
```

The FFI Checker reports this as a RULE1 type mismatch on `llama_model_quantize_default_params`. The descriptor is 56 bytes with 14 members, the C struct is 64 bytes with 15 members.

### Changes

- `pkg/llama/model.go` adds `&ffiTypeSize` to the end of `ffiTypeModelQuantizeParams`.
- `pkg/llama/llama.go` adds `MaxBufSize uint64` to the end of `ModelQuantizeParams`.

### Tests

`go build ./...` and `go vet ./...` pass.