### PR TITLE
WebGPU in the browser

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -64,5 +64,14 @@ jobs:
             --dir $GITHUB_WORKSPACE/$WASM_DIR \
             --model $GITHUB_WORKSPACE/models/SmolLM-135M.Q2_K.gguf \
             --tokens 12
+      # Node has no WebGPU, so this checks the other half of that story: asking
+      # for WebGPU where there is none must quietly take a build on the CPU and
+      # still make text. Only a browser can run the WebGPU build itself.
+      - name: Check the fallback from WebGPU
+        run: |
+          node wasm/node/run.js \
+            --dir $GITHUB_WORKSPACE/$WASM_DIR \
+            --model $GITHUB_WORKSPACE/models/SmolLM-135M.Q2_K.gguf \
+            --tokens 12 --webgpu
       - name: Build the example with the standard toolchain
         run: make wasm-example-go

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -222,13 +222,13 @@ yzma install --lib /path/to/lib --processor cpu --os trixie
 
 ### WebAssembly (browser)
 
-`yzma` runs in a browser with the WebAssembly build of `llama.cpp`. Both builds come down, the one with a single thread and the one with more threads, and the JavaScript glue takes the one that the page can use:
+`yzma` runs in a browser with the WebAssembly build of `llama.cpp`. All three builds come down, the one with WebGPU, the one with more threads, and the one with a single thread, and the JavaScript glue takes the one that the page can use:
 
 ```
 yzma install --lib /path/to/web --os wasm
 ```
 
-This build has no GPU, and it uses the smaller API of the [`pkg/llamawasm`](./pkg/llamawasm) package. See [wasm/README.md](./wasm/README.md).
+WebGPU needs Chrome or Edge 137 and later, and an adapter with f16 shaders; every other browser runs on the CPU. This target uses the smaller API of the [`pkg/llamawasm`](./pkg/llamawasm) package. See [wasm/README.md](./wasm/README.md).
 
 ### Windows CPU
 

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,12 @@ test-wasm:
 test-wasm-mt:
 	node wasm/node/run.js --dir $(WASM_DIR) --model $(MODELS_DIR)/SmolLM-135M.Q2_K.gguf --tokens 12 --mt
 
+# make test-wasm-webgpu to check what happens where there is no WebGPU. Node has
+# none, so this must fall back to a build on the CPU and still make text. Only a
+# browser can run the WebGPU build itself.
+test-wasm-webgpu:
+	node wasm/node/run.js --dir $(WASM_DIR) --model $(MODELS_DIR)/SmolLM-135M.Q2_K.gguf --tokens 12 --webgpu
+
 clean-wasm:
 	rm -rf $(WASM_DIR)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Sure! Let's go to the zoo and feed the llama. What kind of llama are you interes
 
 ### WebAssembly Example
 
-`yzma` also runs in a browser. `llama.cpp` becomes a WebAssembly module, and a Go program compiled by TinyGo drives it through the [`pkg/llamawasm`](./pkg/llamawasm) package:
+`yzma` also runs in a browser, on the CPU or on the GPU with WebGPU. `llama.cpp` becomes a WebAssembly module, and a Go program compiled by TinyGo drives it through the [`pkg/llamawasm`](./pkg/llamawasm) package:
 
 ```shell
 $ make download-llama.cpp-wasm
@@ -183,11 +183,13 @@ You can use multimodal models (image/audio) and text language models with full h
 | macOS   | arm64        | Metal                           |
 | Windows | amd64        | CUDA, Vulkan, HIP, SYCL, OpenCL |
 
-A browser is also a target. There the computation uses the CPU and SIMD only, and the API is the smaller one of the [`pkg/llamawasm`](./pkg/llamawasm) package: text generation and embeddings, with no multimodal input, LoRA adapters, saved state, or quantization. See [wasm/README.md](./wasm/README.md).
+A browser is also a target. The API there is the smaller one of the [`pkg/llamawasm`](./pkg/llamawasm) package: text generation and embeddings, with no multimodal input, LoRA adapters, saved state, or quantization. See [wasm/README.md](./wasm/README.md).
 
 | Target  | CPU          | GPU  |
 | ------- | ------------ | ---- |
-| Browser | wasm32 SIMD, one or more threads | none |
+| Browser | wasm32 SIMD, one or more threads | WebGPU |
+
+The JavaScript glue takes the build that the browser can run, so a browser with no WebGPU still works on the CPU. WebGPU needs Chrome or Edge 137 and later, and an adapter with f16 shaders.
 
 Whenever there is a new release of `llama.cpp`, the tests for `yzma` are run automatically. This helps us stay up to date with the latest code and models.
 

--- a/examples/wasm/chat/main.go
+++ b/examples/wasm/chat/main.go
@@ -48,7 +48,7 @@ func main() {
 	js.Global().Set("yzmaOpenModel", js.FuncOf(openModel))
 	js.Global().Set("yzmaGenerate", js.FuncOf(generate))
 
-	post("ready", fmt.Sprintf("threads: %v", llamawasm.Threaded()))
+	post("ready", backendReport())
 
 	// Keep the program alive so that the page can call into it.
 	<-make(chan struct{})
@@ -98,24 +98,40 @@ func openModel(this js.Value, args []js.Value) any {
 func open(path string) {
 	post("status", "loading the model")
 
+	params := llamawasm.ModelDefaultParams()
+
+	// A build with WebGPU has a device, so put every layer on it. A build on the
+	// CPU has none, and the value does nothing there.
+	if llamawasm.GPUDevice() != "" {
+		params.NGpuLayers = 999
+	}
+
 	var err error
-	if model, err = llamawasm.ModelLoadFromFile(path, llamawasm.ModelDefaultParams()); err != nil {
+	if model, err = llamawasm.ModelLoadFromFile(path, params); err != nil {
 		post("error", err.Error())
 		return
 	}
 
-	params := llamawasm.ContextDefaultParams()
-	params.NCtx = 2048
-	params.NBatch = 512
+	ctxParams := llamawasm.ContextDefaultParams()
+	ctxParams.NCtx = 2048
+	ctxParams.NBatch = 512
 
-	if ctx, err = llamawasm.InitFromModel(model, params); err != nil {
+	if ctx, err = llamawasm.InitFromModel(model, ctxParams); err != nil {
 		post("error", err.Error())
 		return
 	}
 
 	vocab = llamawasm.ModelGetVocab(model)
 
-	post("loaded", llamawasm.ModelDesc(model))
+	post("loaded", llamawasm.ModelDesc(model)+", "+backendReport())
+}
+
+// backendReport says what does the computation.
+func backendReport() string {
+	if device := llamawasm.GPUDevice(); device != "" {
+		return fmt.Sprintf("backend: %s (%s)", llamawasm.Backend(), device)
+	}
+	return fmt.Sprintf("backend: %s", llamawasm.Backend())
 }
 
 // generate(prompt, maxTokens) makes text and sends each piece to the page.

--- a/pkg/download/processor.go
+++ b/pkg/download/processor.go
@@ -9,6 +9,9 @@ var (
 	Metal  = newProcessor("metal")
 	ROCm   = newProcessor("rocm")
 	Vulkan = newProcessor("vulkan")
+
+	// WebGPU is the GPU of a browser. It goes with the Wasm target only.
+	WebGPU = newProcessor("webgpu")
 )
 
 // =============================================================================

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -203,14 +203,20 @@ func defaultResolve(target Target) ([]string, error) {
 		}
 
 	case Wasm:
-		// A WebAssembly build has no GPU, so the processor is always CPU. Both
-		// variants come down: the JavaScript glue takes the one with more than
-		// one thread only if the page is isolated.
-		if prcssr != CPU {
+		// Every build of the target comes down, whichever processor the caller
+		// names, because the JavaScript glue chooses at run time and needs them
+		// all: WebGPU where the browser has it, more than one thread where the
+		// page is isolated, and one thread everywhere else.
+		//
+		// CUDA, Metal, ROCm and Vulkan have no meaning in a browser.
+		if prcssr != CPU && prcssr != WebGPU {
 			return nil, ErrUnknownProcessor
 		}
 		location, tag = builderLocation, version
-		extra = append(extra, fmt.Sprintf("%s/llama-%s-bin-wasm-simd-mt.tar.gz", location, tag))
+		extra = append(extra,
+			fmt.Sprintf("%s/llama-%s-bin-wasm-simd-mt.tar.gz", location, tag),
+			fmt.Sprintf("%s/llama-%s-bin-wasm-webgpu.tar.gz", location, tag),
+		)
 		filename = fmt.Sprintf("llama-%s-bin-wasm-simd.tar.gz", tag)
 
 	default:

--- a/pkg/download/resolver_test.go
+++ b/pkg/download/resolver_test.go
@@ -105,37 +105,42 @@ func TestDefaultResolverWindowsCUDA(t *testing.T) {
 	}
 }
 
-// A wasm target takes both builds from the llama-cpp-builder release page: the
-// JavaScript glue picks the one with more than one thread only if the page can
-// use it.
+// A wasm target takes every build from the llama-cpp-builder release page,
+// because the JavaScript glue chooses at run time: WebGPU where the browser has
+// it, more than one thread where the page is isolated, one thread otherwise.
 func TestDefaultResolverWasm(t *testing.T) {
-	urls, err := DefaultResolver.Resolve(Target{Arch: AMD64, OS: Wasm, Processor: CPU, Version: "b7974"})
-	if err != nil {
-		t.Fatalf("Resolve() failed: %v", err)
-	}
-	if len(urls) != 2 {
-		t.Fatalf("Resolve() returned %d urls, want 2: %v", len(urls), urls)
-	}
-	for _, want := range []string{
-		"llama-cpp-builder/releases/download/b7974/llama-b7974-bin-wasm-simd-mt.tar.gz",
-		"llama-cpp-builder/releases/download/b7974/llama-b7974-bin-wasm-simd.tar.gz",
-	} {
-		found := false
-		for _, url := range urls {
-			if strings.HasSuffix(url, want) {
-				found = true
-			}
+	for _, prcssr := range []Processor{CPU, WebGPU} {
+		urls, err := DefaultResolver.Resolve(Target{Arch: AMD64, OS: Wasm, Processor: prcssr, Version: "b7974"})
+		if err != nil {
+			t.Fatalf("Resolve(%s) failed: %v", prcssr, err)
 		}
-		if !found {
-			t.Errorf("Resolve() = %v, want an asset ending in %q", urls, want)
+		if len(urls) != 3 {
+			t.Fatalf("Resolve(%s) returned %d urls, want 3: %v", prcssr, len(urls), urls)
+		}
+		for _, want := range []string{
+			"llama-cpp-builder/releases/download/b7974/llama-b7974-bin-wasm-simd-mt.tar.gz",
+			"llama-cpp-builder/releases/download/b7974/llama-b7974-bin-wasm-webgpu.tar.gz",
+			"llama-cpp-builder/releases/download/b7974/llama-b7974-bin-wasm-simd.tar.gz",
+		} {
+			found := false
+			for _, url := range urls {
+				if strings.HasSuffix(url, want) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("Resolve(%s) = %v, want an asset ending in %q", prcssr, urls, want)
+			}
 		}
 	}
 }
 
-// A wasm build has no GPU, so any processor other than CPU has no assets.
-func TestDefaultResolverWasmGPU(t *testing.T) {
-	if _, err := DefaultResolver.Resolve(Target{Arch: AMD64, OS: Wasm, Processor: CUDA, Version: "b7974"}); err == nil {
-		t.Fatal("Resolve() accepted a wasm target with a GPU")
+// CUDA, Metal, ROCm and Vulkan have no meaning in a browser.
+func TestDefaultResolverWasmUnknownProcessor(t *testing.T) {
+	for _, prcssr := range []Processor{CUDA, Metal, ROCm, Vulkan} {
+		if _, err := DefaultResolver.Resolve(Target{Arch: AMD64, OS: Wasm, Processor: prcssr, Version: "b7974"}); err == nil {
+			t.Errorf("Resolve() accepted a wasm target with the %s processor", prcssr)
+		}
 	}
 }
 

--- a/pkg/llamawasm/doc.go
+++ b/pkg/llamawasm/doc.go
@@ -48,9 +48,25 @@
 // is not a limit in practice: llama.cpp itself takes one call at a time, and
 // the generation loop is one goroutine.
 //
+// # WebGPU
+//
+// There are three builds of llama.cpp, and the JavaScript glue takes the best
+// one that the browser can run: WebGPU, the CPU with more than one thread, or
+// the CPU with one thread. [Backend] says which one it took, and [GPUDevice]
+// names the GPU that llama.cpp found.
+//
+// A page can have WebGPU while llama.cpp has no device, because the backend
+// needs an adapter with f16 shaders. Ask [GPUDevice], which reports what
+// llama.cpp really has.
+//
+// Set NGpuLayers in [ModelParams] to put layers on the GPU. It does nothing in
+// a build for the CPU.
+//
 // # Limits
 //
-// The computation uses the CPU and SIMD. There is no GPU.
+// A build for the CPU uses SIMD. WebGPU needs Chrome or Edge 137 and later,
+// because the backend waits for the GPU inside a synchronous call and that
+// needs JavaScript Promise Integration.
 //
 // A WebAssembly module can address 4 GB, and one JavaScript ArrayBuffer holds
 // at most 2 GB, so a model of more than 2 GB must be in splits.

--- a/pkg/llamawasm/module.go
+++ b/pkg/llamawasm/module.go
@@ -10,9 +10,17 @@ import (
 	"syscall/js"
 )
 
-// abiVersion is the version of the interface of the shim. It must be the same
-// as YZMA_ABI_VERSION in wasm/yzma_wasm.cpp of the llama-cpp-builder repo.
-const abiVersion = 1
+// The version of the interface of the shim, which is YZMA_ABI_VERSION in
+// wasm/yzma_wasm.cpp of the llama-cpp-builder repo.
+//
+// This package drives a module of any version from abiVersionMin to
+// abiVersion, so a new yzma still works with the modules of an older release.
+// A call that came with a later version is there only if the module has it, so
+// each one is tested for before it is used.
+const (
+	abiVersionMin = 1 // 1 has the calls for text generation and embeddings
+	abiVersion    = 2 // 2 adds yzma_gpu_device
+)
 
 // Error codes that the shim returns. These are the same as the values in
 // wasm/yzma_wasm.cpp.
@@ -37,6 +45,13 @@ var mod js.Value
 
 // threaded tells if the module that the page took uses more than one thread.
 var threaded bool
+
+// moduleABI is the version of the interface of the module that is loaded.
+var moduleABI int
+
+// gpuDevice is the name of the device of llama.cpp that is not the CPU, or an
+// empty string if there is none. Init fills it in.
+var gpuDevice string
 
 // Load waits for the llama.cpp WebAssembly module and attaches to it.
 //
@@ -109,15 +124,24 @@ func attach(m js.Value) error {
 
 	mod = m
 
-	got := int(m.Call("_yzma_abi_version").Int())
-	if got != abiVersion {
+	got := int(settle(m.Call("_yzma_abi_version")).Int())
+	if got < abiVersionMin || got > abiVersion {
 		mod = js.Undefined()
-		return fmt.Errorf("llamawasm: the llama.cpp module has ABI version %d, this build of yzma needs %d", got, abiVersion)
+		return fmt.Errorf("llamawasm: the llama.cpp module has ABI version %d, this build of yzma drives %d to %d",
+			got, abiVersionMin, abiVersion)
 	}
+	moduleABI = got
 
 	threaded = js.Global().Get("yzmaThreaded").Truthy()
+	gpuDevice = ""
 
 	return nil
+}
+
+// has tells if the module has a call. A module of an earlier version does not
+// have the calls that came later.
+func has(name string) bool {
+	return Loaded() && mod.Get(name).Type() == js.TypeFunction
 }
 
 // Loaded tells if the llama.cpp module is ready to use.
@@ -137,7 +161,54 @@ func Init() {
 	if !Loaded() {
 		return
 	}
-	mod.Call("_yzma_backend_init")
+	callVoid("_yzma_backend_init")
+
+	// The devices of llama.cpp exist only after the backend starts, and asking
+	// for them is what makes the WebGPU backend look for an adapter.
+	gpuDevice = readGPUDevice()
+}
+
+// readGPUDevice asks the shim for the name of the device that is not the CPU.
+func readGPUDevice() string {
+	if !has("_yzma_gpu_device") {
+		return ""
+	}
+
+	const size = 256
+	ptr, err := pieceScratch.reserve(size)
+	if err != nil {
+		return ""
+	}
+
+	n := call("_yzma_gpu_device", ptr, size)
+	if n <= 0 {
+		return ""
+	}
+	return string(readBytes(ptr, int(n)))
+}
+
+// GPUDevice gives the name of the device of llama.cpp that is not the CPU, or
+// an empty string if the computation is on the CPU. Call it after Init.
+//
+// A page can ask for WebGPU and still land on the CPU, because the backend
+// needs an adapter that supports f16 shaders. This says what llama.cpp really
+// has.
+func GPUDevice() string {
+	return gpuDevice
+}
+
+// Backend gives the name of what does the computation: "webgpu", "cpu-threads"
+// for the build on the CPU that uses more than one thread, or "cpu". Call it
+// after Init.
+func Backend() string {
+	switch {
+	case gpuDevice != "":
+		return "webgpu"
+	case threaded:
+		return "cpu-threads"
+	default:
+		return "cpu"
+	}
 }
 
 // Close stops the llama.cpp backend.
@@ -164,12 +235,38 @@ func BackendFree() {
 
 // call runs a function of the shim and returns the result as an int32.
 func call(name string, args ...any) int32 {
-	return int32(mod.Call(name, args...).Int())
+	return int32(callValue(name, args...).Int())
 }
 
 // callVoid runs a function of the shim that has no result.
 func callVoid(name string, args ...any) {
-	mod.Call(name, args...)
+	callValue(name, args...)
+}
+
+// callValue runs a function of the shim and gives the result.
+//
+// A module with the WebGPU backend needs the GPU of the browser, and the calls
+// that ask for a GPU are asynchronous. Emscripten builds that module with JSPI,
+// so such a call gives a promise instead of a number. This waits for the
+// promise. A build for the CPU gives the number itself, which stays the fast
+// path.
+func callValue(name string, args ...any) js.Value {
+	return settle(mod.Call(name, args...))
+}
+
+// settle waits for a promise, or gives back a value that is not one.
+func settle(v js.Value) js.Value {
+	if v.Type() != js.TypeObject || v.Get("then").Type() != js.TypeFunction {
+		return v
+	}
+
+	resolved, err := await(v)
+	if err != nil {
+		// The shim has no way to report this, so leave the value undefined and
+		// let the caller see a result that is not a number.
+		return js.Undefined()
+	}
+	return resolved
 }
 
 // callErr runs a function of the shim and turns a negative result into an

--- a/pkg/llamawasm/types.go
+++ b/pkg/llamawasm/types.go
@@ -44,10 +44,13 @@ const (
 // ModelParams holds what the shim can set while it loads a model.
 //
 // The struct is much smaller than llama.ModelParams, because a WebAssembly
-// build has no GPU and no device list.
+// build has no device list.
 type ModelParams struct {
-	// NGpuLayers is here to keep the same shape as llama.ModelParams. A
-	// WebAssembly build has no GPU, so any value other than 0 does nothing.
+	// NGpuLayers is the number of layers to put on the GPU. A value larger than
+	// the number of layers of the model puts them all there.
+	//
+	// It does nothing in a build for the CPU. Test [GPUDevice] first: it is
+	// empty when llama.cpp has no GPU.
 	NGpuLayers int32
 }
 

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -36,7 +36,7 @@ token, the same as the `examples/hello` program.
 
 | File | What it does |
 | --- | --- |
-| `yzma-loader.js` | Tests if the page can use more than one thread, then loads the correct llama.cpp module and puts it in `globalThis.yzmaReady`. |
+| `yzma-loader.js` | Finds what the browser can run — WebGPU, more than one thread, or one thread — then loads that build of llama.cpp and puts it in `globalThis.yzmaReady`. |
 | `worker.js` | Runs llama.cpp and the Go program in a Web Worker, and sends each piece of text to the page. |
 | `index.html` | A page that loads a model and makes text. |
 | `serve/main.go` | A static server that sets the headers that a build with more than one thread needs. |
@@ -55,7 +55,8 @@ make wasm-example
 make serve-wasm
 ```
 
-Then open <http://localhost:8080>.
+Then open <http://localhost:8080>. Add `?mode=cpu` or `?mode=webgpu` to the URL
+of the page to choose the backend instead of letting the loader choose.
 
 `make wasm-example-go` builds the same program with the standard Go toolchain.
 The binary is larger, which is useful if TinyGo cannot build a dependency.
@@ -75,16 +76,76 @@ output does not change from one run to the next and a test can compare it.
 Node gives `SharedArrayBuffer` without the headers that a browser needs, so this
 tests that build outside a browser.
 
-With SmolLM-135M Q2_K on one machine, the build with one thread made 10.8 tokens
-a second, the build with more threads made 36.1 in Node, and the same build in
-Chrome made 55.9. All of them gave the same text, because the greedy sampler
-does not change from one run to the next.
+`make test-wasm-webgpu` tests the other half of the WebGPU story, which is what
+happens where there is none: Node has no WebGPU, so the loader must take a build
+on the CPU and the program must still make text. Only a browser can run the
+WebGPU build itself.
+
+## Speed
+
+Measured in Chrome on one machine, an RTX 4070 with an Intel integrated GPU,
+with the greedy sampler:
+
+| Model | Backend | Tokens a second |
+| --- | --- | --- |
+| SmolLM-135M Q2_K | one thread | 10.8 |
+| SmolLM-135M Q2_K | more threads | 55.9 |
+| SmolLM-135M Q2_K | WebGPU | 47.6 |
+| Gemma 3 1B Q2_K | more threads | 8.7 |
+| Gemma 3 1B Q2_K | WebGPU | 32.3 |
+
+The GPU wins on the larger model and loses on the smaller one, where the work of
+each operation is too small to pay for the trip to the GPU. Try both: the page
+takes `?mode=cpu` and `?mode=webgpu`.
+
+The builds on the CPU give the same text every time. The GPU gives the same text
+for the first few tokens and then goes its own way, because the shaders do the
+arithmetic in a different order than the CPU does.
 
 ## Why a worker
 
 Every call into llama.cpp is synchronous, and one token takes milliseconds. A
 call from the main thread stops the page. The worker also lets the page show
 each token as it comes, because one `Decode` handles one batch.
+
+## WebGPU
+
+There are three builds of llama.cpp, and `yzma-loader.js` takes the best one
+that the browser can run:
+
+| Build | What it needs |
+| --- | --- |
+| `yzma_wasm_webgpu` | WebGPU with f16 shaders, and JSPI. Chrome and Edge 137 and later. |
+| `yzma_wasm_mt` | `SharedArrayBuffer`, so a page with the COOP and COEP headers. |
+| `yzma_wasm` | Nothing. It works everywhere. |
+
+A page can force the choice with `globalThis.yzmaMode`, which takes `auto` (the
+default), `webgpu`, or `cpu`. `webgpu` still falls back to the CPU if the
+browser cannot run that build, because a page that does not work at all is
+worse than a page that is slower.
+
+`llamawasm.Backend()` says what does the computation, and
+`llamawasm.GPUDevice()` names the GPU that llama.cpp found. Ask llama.cpp and
+not the browser: a page can have WebGPU while llama.cpp still has no device.
+
+### f16 shaders, and NVIDIA
+
+The backend of llama.cpp needs `shader-f16`, and it reports no device at all
+without it. Two things follow from how the backend asks for an adapter in a
+browser, where it takes the adapter of the browser with no options of its own:
+
+- An Intel integrated GPU gives f16, and the WebGPU build runs.
+- A discrete NVIDIA card does **not** give f16 in a browser. Dawn has a toggle
+  for it, `vulkan_enable_f16_on_nvidia`, and llama.cpp turns it on outside a
+  browser but cannot in one. A page cannot turn it on either: it is a flag of
+  the browser. So Chrome takes the CPU on such a machine unless somebody starts
+  it with:
+
+  ```
+  google-chrome --enable-dawn-features=vulkan_enable_f16_on_nvidia
+  ```
+
+The fallback makes this a slower page and not a broken one.
 
 ## More than one thread
 
@@ -107,7 +168,12 @@ origin of the page.
 
 ## Limits
 
-- The computation uses the CPU and SIMD. There is no GPU.
+- WebGPU needs Chrome or Edge 137 and later, and an adapter with f16 shaders.
+  Everything else runs on the CPU with SIMD.
+- A browser does not get the matrix instructions of a subgroup, which llama.cpp
+  uses only outside a browser, so the GPU is slower in a page than the same
+  backend is on a desktop.
+- An operation larger than `maxStorageBufferBindingSize` goes back to the CPU.
 - One JavaScript ArrayBuffer holds at most 2 GB, so a larger model must be in
   splits.
 - `pkg/llamawasm` has the calls that text generation and embeddings need. It

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -36,6 +36,7 @@
       <code>pkg/llamawasm</code> package of yzma. Everything runs in a Web
       Worker in this browser.
     </p>
+    <p id="backend">looking for a backend</p>
 
     <label for="model">Model URL (GGUF, less than 2 GB)</label>
     <input
@@ -56,11 +57,18 @@
       const output = document.getElementById("output");
       const generateButton = document.getElementById("generate");
 
-      const worker = new Worker("./worker.js");
+      // ?mode=cpu on the page passes through to the worker, which lets a
+      // reader compare the GPU with the CPU.
+      const mode = new URLSearchParams(location.search).get("mode");
+      const worker = new Worker("./worker.js" + (mode ? "?mode=" + encodeURIComponent(mode) : ""));
 
       worker.onmessage = (event) => {
         const { kind, text } = event.data || {};
         switch (kind) {
+          case "ready":
+            document.getElementById("backend").textContent = text;
+            status.textContent = "ready";
+            break;
           case "token":
             output.textContent += text;
             break;

--- a/wasm/node/run.js
+++ b/wasm/node/run.js
@@ -8,10 +8,15 @@
 // Usage:
 //   node wasm/node/run.js --dir build/wasm --model ~/models/SmolLM-135M.Q2_K.gguf \
 //       --prompt "Are you ready to go?" --tokens 12 [--expect "<text>"] [--mt]
+//       [--webgpu]
 //
 // --mt takes the build with more than one thread. Node has SharedArrayBuffer
 // without the headers that a browser needs, so this is a way to test that build
 // outside a browser.
+//
+// --webgpu asks for the WebGPU build. Node has no WebGPU, so this tests the
+// other half of that story: the loader must quietly take a build on the CPU and
+// the program must still make text.
 
 const fs = require("node:fs");
 const path = require("node:path");
@@ -27,7 +32,21 @@ const prompt = option("prompt", "Are you ready to go?");
 const maxTokens = parseInt(option("tokens", "12"), 10);
 const expect = option("expect", "");
 const mt = process.argv.includes("--mt");
-const moduleName = mt ? "yzma_wasm_mt.js" : "yzma_wasm.js";
+const webgpu = process.argv.includes("--webgpu");
+
+// This harness stands in for yzma-loader.js, so it makes the same choice the
+// loader would make in a place that has no WebGPU: it falls back to the CPU.
+let moduleName = "yzma_wasm.js";
+if (mt) {
+  moduleName = "yzma_wasm_mt.js";
+}
+if (webgpu) {
+  if (globalThis.navigator && globalThis.navigator.gpu) {
+    moduleName = "yzma_wasm_webgpu.js";
+  } else {
+    console.log("[loader] no WebGPU here, using the build on the CPU");
+  }
+}
 
 if (!modelFile) {
   console.error("give a model with --model");
@@ -37,7 +56,16 @@ if (!modelFile) {
 // The output of the Go program comes here, because a Node process has no
 // postMessage.
 const output = [];
+
+let programIsReady;
+const programReady = new Promise((resolve) => {
+  programIsReady = resolve;
+});
+
 globalThis.yzmaOnMessage = (message) => {
+  if (message.kind === "ready" || message.kind === "error") {
+    programIsReady();
+  }
   if (message.kind === "token") {
     output.push(message.text);
     process.stdout.write(message.text);
@@ -62,6 +90,11 @@ async function main() {
   globalThis.yzmaModule = llamaModule;
   globalThis.yzmaReady = Promise.resolve(llamaModule);
   globalThis.yzmaThreaded = mt;
+  globalThis.yzmaBackend = moduleName.includes("webgpu")
+    ? "webgpu"
+    : mt
+      ? "cpu-threads"
+      : "cpu";
 
   // Put the model in the filesystem of the module. A browser gets it over the
   // network instead, with FetchModelFile.
@@ -77,7 +110,9 @@ async function main() {
   // The program blocks at the end of main, so do not wait for this.
   go.run(result.instance);
 
-  await settle();
+  // Wait for the program to say it is ready. Starting the backend takes a
+  // moment, and longer with WebGPU.
+  await programReady;
 
   const done = new Promise((resolve) => {
     const previous = globalThis.yzmaOnMessage;
@@ -112,11 +147,6 @@ async function main() {
     console.error("no tokens came out");
     process.exit(1);
   }
-}
-
-// settle gives the Go program the turns it needs to set its functions.
-function settle() {
-  return new Promise((resolve) => setTimeout(resolve, 50));
 }
 
 main().catch((err) => {

--- a/wasm/worker.js
+++ b/wasm/worker.js
@@ -14,6 +14,14 @@
 
 self.yzmaBase = ".";
 
+// The page can choose the backend with a query on the URL of this worker, such
+// as new Worker("./worker.js?mode=cpu"). The values are the ones that
+// yzma-loader.js takes: auto, webgpu, or cpu.
+const workerQuery = new URLSearchParams((self.location.search || "").slice(1));
+if (workerQuery.get("mode")) {
+  self.yzmaMode = workerQuery.get("mode");
+}
+
 // A failure with nobody to catch it must reach the page. Without this the page
 // only sees that nothing more happens.
 self.onerror = (event) => {
@@ -26,6 +34,24 @@ self.onunhandledrejection = (event) => {
 importScripts("./yzma-loader.js");
 importScripts("./wasm_exec.js");
 
+// The Go program says when it is ready by sending its first message, which is
+// the one of kind "ready". Waiting for that is the only safe way to know that
+// it has set its functions: starting the backend takes a moment with the CPU
+// and much longer with WebGPU, where it has to find an adapter and make the
+// shaders.
+let programIsReady;
+const programReady = new Promise((resolve) => {
+  programIsReady = resolve;
+});
+
+const sendToPage = self.postMessage.bind(self);
+self.postMessage = (message) => {
+  if (message && (message.kind === "ready" || message.kind === "error")) {
+    programIsReady();
+  }
+  sendToPage(message);
+};
+
 const started = (async () => {
   // llama.cpp must be ready before the Go program calls Load.
   await self.yzmaReady;
@@ -37,8 +63,11 @@ const started = (async () => {
   // can call into it. Do not wait for this promise.
   go.run(result.instance);
 
-  // Give the program the turn it needs to set its functions.
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await programReady;
+
+  if (typeof self.yzmaLoadModel !== "function") {
+    throw new Error("the Go program did not set its functions");
+  }
 })();
 
 self.onmessage = async (event) => {

--- a/wasm/yzma-loader.js
+++ b/wasm/yzma-loader.js
@@ -7,22 +7,62 @@
 //   globalThis.yzmaReady     a promise whose value is the llama.cpp module
 //   globalThis.yzmaModule    the module, after the promise is done
 //   globalThis.yzmaThreaded  true if the build uses more than one thread
+//   globalThis.yzmaBackend   "webgpu", "cpu-threads", or "cpu"
+//   globalThis.yzmaAdapter   the name of the GPU, if there is one
 //
-// Set globalThis.yzmaBase before this file if the files of llama.cpp are not
-// beside it.
+// Set these before this file to change what it does:
+//
+//   globalThis.yzmaBase      where the files of llama.cpp are. The default is "."
+//   globalThis.yzmaMode      "auto" (the default), "webgpu", or "cpu"
+//
+// There are three builds of llama.cpp. WebGPU puts the computation on the GPU
+// and needs a browser that has both WebGPU and JSPI, which today is Chrome and
+// Edge 137 and later. The two builds on the CPU work everywhere, and the one
+// that uses more than one thread needs a page that is isolated with the
+// Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers.
+//
+// In "auto" the loader takes the best build that the browser can run, so a
+// browser without WebGPU still works.
 
 (function () {
   const base = globalThis.yzmaBase || ".";
+  const mode = globalThis.yzmaMode || "auto";
 
-  // A browser gives SharedArrayBuffer only to a page that is isolated with the
-  // Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers. The
+  // A browser gives SharedArrayBuffer only to a page that is isolated. The
   // build with more than one thread cannot run without it.
-  const threaded =
+  const canThread =
     typeof SharedArrayBuffer !== "undefined" && globalThis.crossOriginIsolated === true;
 
-  const name = threaded ? "yzma_wasm_mt" : "yzma_wasm";
+  // webgpuAdapter gives the name of a GPU that the WebGPU build of llama.cpp
+  // can use, or an empty string.
+  //
+  // The test is not only for navigator.gpu. The backend of llama.cpp needs f16
+  // shaders, and it reports no device at all without them, and the build needs
+  // JSPI to wait for the GPU.
+  async function webgpuAdapter() {
+    if (!globalThis.navigator || !navigator.gpu) {
+      return "";
+    }
+    if (typeof WebAssembly.Suspending !== "function") {
+      // No JSPI, so the WebGPU build cannot run in this browser.
+      return "";
+    }
 
-  globalThis.yzmaThreaded = threaded;
+    try {
+      const adapter = await navigator.gpu.requestAdapter();
+      if (!adapter || !adapter.features.has("shader-f16")) {
+        return "";
+      }
+
+      // The name of the GPU is only there if the browser gives it.
+      const info = adapter.info || {};
+      return [info.vendor, info.architecture, info.device, info.description]
+        .filter((part) => part)
+        .join(" ") || "webgpu";
+    } catch {
+      return "";
+    }
+  }
 
   function loadScript(url) {
     // A classic worker takes importScripts. A page takes a script element.
@@ -40,6 +80,34 @@
   }
 
   globalThis.yzmaReady = (async () => {
+    let name = "yzma_wasm";
+    let backend = "cpu";
+    let adapter = "";
+
+    if (mode !== "cpu") {
+      adapter = await webgpuAdapter();
+    }
+
+    if (adapter) {
+      name = "yzma_wasm_webgpu";
+      backend = "webgpu";
+    } else if (mode === "webgpu") {
+      // The page asked for WebGPU and the browser cannot give it. Say so, and
+      // then go on with the CPU, which is what "auto" would do.
+      console.warn("yzma: this browser has no WebGPU that llama.cpp can use, using the CPU");
+      if (canThread) {
+        name = "yzma_wasm_mt";
+        backend = "cpu-threads";
+      }
+    } else if (canThread) {
+      name = "yzma_wasm_mt";
+      backend = "cpu-threads";
+    }
+
+    globalThis.yzmaThreaded = backend === "cpu-threads";
+    globalThis.yzmaBackend = backend;
+    globalThis.yzmaAdapter = adapter;
+
     await loadScript(base + "/" + name + ".js");
 
     // MODULARIZE with EXPORT_NAME=yzmaModule makes yzmaModule a function that


### PR DESCRIPTION
Puts browser inference on the GPU. `llama.cpp` gains a third WebAssembly variant built with `GGML_WEBGPU`, and the glue takes it where the browser can run it.

Needs hybridgroup/llama-cpp-builder#33, which builds that variant. The `WebAssembly` CI job here installs the assets of a release, so it stays red until that PR lands and the builder publishes a release carrying `llama-<tag>-bin-wasm-webgpu.tar.gz`.

## Using it

Nothing changes in the shape of a program. Set `NGpuLayers` when there is a GPU:

```go
params := llamawasm.ModelDefaultParams()
if llamawasm.GPUDevice() != "" {
    params.NGpuLayers = 999
}
model, err := llamawasm.ModelLoadFromFile(path, params)
```

`llamawasm.Backend()` reports `webgpu`, `cpu-threads` or `cpu`, and `llamawasm.GPUDevice()` names the GPU. Ask `GPUDevice` rather than the browser: a page can have WebGPU while llama.cpp has no device.

`?mode=cpu` or `?mode=webgpu` on the page forces the choice, which is how the numbers below were measured.

## The two changes with teeth

**Calls can now return promises.** The calls of the WebGPU build that reach the GPU give a promise instead of a number, because the backend waits for the GPU and Emscripten builds it with JSPI. The call helpers wait for a promise when they see one and stay on the fast path when they do not, so one `pkg/llamawasm` drives every build with no build tags. The CPU paths were re-measured before any WebGPU code landed and did not move.

**The worker waited for a guess.** `worker.js` gave the Go program one turn of the event loop to register its functions. That was long enough for the CPU and nowhere near long enough for WebGPU, which has to find an adapter and build shaders — the first browser run failed with `self.yzmaLoadModel is not a function`. It now waits for the program's own `ready` message, and says so if the program never gets there.

The ABI check also becomes a range, so this yzma still drives the modules of the current release rather than requiring the new one.

## Measured

Headless Chrome 152, RTX 4070 with an Intel integrated GPU, greedy sampling:

| Model | Backend | Tokens a second |
| --- | --- | --- |
| SmolLM-135M Q2_K | one thread | 10.8 |
| SmolLM-135M Q2_K | more threads | 55.9 |
| SmolLM-135M Q2_K | WebGPU | 47.6 |
| Gemma 3 1B Q2_K | more threads | 8.7 |
| Gemma 3 1B Q2_K | WebGPU | 32.3 |

The GPU is 3.7x faster on the 1B model and slightly slower on the 135M one, where each operation is too small to pay for the trip to the GPU. Both are in `wasm/README.md` so nobody expects a win on a tiny model.

The builds on the CPU give the same text every run. The GPU agrees for the first few tokens and then goes its own way, because the shaders do the arithmetic in a different order.

## Also verified

- `make test-wasm`, `make test-wasm-mt`, and the new `make test-wasm-webgpu` (which checks the fallback: Node has no WebGPU, so it must quietly use the CPU and still make text) — all pass, same text as before.
- The 1B model loads and generates in the browser on both backends.
- Both toolchains: `make vet-wasm`, `make wasm-example` (TinyGo) and `make wasm-example-go`.
- Native untouched: `go build ./...`, `go vet ./...`, the `pkg/download` tests.
- An ABI 1 module (the current release) still runs under this branch and reports `cpu`.

## Two honest notes

- **A discrete NVIDIA card in a stock Chrome falls back to the CPU.** In a browser the backend takes the default adapter, and NVIDIA does not expose `shader-f16` there unless Chrome is started with `--enable-dawn-features=vulkan_enable_f16_on_nvidia`. An Intel integrated GPU works as it is. Documented rather than worked around, because the fix is a browser flag.
- One threaded-CPU run of the 1B model died with `RuntimeError: unreachable` while loading, and did not reproduce in two later runs. Probably memory pressure right after a GPU Chrome exited. Recording it here rather than pretending it did not happen.