### PR TITLE
llama: align lazy-loading API names with llama.cpp b10679

### DIFF
--- a/pkg/llama/llama.go
+++ b/pkg/llama/llama.go
@@ -184,12 +184,12 @@ const (
 	LoadModeDirectIO  LoadMode = 4  // use direct I/O if available
 )
 
-type TensorReadLazy int32
+type LazyMode int32
 
 const (
-	TensorReadLazyOff  TensorReadLazy = 0 // always read the whole tensor up front
-	TensorReadLazyAuto TensorReadLazy = 1 // lazy only for marked tensors larger than 4 GiB (requires mmap)
-	TensorReadLazyOn   TensorReadLazy = 2 // read the rows of tensors marked by the arch on demand (requires mmap)
+	LazyModeOff  LazyMode = 0 // always read the whole tensor up front
+	LazyModeAuto LazyMode = 1 // lazy only for marked tensors larger than 4 GiB (requires mmap)
+	LazyModeOn   LazyMode = 2 // read the rows of tensors marked by the arch on demand (requires mmap)
 )
 
 type GpuBackend int32
@@ -336,23 +336,23 @@ type ProgressCallback func(progress float32, userData uintptr) uint8
 
 // ModelParams allows configuration of the model and how it's loaded
 type ModelParams struct {
-	Devices                  uintptr        // ggml_backend_dev_t * - NULL-terminated list of devices
-	TensorBuftOverrides      uintptr        // const struct llama_model_tensor_buft_override *
-	NGpuLayers               int32          // number of layers to store in VRAM
-	SplitMode                SplitMode      // how to split the model across multiple GPUs
-	LoadMode                 LoadMode       // how to load the model
-	TensorReadLazy           TensorReadLazy // on-demand reading of tensors marked by the arch
-	MainGpu                  int32          // the GPU that is used for the entire model
-	TensorSplit              *float32       // proportion of the model to offload to each GPU
-	ProgressCallback         uintptr        // llama_progress_callback function pointer
-	ProgressCallbackUserData uintptr        // context pointer passed to the progress callback
-	KvOverrides              uintptr        // const struct llama_model_kv_override *
-	VocabOnly                uint8          // only load the vocabulary, no weights (bool as uint8)
-	CheckTensors             uint8          // validate model tensor data (bool as uint8)
-	UseExtraBufts            uint8          // use extra buffer types (bool as uint8)
-	NoHost                   uint8          // bypass host buffer allowing extra buffers to be used (bool as uint8)
-	NoAlloc                  uint8          // only load metadata and simulate memory allocations (bool as uint8)
-	LoadMTP                  uint8          // whether to load MTP layers (bool as uint8)
+	Devices                  uintptr   // ggml_backend_dev_t * - NULL-terminated list of devices
+	TensorBuftOverrides      uintptr   // const struct llama_model_tensor_buft_override *
+	NGpuLayers               int32     // number of layers to store in VRAM
+	SplitMode                SplitMode // how to split the model across multiple GPUs
+	LoadMode                 LoadMode  // how to load the model
+	LazyMode                 LazyMode  // on-demand reading of tensors marked by the arch
+	MainGpu                  int32     // the GPU that is used for the entire model
+	TensorSplit              *float32  // proportion of the model to offload to each GPU
+	ProgressCallback         uintptr   // llama_progress_callback function pointer
+	ProgressCallbackUserData uintptr   // context pointer passed to the progress callback
+	KvOverrides              uintptr   // const struct llama_model_kv_override *
+	VocabOnly                uint8     // only load the vocabulary, no weights (bool as uint8)
+	CheckTensors             uint8     // validate model tensor data (bool as uint8)
+	UseExtraBufts            uint8     // use extra buffer types (bool as uint8)
+	NoHost                   uint8     // bypass host buffer allowing extra buffers to be used (bool as uint8)
+	NoAlloc                  uint8     // only load metadata and simulate memory allocations (bool as uint8)
+	LoadMTP                  uint8     // whether to load MTP layers (bool as uint8)
 }
 
 // ContextParams controls the parameters available for the model context

--- a/pkg/llama/model_test.go
+++ b/pkg/llama/model_test.go
@@ -79,6 +79,9 @@ func TestModelDefaultParamsLayout(t *testing.T) {
 	if params.LoadMode < LoadModeAuto || params.LoadMode > LoadModeDirectIO {
 		t.Errorf("LoadMode is %d, want a valid LoadMode", params.LoadMode)
 	}
+	if params.LazyMode < LazyModeOff || params.LazyMode > LazyModeOn {
+		t.Errorf("LazyMode is %d, want a valid LazyMode", params.LazyMode)
+	}
 	if params.MainGpu < 0 {
 		t.Errorf("MainGpu is %d, want >= 0", params.MainGpu)
 	}


### PR DESCRIPTION
llama.cpp b10679 renamed its public lazy tensor-loading API in ggml-org/llama.cpp#27881.

Upstream renamed:

```text
enum llama_tensor_read_lazy         -> enum llama_lazy_mode
LLAMA_TENSOR_READ_LAZY_OFF          -> LLAMA_LAZY_MODE_OFF
LLAMA_TENSOR_READ_LAZY_AUTO         -> LLAMA_LAZY_MODE_AUTO
LLAMA_TENSOR_READ_LAZY_ON           -> LLAMA_LAZY_MODE_ON
llama_model_params.tensor_read_lazy -> llama_model_params.lazy_mode
```

This PR renames `TensorReadLazy` to `LazyMode`, the three constants to
`LazyModeOff`, `LazyModeAuto`, and `LazyModeOn`, and the `ModelParams` field
to `LazyMode`.

## The ABI does not change

The enum stays 32 bits, the values stay 0, 1, and 2, and the member stays at
the same offset in `llama_model_params`. `ffiTypeModelParams` keeps the same
32-bit slot in the same position and is not touched.

## There is no source break

`TensorReadLazy` came in with c4fed78, which is after the v1.25.0 tag, so the
old names are in no release. No caller can depend on them. Deprecated aliases
and a migration note are therefore not needed, and this does not have to wait
for a breaking release.

## Tests

`TestModelDefaultParamsLayout` gets a `LazyMode` range check next to the
`LoadMode` one, so a shifted field is caught.

## Verification against b10679

- `go test ./...` passes for all packages with a b10679 build.
- `ModelDefaultParams()` returns `LazyModeAuto`.
- `yzma-checker` against the b10679 headers reports 0 violations and 177 of
  177 constants clean. It now matches all three constants to the upstream
  enum, which the old names could not do:

```text
CONST LazyModeOff  = 0   LLAMA_LAZY_MODE_OFF  (enum llama_lazy_mode, llama.h:218)
CONST LazyModeAuto = 1   LLAMA_LAZY_MODE_AUTO (enum llama_lazy_mode, llama.h:219)
CONST LazyModeOn   = 2   LLAMA_LAZY_MODE_ON   (enum llama_lazy_mode, llama.h:220)
```

Fixes #302