### PR TITLE
loader: keep the FFI argument types alive

### DIFF
--- a/pkg/llama/backend.go
+++ b/pkg/llama/backend.go
@@ -3,6 +3,7 @@ package llama
 import (
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -55,7 +56,7 @@ var (
 	loadModeFromStrFunc ffi.Fun
 )
 
-func loadBackendFuncs(lib ffi.Lib) error {
+func loadBackendFuncs(lib loader.Lib) error {
 	var err error
 	if backendInitFunc, err = lib.Prep("llama_backend_init", &ffi.TypeVoid); err != nil {
 		return loadError("llama_backend_init", err)

--- a/pkg/llama/batch.go
+++ b/pkg/llama/batch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/jupiterrider/ffi"
 )
 
@@ -47,7 +48,7 @@ var (
 	batchGetOneFunc ffi.Fun
 )
 
-func loadBatchFuncs(lib ffi.Lib) error {
+func loadBatchFuncs(lib loader.Lib) error {
 	var err error
 
 	if batchInitFunc, err = lib.Prep("llama_batch_init", &ffiTypeBatch, &ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypeSint32); err != nil {

--- a/pkg/llama/chat.go
+++ b/pkg/llama/chat.go
@@ -3,6 +3,7 @@ package llama
 import (
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -21,7 +22,7 @@ var (
 	chatBuiltinTemplatesFunc ffi.Fun
 )
 
-func loadChatFuncs(lib ffi.Lib) error {
+func loadChatFuncs(lib loader.Lib) error {
 	var err error
 	if chatApplyTemplateFunc, err = lib.Prep("llama_chat_apply_template", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize,
 		&ffi.TypeUint8, &ffi.TypePointer, &ffi.TypeSint32); err != nil {

--- a/pkg/llama/context.go
+++ b/pkg/llama/context.go
@@ -5,6 +5,7 @@ import (
 	"unsafe"
 
 	"github.com/ebitengine/purego"
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/jupiterrider/ffi"
 )
 
@@ -182,7 +183,7 @@ var (
 	nCtxSeqFunc ffi.Fun
 )
 
-func loadContextFuncs(lib ffi.Lib) error {
+func loadContextFuncs(lib loader.Lib) error {
 	var err error
 
 	if contextDefaultParamsFunc, err = lib.Prep("llama_context_default_params", &ffiTypeContextParams); err != nil {

--- a/pkg/llama/ggml.go
+++ b/pkg/llama/ggml.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -170,7 +171,7 @@ var (
 	ggmlBackendRegByNameFunc ffi.Fun
 )
 
-func loadGGML(lib ffi.Lib) error {
+func loadGGML(lib loader.Lib) error {
 	var err error
 
 	if ggmlBackendLoadAllFunc, err = lib.Prep("ggml_backend_load_all", &ffi.TypeVoid); err != nil {

--- a/pkg/llama/ggml_base.go
+++ b/pkg/llama/ggml_base.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -46,7 +47,7 @@ var (
 	ggmlTypeNameFunc ffi.Fun
 )
 
-func loadGGMLBase(lib ffi.Lib) error {
+func loadGGMLBase(lib loader.Lib) error {
 	var err error
 
 	if ggmlBackendCpuBufferType, err = lib.Prep("ggml_backend_cpu_buffer_type", &ffi.TypePointer); err != nil {

--- a/pkg/llama/logs.go
+++ b/pkg/llama/logs.go
@@ -4,6 +4,7 @@ import (
 	"unsafe"
 
 	"github.com/ebitengine/purego"
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/jupiterrider/ffi"
 )
 
@@ -18,7 +19,7 @@ var (
 	logGetFunc ffi.Fun
 )
 
-func loadLogFuncs(lib ffi.Lib) error {
+func loadLogFuncs(lib loader.Lib) error {
 	var err error
 
 	if logSetFunc, err = lib.Prep("llama_log_set", &ffi.TypeVoid, &ffi.TypePointer, &ffi.TypePointer); err != nil {

--- a/pkg/llama/lora.go
+++ b/pkg/llama/lora.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -55,7 +56,7 @@ var (
 	errInvalidAdapter = errors.New("invalid LoRA adapter")
 )
 
-func loadLoraFuncs(lib ffi.Lib) error {
+func loadLoraFuncs(lib loader.Lib) error {
 	var err error
 
 	if adapterLoraInitFunc, err = lib.Prep("llama_adapter_lora_init", &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer); err != nil {

--- a/pkg/llama/memory.go
+++ b/pkg/llama/memory.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/jupiterrider/ffi"
 )
 
@@ -42,7 +43,7 @@ var (
 	memoryCanShiftFunc ffi.Fun
 )
 
-func loadMemoryFuncs(lib ffi.Lib) error {
+func loadMemoryFuncs(lib loader.Lib) error {
 	var err error
 
 	if memoryClearFunc, err = lib.Prep("llama_memory_clear", &ffi.TypeVoid, &ffi.TypePointer, &ffi.TypeUint8); err != nil {

--- a/pkg/llama/model.go
+++ b/pkg/llama/model.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -163,7 +164,7 @@ var (
 	splitPrefixFunc ffi.Fun
 )
 
-func loadModelFuncs(lib ffi.Lib) error {
+func loadModelFuncs(lib loader.Lib) error {
 	var err error
 
 	if modelDefaultParamsFunc, err = lib.Prep("llama_model_default_params", &ffiTypeModelParams); err != nil {

--- a/pkg/llama/perf.go
+++ b/pkg/llama/perf.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/jupiterrider/ffi"
 )
 
@@ -54,7 +55,7 @@ var (
 	perfSamplerResetFunc ffi.Fun
 )
 
-func loadPerfFuncs(lib ffi.Lib) error {
+func loadPerfFuncs(lib loader.Lib) error {
 	var err error
 
 	if perfContextFunc, err = lib.Prep("llama_perf_context", &ffiPerfContextData, &ffi.TypePointer); err != nil {

--- a/pkg/llama/sampling.go
+++ b/pkg/llama/sampling.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -167,7 +168,7 @@ var (
 	samplerGetSeedFunc ffi.Fun
 )
 
-func loadSamplingFuncs(lib ffi.Lib) error {
+func loadSamplingFuncs(lib loader.Lib) error {
 	var err error
 
 	if samplerChainDefaultParamsFunc, err = lib.Prep("llama_sampler_chain_default_params", &ffiSamplerChainParams); err != nil {

--- a/pkg/llama/state.go
+++ b/pkg/llama/state.go
@@ -3,6 +3,7 @@ package llama
 import (
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -119,7 +120,7 @@ var (
 	stateSeqSetDataExtFunc ffi.Fun
 )
 
-func loadStateFuncs(lib ffi.Lib) error {
+func loadStateFuncs(lib loader.Lib) error {
 	var err error
 
 	if stateSaveFileFunc, err = lib.Prep("llama_state_save_file", &ffi.TypeUint8, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypeUint64); err != nil {

--- a/pkg/llama/vocab.go
+++ b/pkg/llama/vocab.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -114,7 +115,7 @@ var (
 	vocabTypeFunc ffi.Fun
 )
 
-func loadVocabFuncs(lib ffi.Lib) error {
+func loadVocabFuncs(lib loader.Lib) error {
 	var err error
 
 	if modelGetVocabFunc, err = lib.Prep("llama_model_get_vocab", &ffi.TypePointer, &ffi.TypePointer); err != nil {

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -5,26 +5,79 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"sync"
 
 	"github.com/jupiterrider/ffi"
 )
 
+// Lib is a handle to a shared library.
+type Lib struct {
+	lib ffi.Lib
+}
+
+// argTypes keeps the argument type arrays reachable. ffi_prep_cif stores the
+// array address in the cif with a C write that the Go collector cannot see.
+// https://github.com/libffi/libffi/blob/v3.4.6/src/prep_cif.c#L128
+var (
+	argTypesMu sync.Mutex
+	argTypes   = make(map[string][]*ffi.Type)
+)
+
+// keepArgTypes returns the kept array for these argument types. One array
+// serves every function with the same signature, so a second call to Load
+// keeps no more memory than the first.
+func keepArgTypes(args []*ffi.Type) []*ffi.Type {
+	if len(args) == 0 {
+		return args
+	}
+
+	var b strings.Builder
+	for _, arg := range args {
+		fmt.Fprintf(&b, "%p,", arg)
+	}
+	key := b.String()
+
+	argTypesMu.Lock()
+	defer argTypesMu.Unlock()
+
+	kept, ok := argTypes[key]
+	if !ok {
+		kept = args
+		argTypes[key] = kept
+	}
+
+	return kept
+}
+
+// Prep gets the address of a function and describes its signature.
+// It keeps the argument types reachable for the life of the program.
+func (l Lib) Prep(name string, ret *ffi.Type, args ...*ffi.Type) (ffi.Fun, error) {
+	// args must reach libffi as the array that keepArgTypes holds.
+	return l.lib.Prep(name, ret, keepArgTypes(args)...)
+}
+
 // LoadLibrary The path can be an empty string to use the location as set by the YZMA_LIB env variable.
 // The lib should be the "short name" for the library, for example:
 // gguf, llama, mtmd
-func LoadLibrary(path, lib string) (ffi.Lib, error) {
+func LoadLibrary(path, lib string) (Lib, error) {
 	if path == "" && os.Getenv("YZMA_LIB") != "" {
 		path = os.Getenv("YZMA_LIB")
 	}
 
 	// Ensure the library path is set
 	if path == "" {
-		return ffi.Lib{}, fmt.Errorf("library path not specified and YZMA_LIB env variable not set")
+		return Lib{}, fmt.Errorf("library path not specified and YZMA_LIB env variable not set")
 	}
 
 	filename := GetLibraryFilename(path, lib)
 
-	return ffi.Load(filename)
+	l, err := ffi.Load(filename)
+	if err != nil {
+		return Lib{}, err
+	}
+
+	return Lib{lib: l}, nil
 }
 
 // GetLibraryFilename returns the full path to the library file for the given path and library name.

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -1,10 +1,13 @@
 package loader
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/jupiterrider/ffi"
 )
 
 func TestGetLibraryFilename(t *testing.T) {
@@ -184,5 +187,67 @@ func TestGetLibraryFilename_DifferentLibNames(t *testing.T) {
 				t.Errorf("expected result to contain '%s', got '%s'", lib, result)
 			}
 		})
+	}
+}
+
+// The cif must point at the same argument type array that Prep keeps alive.
+// If it points somewhere else, the collector can free the array that libffi
+// reads on every call.
+func TestPrepKeepsArgTypes(t *testing.T) {
+	if os.Getenv("YZMA_LIB") == "" {
+		t.Skip("no YZMA_LIB set, skipping test")
+	}
+
+	lib, err := LoadLibrary("", "llama")
+	if err != nil {
+		t.Fatalf("LoadLibrary failed: %v", err)
+	}
+
+	args := []*ffi.Type{&ffi.TypePointer, &ffi.TypeSint32}
+	fun, err := lib.Prep("llama_model_n_params", &ffi.TypeUint64, args...)
+	if err != nil {
+		t.Fatalf("Prep failed: %v", err)
+	}
+
+	kept := keepArgTypes(args)
+
+	if fun.Cif.ArgTypes != &kept[0] {
+		t.Errorf("cif.ArgTypes is %p, want the kept array at %p", fun.Cif.ArgTypes, &kept[0])
+	}
+
+	runtime.GC()
+
+	if fun.Cif.ArgTypes != &kept[0] {
+		t.Errorf("cif.ArgTypes changed after a collection")
+	}
+}
+
+// A second Prep of the same signature must not keep a second array.
+func TestPrepReusesArgTypes(t *testing.T) {
+	if os.Getenv("YZMA_LIB") == "" {
+		t.Skip("no YZMA_LIB set, skipping test")
+	}
+
+	lib, err := LoadLibrary("", "llama")
+	if err != nil {
+		t.Fatalf("LoadLibrary failed: %v", err)
+	}
+
+	argTypesMu.Lock()
+	before := len(argTypes)
+	argTypesMu.Unlock()
+
+	for range 10 {
+		if _, err := lib.Prep("llama_model_n_params", &ffi.TypeUint64, &ffi.TypePointer, &ffi.TypeSint32); err != nil {
+			t.Fatalf("Prep failed: %v", err)
+		}
+	}
+
+	argTypesMu.Lock()
+	after := len(argTypes)
+	argTypesMu.Unlock()
+
+	if after-before > 1 {
+		t.Errorf("10 preps of one signature kept %d arrays, want at most 1", after-before)
 	}
 }

--- a/pkg/mtmd/batch.go
+++ b/pkg/mtmd/batch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/jupiterrider/ffi"
 )
 
@@ -50,7 +51,7 @@ var (
 	batchGetOutputEmbdFunc ffi.Fun
 )
 
-func loadBatchFuncs(lib ffi.Lib) error {
+func loadBatchFuncs(lib loader.Lib) error {
 	var err error
 
 	if batchInitFunc, err = lib.Prep("mtmd_batch_init", &ffi.TypePointer, &ffi.TypePointer); err != nil {

--- a/pkg/mtmd/bitmap.go
+++ b/pkg/mtmd/bitmap.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -84,7 +85,7 @@ var (
 	bitmapInitFromAudioFunc ffi.Fun
 )
 
-func loadBitmapFuncs(lib ffi.Lib) error {
+func loadBitmapFuncs(lib loader.Lib) error {
 	var err error
 
 	if bitmapInitFunc, err = lib.Prep("mtmd_bitmap_init", &ffi.TypePointer, &ffi.TypeSint32, &ffi.TypeSint32, &ffi.TypePointer); err != nil {

--- a/pkg/mtmd/chunks.go
+++ b/pkg/mtmd/chunks.go
@@ -4,6 +4,7 @@ import (
 	"unsafe"
 
 	"github.com/hybridgroup/yzma/pkg/llama"
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -71,7 +72,7 @@ var (
 	inputImageTokensGetNPosFunc ffi.Fun
 )
 
-func loadChunkFuncs(lib ffi.Lib) error {
+func loadChunkFuncs(lib loader.Lib) error {
 	var err error
 
 	if inputChunksInitFunc, err = lib.Prep("mtmd_input_chunks_init", &ffi.TypePointer); err != nil {

--- a/pkg/mtmd/mtmd.go
+++ b/pkg/mtmd/mtmd.go
@@ -7,6 +7,7 @@ import (
 	"unsafe"
 
 	"github.com/hybridgroup/yzma/pkg/llama"
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -157,7 +158,7 @@ var (
 	getMarkerFunc ffi.Fun
 )
 
-func loadFuncs(lib ffi.Lib) error {
+func loadFuncs(lib loader.Lib) error {
 	var err error
 
 	if defaultMarkerFunc, err = lib.Prep("mtmd_default_marker", &ffi.TypePointer); err != nil {

--- a/pkg/mtmd/video.go
+++ b/pkg/mtmd/video.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"unsafe"
 
+	"github.com/hybridgroup/yzma/pkg/loader"
 	"github.com/hybridgroup/yzma/pkg/utils"
 	"github.com/jupiterrider/ffi"
 )
@@ -72,7 +73,7 @@ var (
 	helperVideoGetInfoFunc ffi.Fun
 )
 
-func loadVideoFuncs(lib ffi.Lib) error {
+func loadVideoFuncs(lib loader.Lib) error {
 	var err error
 
 	if helperSupportVideoFunc, err = lib.Prep("mtmd_helper_support_video", &ffi.TypeUint8, &ffi.TypePointer); err != nil {


### PR DESCRIPTION
Fixes #303.

### Cause

`ffi_prep_cif` stores the address of the argument type array in the cif:

```c
cif->arg_types = atypes;
```
[libffi v3.4.6 src/prep_cif.c#L128](https://github.com/libffi/libffi/blob/v3.4.6/src/prep_cif.c#L128)

In `jupiterrider/ffi` that array is the Go backing array of the variadic slice of `Prep`, and the cif is a Go object from `new(Cif)`. So C writes a Go pointer into Go memory with no write barrier. After `Prep` returns, Go holds no reference to the array. The collector can then miss the reference or free the array while libffi still reads it on each call.

Each test calls `Load`, which does all 274 `Prep` calls again. This makes many unbounded pointer writes while the collector runs, which is why the crash was random, appeared on all three platforms, and stopped a different test each time.

The crash report shows this directly. A 32 byte object with `Abi=2, NArgs=5`, which is an `ffi.Cif`, held the address of the 48 byte array that the collector did not mark.

### Changes

- `pkg/loader` adds a `Lib` type that holds the `ffi.Lib` and keeps the argument types reachable. One array serves every function with the same signature, so a second call to `Load` keeps no more memory than the first. libffi only reads the array, and the types it points to are already shared.
- The 19 `loadXxxFuncs` functions take a `loader.Lib`. The 274 `lib.Prep` call sites do not change.
- `Lib` holds the `ffi.Lib` in a private field, so a call cannot reach the unprotected `Prep` by accident.

### Tests

`TestPrepKeepsArgTypes` shows the cif points at the kept array, and that this stays true after a collection. `TestPrepReusesArgTypes` shows that ten preps of one signature keep at most one array. Both fail if the code keeps a copy instead of the array that libffi received.

With `GOGC=1 GODEBUG=gccheckmark=1,clobberfree=1` on `./pkg/llama/ ./pkg/mtmd/ ./pkg/loader/`:

| Branch | Runs with a GC crash |
| --- | --- |
| `main` | 6 of 6 |
| this branch | 0 of 8 |

Memory across repeated loads is flat.

| | Kept arrays | Heap |
| --- | --- | --- |
| start | 0 | 757,280 B |
| after 1 load | 5 | 721,624 B |
| after 200 loads | 5 | 722,088 B |

`go build ./...` and `go vet ./...` pass. The test results are the same as `main`.
