### PR TITLE
Run llama.cpp in a browser with TinyGo

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,66 @@
+name: WebAssembly
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      TINYGO_VERSION: '0.41.1'
+      WASM_DIR: build/wasm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+      - name: Check the WebAssembly code
+        run: make vet-wasm
+      - name: Install TinyGo
+        run: |
+          set -e
+          curl -sSL -o tinygo.deb https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb
+          sudo dpkg -i tinygo.deb
+          tinygo version
+      - name: Get latest llama.cpp version
+        id: llama-version
+        run: |
+          VERSION=$(curl -s https://hybridgroup.github.io/llama-cpp-builder/version.json | jq -r '.tag_name')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Latest llama.cpp version: $VERSION"
+      - name: Install yzma command
+        run: go install .
+      - name: Install the WebAssembly build of llama.cpp
+        run: |
+          set -e
+          yzma install -lib $GITHUB_WORKSPACE/$WASM_DIR -os wasm -version ${{ steps.llama-version.outputs.version }}
+      - name: Build the example with TinyGo
+        run: make wasm-example
+      - name: Cache test model
+        id: cache-model
+        uses: actions/cache@v4
+        with:
+          path: models
+          key: ${{ runner.os }}-wasm-models-v1
+      - name: Download the test model
+        if: steps.cache-model.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ./models
+          yzma model get -y --show-progress=false -o $GITHUB_WORKSPACE/models -u https://huggingface.co/QuantFactory/SmolLM-135M-GGUF/resolve/main/SmolLM-135M.Q2_K.gguf
+      - name: Run inference in Node
+        run: |
+          node wasm/node/run.js \
+            --dir $GITHUB_WORKSPACE/$WASM_DIR \
+            --model $GITHUB_WORKSPACE/models/SmolLM-135M.Q2_K.gguf \
+            --tokens 12
+      - name: Build the example with the standard toolchain
+        run: make wasm-example-go

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -19,10 +19,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      # TinyGo 0.41.1 works with Go 1.26 and not with Go 1.27. Go back to
+      # 'stable' after the release of TinyGo that adds Go 1.27.
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
+          go-version: '1.26'
       - name: Check the WebAssembly code
         run: make vet-wasm
       - name: Install TinyGo

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ lib/
 /models
 yzma
 llama.webm
+
+# WebAssembly build output
+build/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -220,6 +220,16 @@ You can run `yzma` on a [Arduino UNO Q board](https://docs.arduino.cc/hardware/u
 yzma install --lib /path/to/lib --processor cpu --os trixie
 ```
 
+### WebAssembly (browser)
+
+`yzma` runs in a browser with the WebAssembly build of `llama.cpp`. Both builds come down, the one with a single thread and the one with more threads, and the JavaScript glue takes the one that the page can use:
+
+```
+yzma install --lib /path/to/web --os wasm
+```
+
+This build has no GPU, and it uses the smaller API of the [`pkg/llamawasm`](./pkg/llamawasm) package. See [wasm/README.md](./wasm/README.md).
+
 ### Windows CPU
 
 ![Windows logo](./images/windows-10-logo.png)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ MAKEFILE_PATH := $(realpath $(lastword $(MAKEFILE_LIST)))
 MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
 YZMA_LIB ?= $(MAKEFILE_DIR)lib
 MODELS_DIR ?= $(HOME)/models
+WASM_DIR ?= $(MAKEFILE_DIR)build/wasm
 
 # make download-models to download the models used in tests and examples.
 # make download-models MODELS_DIR=/path/to/models to specify a different directory for the models.
@@ -45,6 +46,53 @@ test:
 	export YZMA_TEST_LORA_ADAPTER=$(MODELS_DIR)/Gemma2-Lora-F32-LoRA.gguf && \
 	export YZMA_TEST_SPLIT_MODELS="$(MODELS_DIR)/stories15M-q8_0-00001-of-00003.gguf,$(MODELS_DIR)/stories15M-q8_0-00002-of-00003.gguf,$(MODELS_DIR)/stories15M-q8_0-00003-of-00003.gguf" && \
 	go test -count=1 ./...
+
+# make wasm-example to build the browser example with TinyGo. Run
+# make download-llama.cpp-wasm first to get the WebAssembly build of llama.cpp.
+wasm-example: wasm-assets
+	tinygo build -target wasm -o $(WASM_DIR)/yzma.wasm ./examples/wasm/chat
+	cp "$(shell tinygo env TINYGOROOT)/targets/wasm_exec.js" $(WASM_DIR)/
+
+# make wasm-example-go to build the same example with the standard toolchain.
+# The binary is larger, which helps when TinyGo cannot build a dependency.
+wasm-example-go: wasm-assets
+	GOOS=js GOARCH=wasm go build -o $(WASM_DIR)/yzma.wasm ./examples/wasm/chat
+	cp "$(shell go env GOROOT)/lib/wasm/wasm_exec.js" $(WASM_DIR)/
+
+# wasm-assets copies the JavaScript glue and the page into the build directory.
+# The two wasm_exec.js files are not the same, so the target that builds the
+# program copies the correct one.
+wasm-assets:
+	mkdir -p $(WASM_DIR)
+	cp wasm/yzma-loader.js wasm/worker.js wasm/index.html $(WASM_DIR)/
+
+# make download-llama.cpp-wasm to get the WebAssembly build of llama.cpp.
+download-llama.cpp-wasm:
+	mkdir -p $(WASM_DIR)
+	yzma install -lib $(WASM_DIR) -os wasm $(if $(VERSION),-v $(VERSION))
+
+# make serve-wasm to serve the example with the headers that a build with more
+# than one thread needs.
+serve-wasm:
+	go run ./wasm/serve -dir $(WASM_DIR)
+
+# make vet-wasm to check the WebAssembly code. It does not run in go test,
+# because the tests of the repo build for the machine they run on.
+vet-wasm:
+	GOOS=js GOARCH=wasm go build -o /dev/null ./examples/wasm/chat
+	GOOS=js GOARCH=wasm go vet ./pkg/llamawasm ./examples/wasm/chat
+
+# make test-wasm to run the WebAssembly build in Node, with no browser.
+test-wasm:
+	node wasm/node/run.js --dir $(WASM_DIR) --model $(MODELS_DIR)/SmolLM-135M.Q2_K.gguf --tokens 12
+
+# make test-wasm-mt to run the build with more than one thread in Node. Node has
+# SharedArrayBuffer without the headers that a browser needs.
+test-wasm-mt:
+	node wasm/node/run.js --dir $(WASM_DIR) --model $(MODELS_DIR)/SmolLM-135M.Q2_K.gguf --tokens 12 --mt
+
+clean-wasm:
+	rm -rf $(WASM_DIR)
 
 # make check-ffi to audit the FFI bindings against the headers of the current
 # llama.cpp release. The gate runs first: if it fails, do not use what the

--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ Sure! Let's go to the zoo and feed the llama. What kind of llama are you interes
 
 [See the code here](./examples/chat/main.go).
 
+### WebAssembly Example
+
+`yzma` also runs in a browser. `llama.cpp` becomes a WebAssembly module, and a Go program compiled by TinyGo drives it through the [`pkg/llamawasm`](./pkg/llamawasm) package:
+
+```shell
+$ make download-llama.cpp-wasm
+$ make wasm-example
+$ make serve-wasm
+```
+
+Then open http://localhost:8080
+
+See [wasm/README.md](./wasm/README.md) for how it works and what it can do.
+
 ### Additional Examples
 
 See the [examples](./examples/) directory for more examples of how to use `yzma`.
@@ -168,6 +182,12 @@ You can use multimodal models (image/audio) and text language models with full h
 | Linux   | amd64, arm64 | CUDA, Vulkan, HIP, ROCm, SYCL   |
 | macOS   | arm64        | Metal                           |
 | Windows | amd64        | CUDA, Vulkan, HIP, SYCL, OpenCL |
+
+A browser is also a target. There the computation uses the CPU and SIMD only, and the API is the smaller one of the [`pkg/llamawasm`](./pkg/llamawasm) package: text generation and embeddings, with no multimodal input, LoRA adapters, saved state, or quantization. See [wasm/README.md](./wasm/README.md).
+
+| Target  | CPU          | GPU  |
+| ------- | ------------ | ---- |
+| Browser | wasm32 SIMD, one or more threads | none |
 
 Whenever there is a new release of `llama.cpp`, the tests for `yzma` are run automatically. This helps us stay up to date with the latest code and models.
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -34,7 +34,7 @@ var InstallCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "os",
-			Usage: "operating system to use (linux, windows, darwin, bookworm, trixie)",
+			Usage: "target to use (linux, windows, darwin, bookworm, trixie, wasm)",
 			Value: runtime.GOOS,
 		},
 		&cli.BoolFlag{
@@ -66,8 +66,11 @@ func runInstall(c *cli.Context) error {
 		return fmt.Errorf("missing lib flag or YZMA_LIB env var")
 	}
 
+	// A wasm install puts the WebAssembly build of llama.cpp in place, which has
+	// its own file name, so the check for an existing install follows the target
+	// and not the machine that runs the command.
 	if !upgrade {
-		if _, err := os.Stat(filepath.Join(libPath, download.LibraryName(runtime.GOOS))); !os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(libPath, download.LibraryName(osInstall))); !os.IsNotExist(err) {
 			fmt.Println("llama.cpp already installed at", libPath)
 			return nil
 		}
@@ -85,6 +88,11 @@ func runInstall(c *cli.Context) error {
 		}
 	} else {
 		download.ProgressTracker = nil
+	}
+
+	if osInstall == download.Wasm.String() {
+		// A WebAssembly build has no GPU.
+		processor = download.CPU.String()
 	}
 
 	if processor == "" {
@@ -109,10 +117,27 @@ func runInstall(c *cli.Context) error {
 
 	if !quiet {
 		fmt.Println("done.")
-		showInstallRequirements(libPath)
+		if osInstall == download.Wasm.String() {
+			showWasmRequirements(libPath)
+		} else {
+			showInstallRequirements(libPath)
+		}
 	}
 
 	return nil
+}
+
+// showWasmRequirements says what to do with a WebAssembly install. YZMA_LIB has
+// no part in it, because a browser loads the files over HTTP.
+func showWasmRequirements(libPath string) {
+	fmt.Println(`
+The WebAssembly build of llama.cpp is in ` + libPath + `
+
+Put the JavaScript glue and the program of your page in the same directory, then
+serve it with the headers that a build with more than one thread needs:
+
+    make wasm-example
+    make serve-wasm`)
 }
 
 func showInstallRequirements(libPath string) {

--- a/examples/wasm/chat/main.go
+++ b/examples/wasm/chat/main.go
@@ -1,0 +1,208 @@
+//go:build js && wasm
+
+// Chat runs llama.cpp inference in a browser.
+//
+// The program is the same shape as examples/hello, but it uses the llamawasm
+// package instead of the llama package, and it sends each piece of text to the
+// page instead of printing it.
+//
+// Build it with TinyGo:
+//
+//	tinygo build -target wasm -o build/wasm/yzma.wasm ./examples/wasm/chat
+//
+// or with the standard toolchain:
+//
+//	GOOS=js GOARCH=wasm go build -o build/wasm/yzma.wasm ./examples/wasm/chat
+//
+// See wasm/README.md for how to serve the result.
+package main
+
+import (
+	"fmt"
+	"syscall/js"
+	"time"
+
+	"github.com/hybridgroup/yzma/pkg/llamawasm"
+)
+
+const modelPath = "/models/model.gguf"
+
+var (
+	model   llamawasm.Model
+	ctx     llamawasm.Context
+	vocab   llamawasm.Vocab
+	sampler llamawasm.Sampler
+)
+
+func main() {
+	if err := llamawasm.Load(""); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	llamawasm.LogSet(llamawasm.LogSilent())
+	llamawasm.Init()
+
+	// The page calls these.
+	js.Global().Set("yzmaLoadModel", js.FuncOf(loadModel))
+	js.Global().Set("yzmaOpenModel", js.FuncOf(openModel))
+	js.Global().Set("yzmaGenerate", js.FuncOf(generate))
+
+	post("ready", fmt.Sprintf("threads: %v", llamawasm.Threaded()))
+
+	// Keep the program alive so that the page can call into it.
+	<-make(chan struct{})
+}
+
+// loadModel(url) gets a model over the network and makes a context for it.
+func loadModel(this js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		post("error", "loadModel needs a URL")
+		return nil
+	}
+	url := args[0].String()
+
+	go func() {
+		post("status", "downloading the model")
+
+		err := llamawasm.FetchModelFile(modelPath, url, func(done, total int64) {
+			if total > 0 {
+				post("progress", fmt.Sprintf("%d%%", done*100/total))
+			}
+		})
+		if err != nil {
+			post("error", err.Error())
+			return
+		}
+
+		open(modelPath)
+	}()
+
+	return nil
+}
+
+// openModel(path) loads a model that is already in the filesystem of the
+// llama.cpp module. A test that has the file puts it there itself.
+func openModel(this js.Value, args []js.Value) any {
+	path := modelPath
+	if len(args) > 0 && args[0].Truthy() {
+		path = args[0].String()
+	}
+
+	go open(path)
+
+	return nil
+}
+
+// open loads the model at path and makes a context for it.
+func open(path string) {
+	post("status", "loading the model")
+
+	var err error
+	if model, err = llamawasm.ModelLoadFromFile(path, llamawasm.ModelDefaultParams()); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	params := llamawasm.ContextDefaultParams()
+	params.NCtx = 2048
+	params.NBatch = 512
+
+	if ctx, err = llamawasm.InitFromModel(model, params); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	vocab = llamawasm.ModelGetVocab(model)
+
+	post("loaded", llamawasm.ModelDesc(model))
+}
+
+// generate(prompt, maxTokens) makes text and sends each piece to the page.
+func generate(this js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		post("error", "generate needs a prompt")
+		return nil
+	}
+	prompt := args[0].String()
+
+	maxTokens := int32(128)
+	if len(args) > 1 && args[1].Truthy() {
+		maxTokens = int32(args[1].Int())
+	}
+
+	go func() {
+		if model == 0 || ctx == 0 {
+			post("error", "load a model first")
+			return
+		}
+
+		// Each generation starts from an empty state.
+		if err := llamawasm.MemoryClear(ctx, true); err != nil {
+			post("error", err.Error())
+			return
+		}
+
+		if sampler != 0 {
+			llamawasm.SamplerFree(sampler)
+		}
+		sampler = llamawasm.SamplerChainInit(llamawasm.SamplerChainDefaultParams())
+		llamawasm.SamplerChainAdd(sampler, llamawasm.SamplerInitGreedy())
+
+		tokens := llamawasm.Tokenize(vocab, prompt, true, false)
+		if len(tokens) == 0 {
+			post("error", "the prompt has no tokens")
+			return
+		}
+
+		batch := llamawasm.BatchGetOne(tokens)
+		buf := make([]byte, 64)
+		start := time.Now()
+
+		var count int32
+		for pos := int32(0); pos < maxTokens; pos += batch.NTokens {
+			if _, err := llamawasm.Decode(ctx, batch); err != nil {
+				post("error", err.Error())
+				return
+			}
+
+			token := llamawasm.SamplerSample(sampler, ctx, -1)
+			if llamawasm.VocabIsEOG(vocab, token) {
+				break
+			}
+			llamawasm.SamplerAccept(sampler, token)
+
+			if n := llamawasm.TokenToPiece(vocab, token, buf, 0, true); n > 0 {
+				post("token", string(buf[:n]))
+			}
+
+			count++
+			batch = llamawasm.BatchGetOne([]llamawasm.Token{token})
+		}
+
+		elapsed := time.Since(start).Seconds()
+		if elapsed > 0 {
+			post("done", fmt.Sprintf("%d tokens, %.2f tokens/s", count, float64(count)/elapsed))
+			return
+		}
+		post("done", fmt.Sprintf("%d tokens", count))
+	}()
+
+	return nil
+}
+
+// post sends a message to whatever holds this module. In a worker that is the
+// page, and in Node it is the console.
+func post(kind, text string) {
+	message := map[string]any{"kind": kind, "text": text}
+
+	if fn := js.Global().Get("postMessage"); fn.Type() == js.TypeFunction {
+		fn.Invoke(message)
+		return
+	}
+	if fn := js.Global().Get("yzmaOnMessage"); fn.Type() == js.TypeFunction {
+		fn.Invoke(message)
+		return
+	}
+	fmt.Printf("%s: %s\n", kind, text)
+}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -470,6 +470,8 @@ func LibraryName(operatingSystem string) string {
 		return "llama.dll"
 	case Darwin:
 		return "libllama.dylib"
+	case Wasm:
+		return "yzma_wasm.wasm"
 	default:
 		return "unknown"
 	}

--- a/pkg/download/os.go
+++ b/pkg/download/os.go
@@ -9,6 +9,10 @@ var (
 	Trixie   = newOS("trixie")
 	Darwin   = newOS("darwin")
 	Windows  = newOS("windows")
+
+	// Wasm is the WebAssembly build that a browser runs. It is not an
+	// operating system, but it is a target that has its own assets.
+	Wasm = newOS("wasm")
 )
 
 // =============================================================================

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -202,6 +202,17 @@ func defaultResolve(target Target) ([]string, error) {
 			return nil, ErrUnknownProcessor
 		}
 
+	case Wasm:
+		// A WebAssembly build has no GPU, so the processor is always CPU. Both
+		// variants come down: the JavaScript glue takes the one with more than
+		// one thread only if the page is isolated.
+		if prcssr != CPU {
+			return nil, ErrUnknownProcessor
+		}
+		location, tag = builderLocation, version
+		extra = append(extra, fmt.Sprintf("%s/llama-%s-bin-wasm-simd-mt.tar.gz", location, tag))
+		filename = fmt.Sprintf("llama-%s-bin-wasm-simd.tar.gz", tag)
+
 	default:
 		return nil, ErrUnknownOS
 	}

--- a/pkg/download/resolver_test.go
+++ b/pkg/download/resolver_test.go
@@ -105,6 +105,46 @@ func TestDefaultResolverWindowsCUDA(t *testing.T) {
 	}
 }
 
+// A wasm target takes both builds from the llama-cpp-builder release page: the
+// JavaScript glue picks the one with more than one thread only if the page can
+// use it.
+func TestDefaultResolverWasm(t *testing.T) {
+	urls, err := DefaultResolver.Resolve(Target{Arch: AMD64, OS: Wasm, Processor: CPU, Version: "b7974"})
+	if err != nil {
+		t.Fatalf("Resolve() failed: %v", err)
+	}
+	if len(urls) != 2 {
+		t.Fatalf("Resolve() returned %d urls, want 2: %v", len(urls), urls)
+	}
+	for _, want := range []string{
+		"llama-cpp-builder/releases/download/b7974/llama-b7974-bin-wasm-simd-mt.tar.gz",
+		"llama-cpp-builder/releases/download/b7974/llama-b7974-bin-wasm-simd.tar.gz",
+	} {
+		found := false
+		for _, url := range urls {
+			if strings.HasSuffix(url, want) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Resolve() = %v, want an asset ending in %q", urls, want)
+		}
+	}
+}
+
+// A wasm build has no GPU, so any processor other than CPU has no assets.
+func TestDefaultResolverWasmGPU(t *testing.T) {
+	if _, err := DefaultResolver.Resolve(Target{Arch: AMD64, OS: Wasm, Processor: CUDA, Version: "b7974"}); err == nil {
+		t.Fatal("Resolve() accepted a wasm target with a GPU")
+	}
+}
+
+func TestDefaultResolverLibraryNameWasm(t *testing.T) {
+	if got := LibraryName(Wasm.String()); got != "yzma_wasm.wasm" {
+		t.Errorf("LibraryName(wasm) = %q, want %q", got, "yzma_wasm.wasm")
+	}
+}
+
 func TestDefaultResolverUnknownProcessor(t *testing.T) {
 	_, err := DefaultResolver.Resolve(Target{Arch: ARM64, OS: Windows, Processor: CUDA, Version: "b7974"})
 	if err == nil {

--- a/pkg/llamawasm/batch.go
+++ b/pkg/llamawasm/batch.go
@@ -1,0 +1,17 @@
+//go:build js && wasm
+
+package llamawasm
+
+// BatchGetOne makes a batch that holds the given tokens. The positions of the
+// tokens continue from the state of the context that decodes the batch.
+func BatchGetOne(tokens []Token) Batch {
+	return Batch{
+		NTokens: int32(len(tokens)),
+		tokens:  tokens,
+	}
+}
+
+// Tokens gives the tokens of the batch.
+func (b Batch) Tokens() []Token {
+	return b.tokens
+}

--- a/pkg/llamawasm/context.go
+++ b/pkg/llamawasm/context.go
@@ -1,0 +1,122 @@
+//go:build js && wasm
+
+package llamawasm
+
+// InitFromModel makes an inference context for a model.
+func InitFromModel(model Model, params ContextParams) (Context, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+
+	handle, err := callErr("_yzma_context_new",
+		int(model),
+		int(params.NCtx),
+		int(params.NBatch),
+		int(params.NUbatch),
+		int(params.NThreads),
+		int(params.Embeddings),
+		int(params.PoolingType),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return Context(handle), nil
+}
+
+// Free frees a context.
+func Free(ctx Context) error {
+	if !Loaded() {
+		return ErrNotLoaded
+	}
+	callVoid("_yzma_context_free", int(ctx))
+	return nil
+}
+
+// NCtx gives the size of the context.
+func NCtx(ctx Context) uint32 {
+	if !Loaded() {
+		return 0
+	}
+	n := call("_yzma_context_n_ctx", int(ctx))
+	if n < 0 {
+		return 0
+	}
+	return uint32(n)
+}
+
+// Decode runs a batch of tokens through the model. The positions of the tokens
+// continue from the state of the context, the same as llama.BatchGetOne with
+// llama.Decode.
+func Decode(ctx Context, batch Batch) (int32, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+	if batch.NTokens == 0 {
+		return 0, nil
+	}
+
+	ptr, err := tokenScratch.reserve(len(batch.tokens) * 4)
+	if err != nil {
+		return 0, err
+	}
+	writeTokens(ptr, batch.tokens)
+
+	return callErr("_yzma_decode", int(ctx), ptr, len(batch.tokens))
+}
+
+// Encode runs a batch of tokens through an encoder model.
+func Encode(ctx Context, batch Batch) (int32, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+	if batch.NTokens == 0 {
+		return 0, nil
+	}
+
+	ptr, err := tokenScratch.reserve(len(batch.tokens) * 4)
+	if err != nil {
+		return 0, err
+	}
+	writeTokens(ptr, batch.tokens)
+
+	return callErr("_yzma_encode", int(ctx), ptr, len(batch.tokens))
+}
+
+// GetEmbeddingsSeq gives the embedding of a sequence. The n argument is the
+// number of values to read, which is ModelNEmbd of the model.
+func GetEmbeddingsSeq(ctx Context, seqID SeqId, n int32) ([]float32, error) {
+	if !Loaded() {
+		return nil, ErrNotLoaded
+	}
+	if n <= 0 {
+		return nil, nil
+	}
+
+	ptr, err := embdScratch.reserve(int(n) * 4)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := callErr("_yzma_get_embeddings_seq", int(ctx), int(seqID), ptr, int(n)); err != nil {
+		return nil, err
+	}
+	return readFloats(ptr, int(n)), nil
+}
+
+// MemoryClear removes everything from the memory of the context, which starts
+// the generation again from an empty state.
+//
+// On a native platform this takes a llama.Memory that comes from
+// llama.GetMemory. Here it takes the context, because the shim holds the
+// memory itself.
+func MemoryClear(ctx Context, data bool) error {
+	if !Loaded() {
+		return ErrNotLoaded
+	}
+	clear := 0
+	if data {
+		clear = 1
+	}
+	_, err := callErr("_yzma_memory_clear", int(ctx), clear)
+	return err
+}

--- a/pkg/llamawasm/doc.go
+++ b/pkg/llamawasm/doc.go
@@ -1,0 +1,60 @@
+//go:build js && wasm
+
+// Package llamawasm runs llama.cpp inference in a browser.
+//
+// The [llama] package loads the llama.cpp shared libraries with libffi. A
+// WebAssembly module cannot do this: it has no dlopen and no libffi, and TinyGo
+// cannot compile the C++ of llama.cpp. This package therefore uses a different
+// way to reach the same library. llama.cpp is a second WebAssembly module, made
+// by Emscripten, and this package calls it through JavaScript.
+//
+// The names and the order of the calls are the same as in the [llama] package
+// for the part of the API that this package has, so a program moves from one to
+// the other with a change of the import:
+//
+//	llamawasm.Load("")
+//	llamawasm.LogSet(llamawasm.LogSilent())
+//	llamawasm.Init()
+//
+//	model, err := llamawasm.ModelLoadFromFile("model.gguf", llamawasm.ModelDefaultParams())
+//	ctx, err := llamawasm.InitFromModel(model, llamawasm.ContextDefaultParams())
+//	vocab := llamawasm.ModelGetVocab(model)
+//
+//	tokens := llamawasm.Tokenize(vocab, prompt, true, false)
+//	batch := llamawasm.BatchGetOne(tokens)
+//
+//	sampler := llamawasm.SamplerChainInit(llamawasm.SamplerChainDefaultParams())
+//	llamawasm.SamplerChainAdd(sampler, llamawasm.SamplerInitGreedy())
+//
+// # What the page must do first
+//
+// The JavaScript glue in the wasm directory of yzma must run before [Load]. It
+// finds out if the page can use more than one thread, takes the correct
+// llama.cpp module, and puts the result in globalThis.yzmaReady. [Load] waits
+// for that promise.
+//
+// # Run it in a worker
+//
+// Every call into llama.cpp is synchronous, and one token takes milliseconds.
+// A call from the main thread of a page stops the page. Put this code and the
+// llama.cpp module in a Web Worker, and send the result to the page with
+// postMessage. One [Decode] does one batch, so the worker can send each token
+// as it comes.
+//
+// # One call at a time
+//
+// The package keeps scratch memory in the llama.cpp module for the calls that
+// pass tokens and text, so only one goroutine may call into it at a time. This
+// is not a limit in practice: llama.cpp itself takes one call at a time, and
+// the generation loop is one goroutine.
+//
+// # Limits
+//
+// The computation uses the CPU and SIMD. There is no GPU.
+//
+// A WebAssembly module can address 4 GB, and one JavaScript ArrayBuffer holds
+// at most 2 GB, so a model of more than 2 GB must be in splits.
+//
+// The package has the calls that text generation and embeddings need. It does
+// not have multimodal input, LoRA adapters, saved state, or quantization.
+package llamawasm

--- a/pkg/llamawasm/fs.go
+++ b/pkg/llamawasm/fs.go
@@ -1,0 +1,209 @@
+//go:build js && wasm
+
+package llamawasm
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"syscall/js"
+)
+
+// The llama.cpp module has its own filesystem in memory, and llama.cpp opens
+// the model as an ordinary file in it. A program must therefore put the file
+// there before ModelLoadFromFile.
+
+// WriteModelFile writes data to name in the filesystem of the llama.cpp
+// module. It makes the directories of the path that are not there.
+func WriteModelFile(name string, data []byte) error {
+	fs, err := filesystem()
+	if err != nil {
+		return err
+	}
+	if err := makeDir(fs, name); err != nil {
+		return err
+	}
+
+	buf := js.Global().Get("Uint8Array").New(len(data))
+	js.CopyBytesToJS(buf, data)
+
+	_, err = fsCall(fs, "writeFile", name, buf)
+	return err
+}
+
+// RemoveModelFile removes name from the filesystem of the llama.cpp module,
+// which gives the memory of the file back.
+func RemoveModelFile(name string) error {
+	fs, err := filesystem()
+	if err != nil {
+		return err
+	}
+	_, err = fsCall(fs, "unlink", name)
+	return err
+}
+
+// filesystem gives the FS object of the llama.cpp module.
+func filesystem() (js.Value, error) {
+	if !Loaded() {
+		return js.Undefined(), ErrNotLoaded
+	}
+
+	fs := mod.Get("FS")
+	if fs.IsUndefined() || fs.IsNull() {
+		return js.Undefined(), errors.New("llamawasm: the llama.cpp module has no filesystem")
+	}
+	return fs, nil
+}
+
+// makeDir makes the directories of the path of name. The filesystem of the
+// module starts with almost nothing in it, so a path such as
+// /models/model.gguf needs its directory first.
+func makeDir(fs js.Value, name string) error {
+	dir := path.Dir(name)
+	if dir == "." || dir == "/" || dir == "" {
+		return nil
+	}
+	if _, err := fsCall(fs, "mkdirTree", dir); err != nil {
+		// A directory that is already there is not a failure.
+		if strings.Contains(err.Error(), "EEXIST") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// fsCall calls a function of the filesystem of the module and turns a
+// JavaScript exception into an error. A call that fails throws, and a throw in
+// a call from Go is a panic, which would stop the program.
+func fsCall(fs js.Value, name string, args ...any) (result js.Value, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("llamawasm: FS.%s failed: %v", name, r)
+		}
+	}()
+
+	return fs.Call(name, args...), nil
+}
+
+// FetchModelFile gets a model over the network and writes it to name in the
+// filesystem of the llama.cpp module. It makes the directories of the path that
+// are not there.
+//
+// The body of the response goes into the file piece by piece, so the memory
+// that this needs stays near the size of the model and not twice that size.
+// The progress function, if it is not nil, is called with the number of bytes
+// so far and the total number of bytes. The total is 0 if the server does not
+// give a length.
+//
+// One JavaScript ArrayBuffer holds at most 2 GB, so a larger model must be in
+// splits.
+func FetchModelFile(name, url string, progress func(done, total int64)) error {
+	fs, err := filesystem()
+	if err != nil {
+		return err
+	}
+	if err := makeDir(fs, name); err != nil {
+		return err
+	}
+
+	response, err := await(js.Global().Call("fetch", url))
+	if err != nil {
+		return fmt.Errorf("llamawasm: cannot fetch %s: %w", url, err)
+	}
+	if !response.Get("ok").Bool() {
+		return fmt.Errorf("llamawasm: cannot fetch %s: status %d", url, response.Get("status").Int())
+	}
+
+	var total int64
+	if length := response.Get("headers").Call("get", "content-length"); length.Truthy() {
+		total = int64(js.Global().Get("parseInt").Invoke(length, 10).Int())
+	}
+
+	body := response.Get("body")
+	if body.IsUndefined() || body.IsNull() {
+		return errors.New("llamawasm: the response has no body to read")
+	}
+
+	stream, err := fsCall(fs, "open", name, "w")
+	if err != nil {
+		return err
+	}
+	defer func() { _, _ = fsCall(fs, "close", stream) }()
+
+	reader := body.Call("getReader")
+
+	var done int64
+	for {
+		chunk, err := await(reader.Call("read"))
+		if err != nil {
+			return fmt.Errorf("llamawasm: cannot read %s: %w", url, err)
+		}
+		if chunk.Get("done").Bool() {
+			break
+		}
+
+		value := chunk.Get("value")
+		n := value.Get("length").Int()
+
+		// FS.write takes the position in the file, so the whole model never
+		// needs to be in memory at one time.
+		if _, err := fsCall(fs, "write", stream, value, 0, n, done); err != nil {
+			return err
+		}
+
+		done += int64(n)
+		if progress != nil {
+			progress(done, total)
+		}
+	}
+
+	return nil
+}
+
+// ReleaseScratch gives the scratch memory of this package back to the
+// llama.cpp module. The next call takes it again, so this is only useful after
+// the last inference.
+func ReleaseScratch() {
+	if !Loaded() {
+		return
+	}
+	for _, s := range []*scratch{&tokenScratch, &textScratch, &pieceScratch, &embdScratch, &errScratch} {
+		s.release()
+	}
+}
+
+// await waits for a JavaScript promise and gives its value.
+func await(promise js.Value) (js.Value, error) {
+	type result struct {
+		value js.Value
+		err   error
+	}
+	done := make(chan result, 1)
+
+	onOK := js.FuncOf(func(this js.Value, args []js.Value) any {
+		var v js.Value
+		if len(args) > 0 {
+			v = args[0]
+		}
+		done <- result{value: v}
+		return nil
+	})
+	defer onOK.Release()
+
+	onErr := js.FuncOf(func(this js.Value, args []js.Value) any {
+		msg := "unknown error"
+		if len(args) > 0 {
+			msg = args[0].Call("toString").String()
+		}
+		done <- result{err: errors.New(msg)}
+		return nil
+	})
+	defer onErr.Release()
+
+	promise.Call("then", onOK, onErr)
+
+	r := <-done
+	return r.value, r.err
+}

--- a/pkg/llamawasm/logs.go
+++ b/pkg/llamawasm/logs.go
@@ -1,0 +1,39 @@
+//go:build js && wasm
+
+package llamawasm
+
+// The llama.cpp module cannot take a Go function as its log callback, so the
+// shim holds the callback and this package only sets how much it prints. The
+// values below stand in for the function pointer that llama.LogSet takes, so
+// that the same program builds for both.
+const (
+	// LogNormal lets llama.cpp print its messages to the console.
+	LogNormal uintptr = 0
+
+	// logSilentValue stops every message. LogSilent returns it.
+	logSilentValue uintptr = 1
+
+	// The levels are the same as the ggml_log_level values.
+	logLevelWarn   = 3
+	logLevelSilent = 99
+)
+
+// LogSet sets how much llama.cpp prints. Pass LogSilent to stop the messages,
+// or LogNormal to let them go to the console of the browser.
+func LogSet(cb uintptr) {
+	if !Loaded() {
+		return
+	}
+
+	level := logLevelWarn
+	if cb == logSilentValue {
+		level = logLevelSilent
+	}
+	callVoid("_yzma_log_set_verbosity", level)
+}
+
+// LogSilent gives the value that stops the messages of llama.cpp. Pass it to
+// LogSet.
+func LogSilent() uintptr {
+	return logSilentValue
+}

--- a/pkg/llamawasm/model.go
+++ b/pkg/llamawasm/model.go
@@ -1,0 +1,107 @@
+//go:build js && wasm
+
+package llamawasm
+
+import "fmt"
+
+// ModelLoadFromFile loads a model from a file in the filesystem of the
+// llama.cpp module.
+//
+// The file must be there before this call. Use WriteModelFile or
+// FetchModelFile to put it there.
+func ModelLoadFromFile(pathModel string, params ModelParams) (Model, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+
+	ptr, err := textScratch.reserve(len(pathModel) + 1)
+	if err != nil {
+		return 0, err
+	}
+	writeString(ptr, pathModel)
+
+	handle, err := callErr("_yzma_model_load", ptr, int(params.NGpuLayers))
+	if err != nil {
+		return 0, err
+	}
+	return Model(handle), nil
+}
+
+// ModelFree frees a model.
+func ModelFree(model Model) error {
+	if !Loaded() {
+		return ErrNotLoaded
+	}
+	callVoid("_yzma_model_free", int(model))
+	return nil
+}
+
+// ModelGetVocab gives the vocabulary of a model.
+func ModelGetVocab(model Model) Vocab {
+	if !Loaded() {
+		return 0
+	}
+	return Vocab(call("_yzma_model_get_vocab", int(model)))
+}
+
+// ModelNEmbd gives the number of values in an embedding of the model.
+func ModelNEmbd(model Model) int32 {
+	if !Loaded() {
+		return 0
+	}
+	return call("_yzma_model_n_embd", int(model))
+}
+
+// ModelNCtxTrain gives the size of the context that the model was trained
+// with.
+func ModelNCtxTrain(model Model) int32 {
+	if !Loaded() {
+		return 0
+	}
+	return call("_yzma_model_n_ctx_train", int(model))
+}
+
+// ModelDesc gives a short description of the type of the model.
+func ModelDesc(model Model) string {
+	return modelString("_yzma_model_desc", model, 256)
+}
+
+// ModelChatTemplate gives the chat template that is in the model, or an empty
+// string if the model has none.
+//
+// The name argument is not used. It is here to keep the same shape as
+// llama.ModelChatTemplate.
+func ModelChatTemplate(model Model, name string) string {
+	return modelString("_yzma_model_chat_template", model, 8192)
+}
+
+// modelString reads a string that the shim writes into a buffer, and takes a
+// larger buffer if the first one is too small.
+func modelString(name string, model Model, size int) string {
+	if !Loaded() {
+		return ""
+	}
+
+	for {
+		ptr, err := pieceScratch.reserve(size)
+		if err != nil {
+			return ""
+		}
+
+		n := call(name, int(model), ptr, size)
+		switch {
+		case n < 0 && n == errTooSmall && size < 1<<20:
+			size *= 4
+			continue
+		case n <= 0:
+			return ""
+		default:
+			return string(readBytes(ptr, int(n)))
+		}
+	}
+}
+
+// String gives the handle of the model as text, which helps while debugging.
+func (m Model) String() string {
+	return fmt.Sprintf("model(%d)", int32(m))
+}

--- a/pkg/llamawasm/module.go
+++ b/pkg/llamawasm/module.go
@@ -1,0 +1,341 @@
+//go:build js && wasm
+
+package llamawasm
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"syscall/js"
+)
+
+// abiVersion is the version of the interface of the shim. It must be the same
+// as YZMA_ABI_VERSION in wasm/yzma_wasm.cpp of the llama-cpp-builder repo.
+const abiVersion = 1
+
+// Error codes that the shim returns. These are the same as the values in
+// wasm/yzma_wasm.cpp.
+const (
+	errGeneric  = -1
+	errHandle   = -2
+	errAlloc    = -3
+	errLoad     = -4
+	errTooSmall = -5
+)
+
+var (
+	// ErrNotLoaded says that Load did not run, or that it failed.
+	ErrNotLoaded = errors.New("llamawasm: the llama.cpp module is not loaded, call Load first")
+
+	// ErrNoModule says that the JavaScript glue did not run before Load.
+	ErrNoModule = errors.New("llamawasm: globalThis.yzmaReady is missing, load yzma-loader.js first")
+)
+
+// mod is the Emscripten module instance of llama.cpp.
+var mod js.Value
+
+// threaded tells if the module that the page took uses more than one thread.
+var threaded bool
+
+// Load waits for the llama.cpp WebAssembly module and attaches to it.
+//
+// The path argument is not used. It is here to keep the same shape as
+// llama.Load, so that the same code can build for a native platform and for a
+// browser.
+//
+// The JavaScript glue must run first. It puts a promise in
+// globalThis.yzmaReady, and the value of that promise is the module.
+func Load(path string) error {
+	global := js.Global()
+
+	ready := global.Get("yzmaReady")
+	if ready.IsUndefined() || ready.IsNull() {
+		// The glue may have put the instance in place without a promise.
+		if m := global.Get("yzmaModule"); !m.IsUndefined() && !m.IsNull() {
+			return attach(m)
+		}
+		return ErrNoModule
+	}
+
+	if ready.Type() != js.TypeObject || ready.Get("then").IsUndefined() {
+		return attach(ready)
+	}
+
+	type result struct {
+		value js.Value
+		err   error
+	}
+	done := make(chan result, 1)
+
+	onOK := js.FuncOf(func(this js.Value, args []js.Value) any {
+		var v js.Value
+		if len(args) > 0 {
+			v = args[0]
+		}
+		done <- result{value: v}
+		return nil
+	})
+	defer onOK.Release()
+
+	onErr := js.FuncOf(func(this js.Value, args []js.Value) any {
+		msg := "unknown error"
+		if len(args) > 0 {
+			msg = args[0].Call("toString").String()
+		}
+		done <- result{err: fmt.Errorf("llamawasm: the llama.cpp module failed to load: %s", msg)}
+		return nil
+	})
+	defer onErr.Release()
+
+	ready.Call("then", onOK, onErr)
+
+	r := <-done
+	if r.err != nil {
+		return r.err
+	}
+	return attach(r.value)
+}
+
+// attach keeps the module and makes sure that it has the interface that this
+// package needs.
+func attach(m js.Value) error {
+	if m.IsUndefined() || m.IsNull() {
+		return ErrNoModule
+	}
+	if m.Get("_yzma_abi_version").IsUndefined() {
+		return errors.New("llamawasm: the module is not a yzma build of llama.cpp")
+	}
+
+	mod = m
+
+	got := int(m.Call("_yzma_abi_version").Int())
+	if got != abiVersion {
+		mod = js.Undefined()
+		return fmt.Errorf("llamawasm: the llama.cpp module has ABI version %d, this build of yzma needs %d", got, abiVersion)
+	}
+
+	threaded = js.Global().Get("yzmaThreaded").Truthy()
+
+	return nil
+}
+
+// Loaded tells if the llama.cpp module is ready to use.
+func Loaded() bool {
+	return !mod.IsUndefined() && !mod.IsNull()
+}
+
+// Threaded tells if the module that the page took uses more than one thread. A
+// browser gives more than one thread only to a page that sets the
+// Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers.
+func Threaded() bool {
+	return threaded
+}
+
+// Init starts the llama.cpp backend. Call it after Load.
+func Init() {
+	if !Loaded() {
+		return
+	}
+	mod.Call("_yzma_backend_init")
+}
+
+// Close stops the llama.cpp backend.
+func Close() {
+	BackendFree()
+}
+
+// BackendInit starts the llama.cpp backend.
+func BackendInit() {
+	Init()
+}
+
+// BackendFree stops the llama.cpp backend.
+func BackendFree() {
+	if !Loaded() {
+		return
+	}
+	mod.Call("_yzma_backend_free")
+}
+
+//
+// calls into the module
+//
+
+// call runs a function of the shim and returns the result as an int32.
+func call(name string, args ...any) int32 {
+	return int32(mod.Call(name, args...).Int())
+}
+
+// callVoid runs a function of the shim that has no result.
+func callVoid(name string, args ...any) {
+	mod.Call(name, args...)
+}
+
+// callErr runs a function of the shim and turns a negative result into an
+// error that holds the text from the shim.
+func callErr(name string, args ...any) (int32, error) {
+	rc := call(name, args...)
+	if rc < 0 {
+		return rc, shimError(name, rc)
+	}
+	return rc, nil
+}
+
+// shimError makes an error from a return code and the last error of the shim.
+func shimError(name string, rc int32) error {
+	if text := lastError(); text != "" {
+		return fmt.Errorf("llamawasm: %s: %s (%d)", name, text, rc)
+	}
+	return fmt.Errorf("llamawasm: %s failed with code %d", name, rc)
+}
+
+// lastError reads the text of the last error of the shim.
+func lastError() string {
+	const size = 512
+	ptr, err := errScratch.reserve(size)
+	if err != nil {
+		return ""
+	}
+	n := call("_yzma_last_error", ptr, size)
+	if n <= 0 {
+		return ""
+	}
+	return string(readBytes(ptr, int(n)))
+}
+
+//
+// memory of the module
+//
+// The two WebAssembly modules do not share memory, so every value that goes
+// into llama.cpp is a copy. ALLOW_MEMORY_GROWTH makes a new buffer each time
+// the memory of the module grows, and that leaves the old views detached, so
+// each read and write takes the view again.
+//
+
+func heapU8() js.Value {
+	return mod.Get("HEAPU8")
+}
+
+func view(ptr, n int) js.Value {
+	return heapU8().Call("subarray", ptr, ptr+n)
+}
+
+func malloc(n int) (int, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+	ptr := mod.Call("_malloc", n).Int()
+	if ptr == 0 {
+		return 0, fmt.Errorf("llamawasm: cannot allocate %d bytes in the llama.cpp module", n)
+	}
+	return ptr, nil
+}
+
+func free(ptr int) {
+	if ptr != 0 && Loaded() {
+		mod.Call("_free", ptr)
+	}
+}
+
+func writeBytes(ptr int, b []byte) {
+	if len(b) == 0 {
+		return
+	}
+	js.CopyBytesToJS(view(ptr, len(b)), b)
+}
+
+func readBytes(ptr, n int) []byte {
+	b := make([]byte, n)
+	if n > 0 {
+		js.CopyBytesToGo(b, view(ptr, n))
+	}
+	return b
+}
+
+// writeString writes s and a zero byte at ptr. The room at ptr must be at
+// least len(s)+1 bytes.
+func writeString(ptr int, s string) {
+	b := make([]byte, len(s)+1)
+	copy(b, s)
+	writeBytes(ptr, b)
+}
+
+func writeTokens(ptr int, tokens []Token) {
+	b := make([]byte, len(tokens)*4)
+	for i, t := range tokens {
+		binary.LittleEndian.PutUint32(b[i*4:], uint32(t))
+	}
+	writeBytes(ptr, b)
+}
+
+func readTokens(ptr, n int) []Token {
+	b := readBytes(ptr, n*4)
+	tokens := make([]Token, n)
+	for i := range tokens {
+		tokens[i] = Token(int32(binary.LittleEndian.Uint32(b[i*4:])))
+	}
+	return tokens
+}
+
+func readFloats(ptr, n int) []float32 {
+	b := readBytes(ptr, n*4)
+	values := make([]float32, n)
+	for i := range values {
+		values[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
+	}
+	return values
+}
+
+//
+// scratch memory
+//
+// The loop that makes tokens calls into the module many times for each token.
+// A scratch area that stays keeps the loop from allocating in the module, which
+// also keeps the memory of the module from growing during generation.
+//
+
+type scratch struct {
+	ptr  int
+	size int
+}
+
+// reserve gives a pointer to at least n bytes. The contents of an earlier
+// reserve on the same scratch are lost.
+func (s *scratch) reserve(n int) (int, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+	if s.size >= n {
+		return s.ptr, nil
+	}
+
+	// Take room for more than the request, so that a loop that grows a little
+	// each time does not allocate each time.
+	size := n * 2
+	ptr, err := malloc(size)
+	if err != nil {
+		return 0, err
+	}
+
+	free(s.ptr)
+	s.ptr, s.size = ptr, size
+	return ptr, nil
+}
+
+// release gives the memory of the scratch back to the module.
+func (s *scratch) release() {
+	free(s.ptr)
+	s.ptr, s.size = 0, 0
+}
+
+// Each purpose has its own scratch, because more than one is in use at the
+// same time. tokenScratch holds tokens on the way in, textScratch holds a
+// string on the way in, and pieceScratch holds bytes on the way out.
+var (
+	tokenScratch scratch
+	textScratch  scratch
+	pieceScratch scratch
+	embdScratch  scratch
+	errScratch   scratch
+)

--- a/pkg/llamawasm/sampling.go
+++ b/pkg/llamawasm/sampling.go
@@ -1,0 +1,111 @@
+//go:build js && wasm
+
+package llamawasm
+
+// SamplerChainInit makes a chain of samplers.
+func SamplerChainInit(params SamplerChainParams) Sampler {
+	if !Loaded() {
+		return 0
+	}
+	return Sampler(call("_yzma_sampler_chain_new", int(params.NoPerf)))
+}
+
+// SamplerChainAdd puts a sampler at the end of a chain.
+//
+// The chain then owns the sampler, so the handle of the sampler is no longer
+// valid and SamplerFree of that handle does nothing. Freeing the chain frees
+// every sampler in it.
+func SamplerChainAdd(chain Sampler, smpl Sampler) {
+	if !Loaded() {
+		return
+	}
+	callVoid("_yzma_sampler_chain_add", int(chain), int(smpl))
+}
+
+// SamplerInitGreedy makes a sampler that always takes the token with the
+// highest probability.
+func SamplerInitGreedy() Sampler {
+	return newSampler("_yzma_sampler_greedy")
+}
+
+// SamplerInitDist makes a sampler that takes a token at random, following the
+// probability of each one. A seed of 0xFFFFFFFF takes a random seed.
+func SamplerInitDist(seed uint32) Sampler {
+	return newSampler("_yzma_sampler_dist", int(seed))
+}
+
+// SamplerInitTemp makes a sampler that changes the shape of the distribution.
+// A value below 1.0 makes the output more sure, and a value above 1.0 makes it
+// more varied.
+func SamplerInitTemp(t float32) Sampler {
+	return newSampler("_yzma_sampler_temp", float64(t))
+}
+
+// SamplerInitTopK makes a sampler that keeps only the k most probable tokens.
+func SamplerInitTopK(k int32) Sampler {
+	return newSampler("_yzma_sampler_top_k", int(k))
+}
+
+// SamplerInitTopP makes a sampler that keeps the most probable tokens up to a
+// total probability of p.
+func SamplerInitTopP(p float32, keep uint32) Sampler {
+	return newSampler("_yzma_sampler_top_p", float64(p), int(keep))
+}
+
+// SamplerInitMinP makes a sampler that removes every token whose probability
+// is below p of the probability of the most likely token.
+func SamplerInitMinP(p float32, keep uint32) Sampler {
+	return newSampler("_yzma_sampler_min_p", float64(p), int(keep))
+}
+
+// SamplerInitPenalties makes a sampler that lowers the probability of the
+// tokens that came before.
+func SamplerInitPenalties(nVocab int32, lastN int32, repeat float32, freq float32, present float32) Sampler {
+	return newSampler("_yzma_sampler_penalties", int(nVocab), int(lastN),
+		float64(repeat), float64(freq), float64(present))
+}
+
+// SamplerSample takes the next token. An idx of -1 uses the logits of the last
+// token of the batch.
+func SamplerSample(smpl Sampler, ctx Context, idx int32) Token {
+	if !Loaded() {
+		return -1
+	}
+	return Token(call("_yzma_sampler_sample", int(smpl), int(ctx), int(idx)))
+}
+
+// SamplerAccept tells the sampler which token the program took, which the
+// samplers that look at the tokens that came before need.
+func SamplerAccept(smpl Sampler, token Token) {
+	if !Loaded() {
+		return
+	}
+	callVoid("_yzma_sampler_accept", int(smpl), int(token))
+}
+
+// SamplerReset puts a sampler back to its starting state.
+func SamplerReset(smpl Sampler) {
+	if !Loaded() {
+		return
+	}
+	callVoid("_yzma_sampler_reset", int(smpl))
+}
+
+// SamplerFree frees a sampler or a chain of samplers.
+func SamplerFree(smpl Sampler) {
+	if !Loaded() {
+		return
+	}
+	callVoid("_yzma_sampler_free", int(smpl))
+}
+
+func newSampler(name string, args ...any) Sampler {
+	if !Loaded() {
+		return 0
+	}
+	h := call(name, args...)
+	if h < 0 {
+		return 0
+	}
+	return Sampler(h)
+}

--- a/pkg/llamawasm/types.go
+++ b/pkg/llamawasm/types.go
@@ -1,0 +1,110 @@
+//go:build js && wasm
+
+package llamawasm
+
+// The shim gives each object of llama.cpp a small int32 handle. A handle of 0
+// is never valid. The Go code never holds an address inside the llama.cpp
+// module, so the module is free to move or grow its memory.
+type (
+	// Token is one token of a vocabulary.
+	Token int32
+
+	// Pos is the position of a token in a sequence.
+	Pos int32
+
+	// SeqId is the identifier of a sequence.
+	SeqId int32
+
+	// Model is a handle to a loaded model.
+	Model int32
+
+	// Context is a handle to an inference context.
+	Context int32
+
+	// Vocab is a handle to the vocabulary of a model.
+	Vocab int32
+
+	// Sampler is a handle to a sampler or to a chain of samplers.
+	Sampler int32
+)
+
+// PoolingType is how the embeddings of the tokens of a sequence become one
+// embedding.
+type PoolingType int32
+
+const (
+	PoolingTypeUnspecified PoolingType = -1
+	PoolingTypeNone        PoolingType = 0
+	PoolingTypeMean        PoolingType = 1
+	PoolingTypeCLS         PoolingType = 2
+	PoolingTypeLast        PoolingType = 3
+	PoolingTypeRank        PoolingType = 4
+)
+
+// ModelParams holds what the shim can set while it loads a model.
+//
+// The struct is much smaller than llama.ModelParams, because a WebAssembly
+// build has no GPU and no device list.
+type ModelParams struct {
+	// NGpuLayers is here to keep the same shape as llama.ModelParams. A
+	// WebAssembly build has no GPU, so any value other than 0 does nothing.
+	NGpuLayers int32
+}
+
+// ModelDefaultParams gives the parameters that a model uses if the program
+// changes nothing.
+func ModelDefaultParams() ModelParams {
+	return ModelParams{
+		NGpuLayers: 0,
+	}
+}
+
+// ContextParams holds what the shim can set while it makes a context.
+type ContextParams struct {
+	NCtx        uint32      // size of the text context, 0 = from the model
+	NBatch      uint32      // largest logical batch, 0 = from llama.cpp
+	NUbatch     uint32      // largest physical batch, 0 = from llama.cpp
+	NThreads    int32       // number of threads, 0 = from the module
+	PoolingType PoolingType // how to pool embeddings
+	Embeddings  uint8       // 1 to compute embeddings
+}
+
+// ContextDefaultParams gives the parameters that a context uses if the program
+// changes nothing.
+//
+// NThreads is 0, which leaves the number of threads to the module: the build
+// with more than one thread takes the number of cores of the machine, and the
+// build with one thread stays at one.
+func ContextDefaultParams() ContextParams {
+	return ContextParams{
+		NCtx:        0,
+		NBatch:      0,
+		NUbatch:     0,
+		NThreads:    0,
+		PoolingType: PoolingTypeUnspecified,
+		Embeddings:  0,
+	}
+}
+
+// SamplerChainParams holds the parameters of a chain of samplers.
+type SamplerChainParams struct {
+	NoPerf uint8 // 1 to stop the measurement of the time of each sample
+}
+
+// SamplerChainDefaultParams gives the parameters that a chain uses if the
+// program changes nothing.
+func SamplerChainDefaultParams() SamplerChainParams {
+	return SamplerChainParams{NoPerf: 1}
+}
+
+// Batch holds the tokens of one call to Decode or Encode.
+//
+// On a native platform llama.Batch is a C struct. Here it is an ordinary Go
+// struct, because the shim makes the C batch itself.
+type Batch struct {
+	// NTokens is the number of tokens in the batch. A generation loop reads
+	// it to move the position forward.
+	NTokens int32
+
+	tokens []Token
+}

--- a/pkg/llamawasm/vocab.go
+++ b/pkg/llamawasm/vocab.go
@@ -1,0 +1,149 @@
+//go:build js && wasm
+
+package llamawasm
+
+// errBadHandle is what a function of the shim returns for a bad handle if its
+// normal result can also be negative. It is the same value as
+// YZMA_ERR_BAD_HANDLE in wasm/yzma_wasm.cpp.
+const errBadHandle = -1000000
+
+// Tokenize turns text into tokens.
+func Tokenize(vocab Vocab, text string, addSpecial bool, parseSpecial bool) []Token {
+	if !Loaded() {
+		return nil
+	}
+
+	textPtr, err := textScratch.reserve(len(text) + 1)
+	if err != nil {
+		return nil
+	}
+	writeString(textPtr, text)
+
+	// One token holds at least one byte of text, so the number of bytes plus
+	// room for the special tokens is always enough.
+	max := len(text) + 8
+
+	for {
+		tokenPtr, err := tokenScratch.reserve(max * 4)
+		if err != nil {
+			return nil
+		}
+
+		n := call("_yzma_tokenize", int(vocab), textPtr, len(text), tokenPtr, max,
+			boolToInt(addSpecial), boolToInt(parseSpecial))
+		switch {
+		case n <= errBadHandle:
+			return nil
+		case n < 0:
+			// The shim gives the negative of the number of tokens that it
+			// needs.
+			max = int(-n)
+			continue
+		default:
+			return readTokens(tokenPtr, int(n))
+		}
+	}
+}
+
+// Detokenize turns tokens back into text.
+//
+// The shim has no call for this, so the text comes from TokenToPiece of each
+// token, which is what a generation loop does.
+func Detokenize(vocab Vocab, tokens []Token, removeSpecial bool, unparseSpecial bool) string {
+	if !Loaded() {
+		return ""
+	}
+
+	buf := make([]byte, 64)
+	out := make([]byte, 0, len(tokens)*4)
+	for _, token := range tokens {
+		n := TokenToPiece(vocab, token, buf, 0, unparseSpecial)
+		if n <= 0 {
+			continue
+		}
+		out = append(out, buf[:n]...)
+	}
+	return string(out)
+}
+
+// TokenToPiece writes the text of one token into buf and gives the number of
+// bytes that it wrote. A negative result is the negative of the number of
+// bytes that buf needs.
+func TokenToPiece(vocab Vocab, token Token, buf []byte, lstrip int32, special bool) int32 {
+	if !Loaded() {
+		return 0
+	}
+
+	ptr, err := pieceScratch.reserve(len(buf))
+	if err != nil {
+		return 0
+	}
+
+	n := call("_yzma_token_to_piece", int(vocab), int(token), ptr, len(buf),
+		int(lstrip), boolToInt(special))
+	switch {
+	case n <= errBadHandle:
+		return 0
+	case n <= 0:
+		return n
+	}
+
+	copy(buf, readBytes(ptr, int(n)))
+	return n
+}
+
+// VocabIsEOG tells if a token ends the generation.
+func VocabIsEOG(vocab Vocab, token Token) bool {
+	if !Loaded() {
+		return false
+	}
+	return call("_yzma_vocab_is_eog", int(vocab), int(token)) == 1
+}
+
+// VocabBOS gives the token that starts a sequence.
+func VocabBOS(vocab Vocab) Token {
+	return vocabToken("_yzma_vocab_bos", vocab)
+}
+
+// VocabEOS gives the token that ends a sequence.
+func VocabEOS(vocab Vocab) Token {
+	return vocabToken("_yzma_vocab_eos", vocab)
+}
+
+// VocabNTokens gives the number of tokens in the vocabulary.
+func VocabNTokens(vocab Vocab) int32 {
+	if !Loaded() {
+		return 0
+	}
+	n := call("_yzma_vocab_n_tokens", int(vocab))
+	if n <= errBadHandle {
+		return 0
+	}
+	return n
+}
+
+// VocabGetAddBOS tells if the vocabulary adds the token that starts a sequence.
+func VocabGetAddBOS(vocab Vocab) bool {
+	if !Loaded() {
+		return false
+	}
+	return call("_yzma_vocab_get_add_bos", int(vocab)) == 1
+}
+
+func vocabToken(name string, vocab Vocab) Token {
+	if !Loaded() {
+		return -1
+	}
+	t := call(name, int(vocab))
+	if t <= errBadHandle {
+		return -1
+	}
+	return Token(t)
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,0 +1,114 @@
+# yzma in WebAssembly
+
+This directory holds what a browser needs to run yzma: the JavaScript glue that
+takes the correct WebAssembly build of llama.cpp, a Web Worker that holds the
+program, a page, a static server, and a test that runs in Node.
+
+The Go code is in [`pkg/llamawasm`](../pkg/llamawasm), and the example is in
+[`examples/wasm/chat`](../examples/wasm/chat).
+
+## How it works
+
+There are two WebAssembly modules:
+
+```
+   page (index.html)
+         |  postMessage
+   Web Worker
+     |            \
+   Go program      llama.cpp module
+   (TinyGo)   -->  (Emscripten)
+       through JavaScript
+```
+
+On a native platform yzma calls llama.cpp with libffi and loads the shared
+libraries at run time. A WebAssembly module has no `dlopen` and no libffi, and
+TinyGo cannot compile the C++ of llama.cpp. So llama.cpp becomes a second
+WebAssembly module, made by Emscripten with a small C shim, and the Go code
+calls that module through JavaScript. The shim is in the
+[llama-cpp-builder](https://github.com/hybridgroup/llama-cpp-builder) repo, in
+its `wasm` directory.
+
+The generation loop stays in Go. One `Decode` and one `SamplerSample` for each
+token, the same as the `examples/hello` program.
+
+## Files
+
+| File | What it does |
+| --- | --- |
+| `yzma-loader.js` | Tests if the page can use more than one thread, then loads the correct llama.cpp module and puts it in `globalThis.yzmaReady`. |
+| `worker.js` | Runs llama.cpp and the Go program in a Web Worker, and sends each piece of text to the page. |
+| `index.html` | A page that loads a model and makes text. |
+| `serve/main.go` | A static server that sets the headers that a build with more than one thread needs. |
+| `node/run.js` | Runs the same build in Node, with no browser. This is the test that CI uses. |
+
+## Build and run
+
+```
+# get the WebAssembly build of llama.cpp
+make download-llama.cpp-wasm
+
+# build the program with TinyGo
+make wasm-example
+
+# serve it
+make serve-wasm
+```
+
+Then open <http://localhost:8080>.
+
+`make wasm-example-go` builds the same program with the standard Go toolchain.
+The binary is larger, which is useful if TinyGo cannot build a dependency.
+
+## Run it without a browser
+
+```
+make wasm-example
+make test-wasm
+```
+
+`node/run.js` loads a small model, makes tokens with the greedy sampler, and
+prints them. The greedy sampler always takes the most probable token, so the
+output does not change from one run to the next and a test can compare it.
+
+`make test-wasm-mt` does the same with the build that uses more than one thread.
+Node gives `SharedArrayBuffer` without the headers that a browser needs, so this
+tests that build outside a browser.
+
+With SmolLM-135M Q2_K on one machine, the build with one thread made 10.8 tokens
+a second, the build with more threads made 36.1 in Node, and the same build in
+Chrome made 55.9. All of them gave the same text, because the greedy sampler
+does not change from one run to the next.
+
+## Why a worker
+
+Every call into llama.cpp is synchronous, and one token takes milliseconds. A
+call from the main thread stops the page. The worker also lets the page show
+each token as it comes, because one `Decode` handles one batch.
+
+## More than one thread
+
+The faster build of llama.cpp needs `SharedArrayBuffer`, and a browser gives
+that only to a page that comes with these headers:
+
+```
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+`wasm/serve` sets them. If a host does not, `yzma-loader.js` takes the build
+with one thread, which is slower but works everywhere. `llamawasm.Threaded()`
+says which build the page took.
+
+An isolated page can only get a model from another origin if that origin sends
+the CORS headers. Hugging Face does, so the model in `index.html` comes down as
+it is, but a model on a host that sends no CORS headers needs a copy on the
+origin of the page.
+
+## Limits
+
+- The computation uses the CPU and SIMD. There is no GPU.
+- One JavaScript ArrayBuffer holds at most 2 GB, so a larger model must be in
+  splits.
+- `pkg/llamawasm` has the calls that text generation and embeddings need. It
+  does not have multimodal input, LoRA adapters, saved state, or quantization.

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>yzma in WebAssembly</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 0 auto;
+        max-width: 46rem;
+        padding: 1.5rem;
+        line-height: 1.5;
+      }
+      label { display: block; margin-top: 1rem; font-weight: 600; }
+      input, textarea, button { font: inherit; width: 100%; box-sizing: border-box; }
+      input, textarea { padding: 0.4rem; }
+      button { margin-top: 0.75rem; padding: 0.5rem; cursor: pointer; }
+      #status { margin-top: 1rem; color: #555; }
+      #output {
+        margin-top: 1rem;
+        padding: 0.75rem;
+        min-height: 8rem;
+        white-space: pre-wrap;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>yzma in WebAssembly</h1>
+    <p>
+      llama.cpp runs as a WebAssembly module. The program that drives it is Go,
+      compiled by TinyGo, and it calls llama.cpp through the
+      <code>pkg/llamawasm</code> package of yzma. Everything runs in a Web
+      Worker in this browser.
+    </p>
+
+    <label for="model">Model URL (GGUF, less than 2 GB)</label>
+    <input
+      id="model"
+      value="https://huggingface.co/QuantFactory/SmolLM-135M-GGUF/resolve/main/SmolLM-135M.Q2_K.gguf"
+    />
+    <button id="load">Load the model</button>
+
+    <label for="prompt">Prompt</label>
+    <textarea id="prompt" rows="3">Are you ready to go?</textarea>
+    <button id="generate" disabled>Generate</button>
+
+    <div id="status">starting</div>
+    <div id="output"></div>
+
+    <script>
+      const status = document.getElementById("status");
+      const output = document.getElementById("output");
+      const generateButton = document.getElementById("generate");
+
+      const worker = new Worker("./worker.js");
+
+      worker.onmessage = (event) => {
+        const { kind, text } = event.data || {};
+        switch (kind) {
+          case "token":
+            output.textContent += text;
+            break;
+          case "loaded":
+            status.textContent = "model loaded: " + text;
+            generateButton.disabled = false;
+            break;
+          case "error":
+            status.textContent = "error: " + text;
+            break;
+          default:
+            status.textContent = kind + ": " + text;
+        }
+      };
+
+      document.getElementById("load").onclick = () => {
+        status.textContent = "loading";
+        generateButton.disabled = true;
+        worker.postMessage({ kind: "load", url: document.getElementById("model").value });
+      };
+
+      generateButton.onclick = () => {
+        output.textContent = "";
+        status.textContent = "generating";
+        worker.postMessage({
+          kind: "generate",
+          prompt: document.getElementById("prompt").value,
+          maxTokens: 128,
+        });
+      };
+    </script>
+  </body>
+</html>

--- a/wasm/node/run.js
+++ b/wasm/node/run.js
@@ -1,0 +1,125 @@
+// run.js runs the WebAssembly build of yzma in Node, without a browser.
+//
+// It is the test that CI uses: it loads a small model, makes a fixed number of
+// tokens with the greedy sampler, and prints them. The greedy sampler always
+// takes the most probable token, so the output of a model does not change, and
+// a test can compare it.
+//
+// Usage:
+//   node wasm/node/run.js --dir build/wasm --model ~/models/SmolLM-135M.Q2_K.gguf \
+//       --prompt "Are you ready to go?" --tokens 12 [--expect "<text>"] [--mt]
+//
+// --mt takes the build with more than one thread. Node has SharedArrayBuffer
+// without the headers that a browser needs, so this is a way to test that build
+// outside a browser.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function option(name, fallback) {
+  const i = process.argv.indexOf("--" + name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : fallback;
+}
+
+const dir = path.resolve(option("dir", "build/wasm"));
+const modelFile = option("model", "");
+const prompt = option("prompt", "Are you ready to go?");
+const maxTokens = parseInt(option("tokens", "12"), 10);
+const expect = option("expect", "");
+const mt = process.argv.includes("--mt");
+const moduleName = mt ? "yzma_wasm_mt.js" : "yzma_wasm.js";
+
+if (!modelFile) {
+  console.error("give a model with --model");
+  process.exit(2);
+}
+
+// The output of the Go program comes here, because a Node process has no
+// postMessage.
+const output = [];
+globalThis.yzmaOnMessage = (message) => {
+  if (message.kind === "token") {
+    output.push(message.text);
+    process.stdout.write(message.text);
+    return;
+  }
+  console.log("[" + message.kind + "] " + message.text);
+};
+
+async function main() {
+  // Take the build with one thread. Node has no crossOriginIsolated, so the
+  // loader would take it anyway, but this says so.
+  globalThis.crossOriginIsolated = mt;
+  globalThis.yzmaBase = dir;
+
+  const factory = require(path.join(dir, moduleName));
+  const llamaModule = await factory({
+    locateFile: (file) => path.join(dir, file),
+    print: () => {},
+    printErr: () => {},
+  });
+
+  globalThis.yzmaModule = llamaModule;
+  globalThis.yzmaReady = Promise.resolve(llamaModule);
+  globalThis.yzmaThreaded = mt;
+
+  // Put the model in the filesystem of the module. A browser gets it over the
+  // network instead, with FetchModelFile.
+  llamaModule.FS.mkdirTree("/models");
+  llamaModule.FS.writeFile("/models/model.gguf", fs.readFileSync(modelFile));
+
+  require(path.join(dir, "wasm_exec.js"));
+
+  const go = new Go();
+  const binary = fs.readFileSync(path.join(dir, "yzma.wasm"));
+  const result = await WebAssembly.instantiate(binary, go.importObject);
+
+  // The program blocks at the end of main, so do not wait for this.
+  go.run(result.instance);
+
+  await settle();
+
+  const done = new Promise((resolve) => {
+    const previous = globalThis.yzmaOnMessage;
+    globalThis.yzmaOnMessage = (message) => {
+      previous(message);
+      if (message.kind === "loaded") {
+        globalThis.yzmaGenerate(prompt, maxTokens);
+      }
+      if (message.kind === "done" || message.kind === "error") {
+        resolve(message);
+      }
+    };
+  });
+
+  globalThis.yzmaOpenModel("/models/model.gguf");
+
+  const last = await done;
+  console.log();
+
+  if (last.kind === "error") {
+    process.exit(1);
+  }
+
+  const text = output.join("");
+  if (expect && text !== expect) {
+    console.error("the output is not what the test expects");
+    console.error("  expected: " + JSON.stringify(expect));
+    console.error("  received: " + JSON.stringify(text));
+    process.exit(1);
+  }
+  if (text.length === 0) {
+    console.error("no tokens came out");
+    process.exit(1);
+  }
+}
+
+// settle gives the Go program the turns it needs to set its functions.
+function settle() {
+  return new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/wasm/serve/main.go
+++ b/wasm/serve/main.go
@@ -1,0 +1,53 @@
+// Serve puts the files of the WebAssembly build of yzma on a local HTTP
+// server.
+//
+// The server sets the Cross-Origin-Opener-Policy and
+// Cross-Origin-Embedder-Policy headers. Without them a browser does not give
+// the page SharedArrayBuffer, and the build of llama.cpp that uses more than
+// one thread cannot run.
+//
+//	go run ./wasm/serve -dir build/wasm -port 8080
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	dir := flag.String("dir", "build/wasm", "directory of files to serve")
+	port := flag.Int("port", 8080, "port to listen on")
+	flag.Parse()
+
+	path, err := filepath.Abs(*dir)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		log.Fatalf("cannot serve %s: %v (run \"make wasm-example\" first)", path, err)
+	}
+
+	files := http.FileServer(http.Dir(path))
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// These two headers isolate the page, which is what gives it
+		// SharedArrayBuffer and therefore more than one thread.
+		w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
+		w.Header().Set("Cross-Origin-Embedder-Policy", "require-corp")
+
+		// A browser runs a .wasm file only if the type is correct.
+		if filepath.Ext(r.URL.Path) == ".wasm" {
+			w.Header().Set("Content-Type", "application/wasm")
+		}
+
+		files.ServeHTTP(w, r)
+	})
+
+	address := fmt.Sprintf("localhost:%d", *port)
+	log.Printf("serving %s at http://%s", path, address)
+	log.Fatal(http.ListenAndServe(address, nil))
+}

--- a/wasm/worker.js
+++ b/wasm/worker.js
@@ -1,0 +1,63 @@
+// worker.js runs llama.cpp and the Go program in a Web Worker.
+//
+// Every call into llama.cpp is synchronous and one token takes milliseconds, so
+// this work cannot go on the main thread of the page: it would stop the page.
+// The worker sends each piece of text to the page as it comes.
+//
+// The page sends these messages to the worker:
+//
+//   { kind: "load", url: "<model URL>" }
+//   { kind: "generate", prompt: "<text>", maxTokens: 128 }
+//
+// The worker sends back { kind, text } messages, where kind is one of ready,
+// status, progress, loaded, token, done, or error.
+
+self.yzmaBase = ".";
+
+// A failure with nobody to catch it must reach the page. Without this the page
+// only sees that nothing more happens.
+self.onerror = (event) => {
+  self.postMessage({ kind: "error", text: String((event && event.message) || event) });
+};
+self.onunhandledrejection = (event) => {
+  self.postMessage({ kind: "error", text: String((event && event.reason) || event) });
+};
+
+importScripts("./yzma-loader.js");
+importScripts("./wasm_exec.js");
+
+const started = (async () => {
+  // llama.cpp must be ready before the Go program calls Load.
+  await self.yzmaReady;
+
+  const go = new Go();
+  const result = await WebAssembly.instantiateStreaming(fetch("./yzma.wasm"), go.importObject);
+
+  // The Go program blocks at the end of main, so it keeps running and the page
+  // can call into it. Do not wait for this promise.
+  go.run(result.instance);
+
+  // Give the program the turn it needs to set its functions.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+})();
+
+self.onmessage = async (event) => {
+  const message = event.data || {};
+
+  try {
+    await started;
+
+    switch (message.kind) {
+      case "load":
+        self.yzmaLoadModel(message.url);
+        break;
+      case "generate":
+        self.yzmaGenerate(message.prompt, message.maxTokens || 128);
+        break;
+      default:
+        self.postMessage({ kind: "error", text: "unknown message: " + message.kind });
+    }
+  } catch (err) {
+    self.postMessage({ kind: "error", text: String(err) });
+  }
+};

--- a/wasm/yzma-loader.js
+++ b/wasm/yzma-loader.js
@@ -1,0 +1,62 @@
+// yzma-loader.js takes the correct WebAssembly build of llama.cpp and makes it
+// ready for the pkg/llamawasm Go package.
+//
+// It works in a Web Worker and in a page. Load it before the Go program runs.
+// It sets:
+//
+//   globalThis.yzmaReady     a promise whose value is the llama.cpp module
+//   globalThis.yzmaModule    the module, after the promise is done
+//   globalThis.yzmaThreaded  true if the build uses more than one thread
+//
+// Set globalThis.yzmaBase before this file if the files of llama.cpp are not
+// beside it.
+
+(function () {
+  const base = globalThis.yzmaBase || ".";
+
+  // A browser gives SharedArrayBuffer only to a page that is isolated with the
+  // Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers. The
+  // build with more than one thread cannot run without it.
+  const threaded =
+    typeof SharedArrayBuffer !== "undefined" && globalThis.crossOriginIsolated === true;
+
+  const name = threaded ? "yzma_wasm_mt" : "yzma_wasm";
+
+  globalThis.yzmaThreaded = threaded;
+
+  function loadScript(url) {
+    // A classic worker takes importScripts. A page takes a script element.
+    if (typeof importScripts === "function") {
+      importScripts(url);
+      return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+      const element = document.createElement("script");
+      element.src = url;
+      element.onload = () => resolve();
+      element.onerror = () => reject(new Error("cannot load " + url));
+      document.head.appendChild(element);
+    });
+  }
+
+  globalThis.yzmaReady = (async () => {
+    await loadScript(base + "/" + name + ".js");
+
+    // MODULARIZE with EXPORT_NAME=yzmaModule makes yzmaModule a function that
+    // gives the instance.
+    const factory = globalThis.yzmaModule;
+    if (typeof factory !== "function") {
+      throw new Error("yzmaModule is not there, check the build of llama.cpp");
+    }
+
+    const instance = await factory({
+      locateFile: (path) => base + "/" + path,
+      print: (text) => console.log(text),
+      printErr: (text) => console.warn(text),
+    });
+
+    // From here on yzmaModule is the instance, which is what the Go code uses.
+    globalThis.yzmaModule = instance;
+    return instance;
+  })();
+})();


### PR DESCRIPTION
Adds a WebAssembly target to yzma: llama.cpp runs as a WebAssembly module, and a Go program compiled by TinyGo drives it.

Needs hybridgroup/llama-cpp-builder#32, which makes the WebAssembly build of llama.cpp and its shim. The CI job here installs those assets, so it stays red until that PR lands and the builder publishes a release with them.

## How it works

```
   page (index.html)
         |  postMessage
   Web Worker
     |            \
   Go program      llama.cpp module
   (TinyGo)   -->  (Emscripten)
       through JavaScript
```

`pkg/llama` reaches llama.cpp with libffi and loads the shared libraries at run time. A WebAssembly module has no `dlopen` and no libffi, and TinyGo cannot compile the C++ of llama.cpp, so none of that works in a browser. `pkg/llamawasm` is a second way to reach the same library: llama.cpp is a separate WebAssembly module made by Emscripten, and this package calls it through JavaScript.

`pkg/llama` is untouched.

## What a program looks like

The names and the order of the calls are the same as in `pkg/llama`, so a program moves over with a change of the import:

```go
llamawasm.Load("")
llamawasm.LogSet(llamawasm.LogSilent())
llamawasm.Init()

model, err := llamawasm.ModelLoadFromFile("model.gguf", llamawasm.ModelDefaultParams())
ctx, err := llamawasm.InitFromModel(model, llamawasm.ContextDefaultParams())
vocab := llamawasm.ModelGetVocab(model)

tokens := llamawasm.Tokenize(vocab, prompt, true, false)
batch := llamawasm.BatchGetOne(tokens)

sampler := llamawasm.SamplerChainInit(llamawasm.SamplerChainDefaultParams())
llamawasm.SamplerChainAdd(sampler, llamawasm.SamplerInitGreedy())
```

The generation loop stays in Go, one `Decode` and one `SamplerSample` for each token, which is what lets the page show each token as it comes.

## Try it

```
make download-llama.cpp-wasm
make wasm-example
make serve-wasm
```

Then open http://localhost:8080. `make wasm-example-go` builds the same program with the standard toolchain.

## What comes with it

- `pkg/llamawasm` — the calls that text generation and embeddings need, over `syscall/js`. `FetchModelFile` streams a GGUF into the filesystem of the module, so the memory it needs stays near the size of the model.
- `wasm/` — the JavaScript glue that takes the correct build of llama.cpp, the Web Worker, a page, a static server that sets the headers that a build with more than one thread needs, and a test that runs in Node.
- `examples/wasm/chat` — the same shape as `examples/hello`.
- `yzma install -os wasm` — gets both variants of the WebAssembly build.
- `.github/workflows/wasm.yml` — vets the code, builds with TinyGo, then runs inference in Node with no browser. The greedy sampler makes the output the same every time, so the test can compare it.

## Two things to know

- **Run it in a worker.** Every call into llama.cpp is synchronous and one token takes milliseconds, so a call from the main thread stops the page.
- **No GPU.** The computation uses the CPU and SIMD. One JavaScript ArrayBuffer holds at most 2 GB, so a larger model must be in splits.

`pkg/llamawasm` does not have multimodal input, LoRA adapters, saved state, or quantization.

## Test

With SmolLM-135M Q2_K:

| Build | Result |
| --- | --- |
| one thread, Node, TinyGo | 10.8 tokens/s |
| one thread, Node, standard toolchain | 10.8 tokens/s |
| more threads, Node, TinyGo | 36.1 tokens/s |
| more threads, headless Chrome, full page and worker | 128 tokens at 55.9 tokens/s |

All of them gave the same text. Tokenize, detokenize, the vocabulary calls, embeddings with mean pooling, memory clear, and the error path of a model that is not there were each checked in a browser and in Node. On the native side, `go build ./...`, `go vet ./...`, the `pkg/download` tests, and the FFI checker gate all behave as before.