### PR TITLE
A model with eyes in the browser

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -45,19 +45,23 @@ jobs:
         run: |
           set -e
           yzma install -lib $GITHUB_WORKSPACE/$WASM_DIR -os wasm -version ${{ steps.llama-version.outputs.version }}
-      - name: Build the example with TinyGo
-        run: make wasm-example
-      - name: Cache test model
+      - name: Build the examples with TinyGo
+        run: |
+          make wasm-example
+          make wasm-vlm-example
+      - name: Cache test models
         id: cache-model
         uses: actions/cache@v4
         with:
           path: models
-          key: ${{ runner.os }}-wasm-models-v1
-      - name: Download the test model
+          key: ${{ runner.os }}-wasm-models-v2
+      - name: Download the test models
         if: steps.cache-model.outputs.cache-hit != 'true'
         run: |
           mkdir -p ./models
           yzma model get -y --show-progress=false -o $GITHUB_WORKSPACE/models -u https://huggingface.co/QuantFactory/SmolLM-135M-GGUF/resolve/main/SmolLM-135M.Q2_K.gguf
+          yzma model get -y --show-progress=false -o $GITHUB_WORKSPACE/models -u https://huggingface.co/ggml-org/SmolVLM-256M-Instruct-GGUF/resolve/main/SmolVLM-256M-Instruct-Q8_0.gguf
+          yzma model get -y --show-progress=false -o $GITHUB_WORKSPACE/models -u https://huggingface.co/ggml-org/SmolVLM-256M-Instruct-GGUF/resolve/main/mmproj-SmolVLM-256M-Instruct-Q8_0.gguf
       - name: Run inference in Node
         run: |
           node wasm/node/run.js \
@@ -73,5 +77,14 @@ jobs:
             --dir $GITHUB_WORKSPACE/$WASM_DIR \
             --model $GITHUB_WORKSPACE/models/SmolLM-135M.Q2_K.gguf \
             --tokens 12 --webgpu
-      - name: Build the example with the standard toolchain
+      # Node has no canvas, so the harness makes its own pixels. This checks the
+      # whole path: the pixels, the projector, and the tokens that come out.
+      - name: Ask about an image in Node
+        run: |
+          node wasm/node/vlm.js \
+            --dir $GITHUB_WORKSPACE/$WASM_DIR \
+            --model $GITHUB_WORKSPACE/models/SmolVLM-256M-Instruct-Q8_0.gguf \
+            --mmproj $GITHUB_WORKSPACE/models/mmproj-SmolVLM-256M-Instruct-Q8_0.gguf \
+            --tokens 24 --mt
+      - name: Build the examples with the standard toolchain
         run: make wasm-example-go

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -228,7 +228,7 @@ yzma install --lib /path/to/lib --processor cpu --os trixie
 yzma install --lib /path/to/web --os wasm
 ```
 
-WebGPU needs Chrome or Edge 137 and later, and an adapter with f16 shaders; every other browser runs on the CPU. This target uses the smaller API of the [`pkg/llamawasm`](./pkg/llamawasm) package. See [wasm/README.md](./wasm/README.md).
+WebGPU needs Chrome or Edge 137 and later, and an adapter with f16 shaders; every other browser runs on the CPU. Every build has the multimodal library, so a model with a projector works for images. This target uses the smaller API of the [`pkg/llamawasm`](./pkg/llamawasm) package. See [wasm/README.md](./wasm/README.md).
 
 ### Windows CPU
 

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,16 @@ wasm-example: wasm-assets
 	tinygo build -target wasm -o $(WASM_DIR)/yzma.wasm ./examples/wasm/chat
 	cp "$(shell tinygo env TINYGOROOT)/targets/wasm_exec.js" $(WASM_DIR)/
 
-# make wasm-example-go to build the same example with the standard toolchain.
-# The binary is larger, which helps when TinyGo cannot build a dependency.
+# make wasm-vlm-example to build the browser example that takes an image.
+wasm-vlm-example: wasm-assets
+	tinygo build -target wasm -o $(WASM_DIR)/yzma-vlm.wasm ./examples/wasm/vlm
+	cp "$(shell tinygo env TINYGOROOT)/targets/wasm_exec.js" $(WASM_DIR)/
+
+# make wasm-example-go to build the same examples with the standard toolchain.
+# The binaries are larger, which helps when TinyGo cannot build a dependency.
 wasm-example-go: wasm-assets
 	GOOS=js GOARCH=wasm go build -o $(WASM_DIR)/yzma.wasm ./examples/wasm/chat
+	GOOS=js GOARCH=wasm go build -o $(WASM_DIR)/yzma-vlm.wasm ./examples/wasm/vlm
 	cp "$(shell go env GOROOT)/lib/wasm/wasm_exec.js" $(WASM_DIR)/
 
 # wasm-assets copies the JavaScript glue and the page into the build directory.
@@ -64,7 +70,7 @@ wasm-example-go: wasm-assets
 # program copies the correct one.
 wasm-assets:
 	mkdir -p $(WASM_DIR)
-	cp wasm/yzma-loader.js wasm/worker.js wasm/index.html $(WASM_DIR)/
+	cp wasm/yzma-loader.js wasm/worker.js wasm/index.html wasm/vlm.html $(WASM_DIR)/
 
 # make download-llama.cpp-wasm to get the WebAssembly build of llama.cpp.
 download-llama.cpp-wasm:
@@ -80,7 +86,8 @@ serve-wasm:
 # because the tests of the repo build for the machine they run on.
 vet-wasm:
 	GOOS=js GOARCH=wasm go build -o /dev/null ./examples/wasm/chat
-	GOOS=js GOARCH=wasm go vet ./pkg/llamawasm ./examples/wasm/chat
+	GOOS=js GOARCH=wasm go build -o /dev/null ./examples/wasm/vlm
+	GOOS=js GOARCH=wasm go vet ./pkg/llamawasm ./examples/wasm/chat ./examples/wasm/vlm
 
 # make test-wasm to run the WebAssembly build in Node, with no browser.
 test-wasm:
@@ -96,6 +103,17 @@ test-wasm-mt:
 # browser can run the WebGPU build itself.
 test-wasm-webgpu:
 	node wasm/node/run.js --dir $(WASM_DIR) --model $(MODELS_DIR)/SmolLM-135M.Q2_K.gguf --tokens 12 --webgpu
+
+# make test-wasm-vlm to answer a question about an image in Node, with no
+# browser. Node has no canvas, so the harness makes the pixels itself.
+#
+# It takes the build with more threads, because putting an image through a
+# projector is slow: about 30 seconds with threads and 80 with one.
+test-wasm-vlm:
+	node wasm/node/vlm.js --dir $(WASM_DIR) \
+		--model $(MODELS_DIR)/SmolVLM-256M-Instruct-Q8_0.gguf \
+		--mmproj $(MODELS_DIR)/mmproj-SmolVLM-256M-Instruct-Q8_0.gguf \
+		--tokens 24 --mt
 
 clean-wasm:
 	rm -rf $(WASM_DIR)

--- a/README.md
+++ b/README.md
@@ -135,15 +135,16 @@ Sure! Let's go to the zoo and feed the llama. What kind of llama are you interes
 
 ### WebAssembly Example
 
-`yzma` also runs in a browser, on the CPU or on the GPU with WebGPU. `llama.cpp` becomes a WebAssembly module, and a Go program compiled by TinyGo drives it through the [`pkg/llamawasm`](./pkg/llamawasm) package:
+`yzma` also runs in a browser, on the CPU or on the GPU with WebGPU, with text or with images. `llama.cpp` becomes a WebAssembly module, and a Go program compiled by TinyGo drives it through the [`pkg/llamawasm`](./pkg/llamawasm) package:
 
 ```shell
 $ make download-llama.cpp-wasm
 $ make wasm-example
+$ make wasm-vlm-example
 $ make serve-wasm
 ```
 
-Then open http://localhost:8080
+Then open http://localhost:8080 for chat, or http://localhost:8080/vlm.html to ask about an image.
 
 See [wasm/README.md](./wasm/README.md) for how it works and what it can do.
 
@@ -183,7 +184,7 @@ You can use multimodal models (image/audio) and text language models with full h
 | macOS   | arm64        | Metal                           |
 | Windows | amd64        | CUDA, Vulkan, HIP, SYCL, OpenCL |
 
-A browser is also a target. The API there is the smaller one of the [`pkg/llamawasm`](./pkg/llamawasm) package: text generation and embeddings, with no multimodal input, LoRA adapters, saved state, or quantization. See [wasm/README.md](./wasm/README.md).
+A browser is also a target. The API there is the smaller one of the [`pkg/llamawasm`](./pkg/llamawasm) package: text generation, embeddings, and images, with no audio, video, LoRA adapters, saved state, or quantization. See [wasm/README.md](./wasm/README.md).
 
 | Target  | CPU          | GPU  |
 | ------- | ------------ | ---- |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 - Run the latest Vision Language Models (VLM) and Large/Small/Tiny Language Models (LLM) on Linux, macOS, or Windows.
 - Use any available hardware acceleration such as [CUDA](https://en.wikipedia.org/wiki/CUDA), [Metal](https://en.wikipedia.org/wiki/Metal_(API)), or [Vulkan](https://en.wikipedia.org/wiki/Vulkan) for maximum performance.
+- Run in a browser as well, with [TinyGo](https://tinygo.org) and WebAssembly, on the CPU or on the GPU with [WebGPU](https://en.wikipedia.org/wiki/WebGPU).
 - `yzma` uses the [`purego`](https://github.com/ebitengine/purego) and [`ffi`](https://github.com/JupiterRider/ffi) packages so CGo is not needed.
 - Works with the newest `llama.cpp` releases so you can use the latest features, performance improvements, and bugfixes.
 
@@ -135,7 +136,7 @@ Sure! Let's go to the zoo and feed the llama. What kind of llama are you interes
 
 ### WebAssembly Example
 
-`yzma` also runs in a browser, on the CPU or on the GPU with WebGPU, with text or with images. `llama.cpp` becomes a WebAssembly module, and a Go program compiled by TinyGo drives it through the [`pkg/llamawasm`](./pkg/llamawasm) package:
+`yzma` also runs in a browser, with text or with images. `llama.cpp` becomes a WebAssembly module of its own, and a Go program compiled by [TinyGo](https://tinygo.org) drives it through the [`pkg/llamawasm`](./pkg/llamawasm) package. The model never leaves the machine of the reader, and no server does any of the work.
 
 ```shell
 $ make download-llama.cpp-wasm
@@ -144,9 +145,27 @@ $ make wasm-vlm-example
 $ make serve-wasm
 ```
 
-Then open http://localhost:8080 for chat, or http://localhost:8080/vlm.html to ask about an image.
+Then open http://localhost:8080 for chat, or http://localhost:8080/vlm.html to ask a question about an image. Each page says which backend it got:
 
-See [wasm/README.md](./wasm/README.md) for how it works and what it can do.
+```
+backend: webgpu (WebGPU)
+```
+
+There are three builds of `llama.cpp`, and the JavaScript glue takes the best one the browser can run:
+
+| Build | What the browser needs |
+|-------|------------------------|
+| WebGPU | WebGPU with f16 shaders, and JSPI: Chrome or Edge 137 and later |
+| More threads | `SharedArrayBuffer`, so a page with the COOP and COEP headers |
+| One thread | Nothing. It works everywhere. |
+
+So a browser without WebGPU still works, on the CPU. The GPU is worth the most to a page that takes images: putting one through the projector of a model takes a second or two on the GPU against half a minute or more on the CPU.
+
+The API in a browser is the smaller one of [`pkg/llamawasm`](./pkg/llamawasm): the calls that text generation, embeddings, and images need. The names and the order of the calls are the same as in [`pkg/llama`](./pkg/llama) and [`pkg/mtmd`](./pkg/mtmd), so a program moves over with a change of the import.
+
+[See the code here](./examples/wasm/chat/main.go), or [the one that takes an image](./examples/wasm/vlm/main.go).
+
+See [wasm/README.md](./wasm/README.md) for how it works, what each build costs in speed, and what a page must do to use one.
 
 ### Additional Examples
 
@@ -184,13 +203,13 @@ You can use multimodal models (image/audio) and text language models with full h
 | macOS   | arm64        | Metal                           |
 | Windows | amd64        | CUDA, Vulkan, HIP, SYCL, OpenCL |
 
-A browser is also a target. The API there is the smaller one of the [`pkg/llamawasm`](./pkg/llamawasm) package: text generation, embeddings, and images, with no audio, video, LoRA adapters, saved state, or quantization. See [wasm/README.md](./wasm/README.md).
+A browser is also a target:
 
 | Target  | CPU          | GPU  |
 | ------- | ------------ | ---- |
 | Browser | wasm32 SIMD, one or more threads | WebGPU |
 
-The JavaScript glue takes the build that the browser can run, so a browser with no WebGPU still works on the CPU. WebGPU needs Chrome or Edge 137 and later, and an adapter with f16 shaders.
+There the API is the smaller one of the [`pkg/llamawasm`](./pkg/llamawasm) package: text generation, embeddings, and images, with no audio, video, LoRA adapters, saved state, or quantization. See the [WebAssembly example](#webassembly-example) above and [wasm/README.md](./wasm/README.md).
 
 Whenever there is a new release of `llama.cpp`, the tests for `yzma` are run automatically. This helps us stay up to date with the latest code and models.
 

--- a/examples/wasm/chat/main.go
+++ b/examples/wasm/chat/main.go
@@ -131,7 +131,7 @@ func backendReport() string {
 	if device := llamawasm.GPUDevice(); device != "" {
 		return fmt.Sprintf("backend: %s (%s)", llamawasm.Backend(), device)
 	}
-	return fmt.Sprintf("backend: %s", llamawasm.Backend())
+	return fmt.Sprintf("backend: %s, %d threads", llamawasm.Backend(), llamawasm.Threads())
 }
 
 // generate(prompt, maxTokens) makes text and sends each piece to the page.

--- a/examples/wasm/vlm/main.go
+++ b/examples/wasm/vlm/main.go
@@ -1,0 +1,306 @@
+//go:build js && wasm
+
+// Vlm answers a question about an image in a browser.
+//
+// It is the same shape as examples/wasm/chat, with the multimodal calls of
+// pkg/llamawasm added: the page decodes the image and sends the pixels, and this
+// program turns them into a bitmap, puts them in the prompt beside the text, and
+// then runs the same loop of sampling and decoding.
+//
+// Build it with TinyGo:
+//
+//	tinygo build -target wasm -o build/wasm/yzma-vlm.wasm ./examples/wasm/vlm
+//
+// See wasm/README.md for how to serve the result.
+package main
+
+import (
+	"fmt"
+	"syscall/js"
+	"time"
+
+	"github.com/hybridgroup/yzma/pkg/llamawasm"
+)
+
+const (
+	modelPath   = "/models/model.gguf"
+	projectPath = "/models/mmproj.gguf"
+)
+
+var (
+	model   llamawasm.Model
+	ctx     llamawasm.Context
+	mctx    llamawasm.MtmdContext
+	vocab   llamawasm.Vocab
+	sampler llamawasm.Sampler
+	nBatch  int32 = 2048
+)
+
+func main() {
+	if err := llamawasm.Load(""); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	llamawasm.LogSet(llamawasm.LogSilent())
+	llamawasm.Init()
+
+	if !llamawasm.MtmdSupported() {
+		post("error", "this build of llama.cpp has no multimodal calls")
+		return
+	}
+
+	js.Global().Set("yzmaLoadModel", js.FuncOf(loadModel))
+	js.Global().Set("yzmaOpenModel", js.FuncOf(openModel))
+	js.Global().Set("yzmaDescribe", js.FuncOf(describe))
+
+	post("ready", backendReport())
+
+	<-make(chan struct{})
+}
+
+// loadModel(modelURL, projectorURL) gets both files and makes the contexts.
+func loadModel(this js.Value, args []js.Value) any {
+	if len(args) < 2 || !args[0].Truthy() || !args[1].Truthy() {
+		post("error", "loadModel needs the URL of a model and of a projector")
+		return nil
+	}
+	modelURL, projectorURL := args[0].String(), args[1].String()
+
+	go func() {
+		for _, file := range []struct {
+			name, url, path string
+		}{
+			{"model", modelURL, modelPath},
+			{"projector", projectorURL, projectPath},
+		} {
+			post("status", "downloading the "+file.name)
+
+			err := llamawasm.FetchModelFile(file.path, file.url, func(done, total int64) {
+				if total > 0 {
+					post("progress", fmt.Sprintf("%s %d%%", file.name, done*100/total))
+				}
+			})
+			if err != nil {
+				post("error", err.Error())
+				return
+			}
+		}
+
+		open()
+	}()
+
+	return nil
+}
+
+// openModel() loads the files that are already in the filesystem of the module.
+// A test that has them puts them there itself.
+func openModel(this js.Value, args []js.Value) any {
+	go open()
+	return nil
+}
+
+// open loads the model, the context, and the projector.
+func open() {
+	post("status", "loading the model")
+
+	params := llamawasm.ModelDefaultParams()
+	onGPU := llamawasm.GPUDevice() != ""
+	if onGPU {
+		params.NGpuLayers = 999
+	}
+
+	var err error
+	if model, err = llamawasm.ModelLoadFromFile(modelPath, params); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	// A model with eyes needs room for the tokens of the image as well as the
+	// text, so the context is larger than the one the chat example uses.
+	ctxParams := llamawasm.ContextDefaultParams()
+	ctxParams.NCtx = 4096
+	ctxParams.NBatch = uint32(nBatch)
+
+	if ctx, err = llamawasm.InitFromModel(model, ctxParams); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	vocab = llamawasm.ModelGetVocab(model)
+
+	post("status", "loading the projector")
+
+	if mctx, err = llamawasm.MtmdInitFromFile(projectPath, model, 0, onGPU); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	if !llamawasm.MtmdSupportVision(mctx) {
+		post("error", "this projector does not take images")
+		return
+	}
+
+	post("loaded", llamawasm.ModelDesc(model)+", "+backendReport())
+}
+
+// describe(prompt, width, height, rgba, maxTokens) answers a question about an
+// image. The pixels come from a canvas of the page, so they are RGBA.
+func describe(this js.Value, args []js.Value) any {
+	if len(args) < 4 {
+		post("error", "describe needs a prompt, a size, and the pixels")
+		return nil
+	}
+
+	prompt := args[0].String()
+	width := int32(args[1].Int())
+	height := int32(args[2].Int())
+
+	rgba := make([]byte, args[3].Get("length").Int())
+	js.CopyBytesToGo(rgba, args[3])
+
+	maxTokens := int32(128)
+	if len(args) > 4 && args[4].Truthy() {
+		maxTokens = int32(args[4].Int())
+	}
+
+	go run(prompt, width, height, rgba, maxTokens)
+
+	return nil
+}
+
+func run(prompt string, width, height int32, rgba []byte, maxTokens int32) {
+	if model == 0 || ctx == 0 || mctx == 0 {
+		post("error", "load a model first")
+		return
+	}
+
+	// Every answer starts from an empty state.
+	if err := llamawasm.MemoryClear(ctx, true); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	post("status", "looking at the image")
+
+	bitmap, err := llamawasm.MtmdBitmapInit(width, height, dropAlpha(rgba))
+	if err != nil {
+		post("error", err.Error())
+		return
+	}
+	defer llamawasm.MtmdBitmapFree(bitmap)
+
+	chunks, err := llamawasm.MtmdInputChunksInit()
+	if err != nil {
+		post("error", err.Error())
+		return
+	}
+	defer llamawasm.MtmdInputChunksFree(chunks)
+
+	text := buildPrompt(prompt)
+
+	if err := llamawasm.MtmdTokenize(mctx, chunks, text, true, true, []llamawasm.MtmdBitmap{bitmap}); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	// This is where the image goes through the projector and into the model. It
+	// is the slow part, so it is timed on its own: putting it into the rate of
+	// the tokens would say nothing about either.
+	encodeStart := time.Now()
+
+	nPast, err := llamawasm.MtmdHelperEvalChunks(mctx, ctx, chunks, 0, 0, nBatch, true)
+	if err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	encode := time.Since(encodeStart).Seconds()
+	post("status", fmt.Sprintf("answering, %d tokens of image and text in %.1fs", nPast, encode))
+
+	start := time.Now()
+
+	if sampler != 0 {
+		llamawasm.SamplerFree(sampler)
+	}
+	sampler = llamawasm.SamplerChainInit(llamawasm.SamplerChainDefaultParams())
+	llamawasm.SamplerChainAdd(sampler, llamawasm.SamplerInitGreedy())
+
+	buf := make([]byte, 64)
+
+	var count int32
+	for count < maxTokens {
+		token := llamawasm.SamplerSample(sampler, ctx, -1)
+		if llamawasm.VocabIsEOG(vocab, token) {
+			break
+		}
+		llamawasm.SamplerAccept(sampler, token)
+
+		if n := llamawasm.TokenToPiece(vocab, token, buf, 0, true); n > 0 {
+			post("token", string(buf[:n]))
+		}
+		count++
+
+		// The positions carry on from the chunks, which the module knows.
+		if _, err := llamawasm.Decode(ctx, llamawasm.BatchGetOne([]llamawasm.Token{token})); err != nil {
+			post("error", err.Error())
+			return
+		}
+	}
+
+	elapsed := time.Since(start).Seconds()
+	if elapsed > 0 {
+		post("done", fmt.Sprintf("%d tokens, %.2f tokens/s, and %.1fs for the image",
+			count, float64(count)/elapsed, encode))
+		return
+	}
+	post("done", fmt.Sprintf("%d tokens, and %.1fs for the image", count, encode))
+}
+
+// buildPrompt puts the marker of the model and the question into the chat format
+// of the model. The marker is where the image goes.
+func buildPrompt(question string) string {
+	marker := llamawasm.MtmdMarker(mctx)
+	if marker == "" {
+		marker = "<__media__>"
+	}
+
+	text := marker + "\n" + question
+
+	// A model with no chat template takes the text as it is.
+	if formatted, err := llamawasm.ChatApplyTemplate(model, "user", text, true); err == nil && formatted != "" {
+		return formatted
+	}
+	return text
+}
+
+// dropAlpha turns the RGBA of a canvas into the RGB that a bitmap needs.
+func dropAlpha(rgba []byte) []byte {
+	rgb := make([]byte, 0, len(rgba)/4*3)
+	for i := 0; i+3 < len(rgba); i += 4 {
+		rgb = append(rgb, rgba[i], rgba[i+1], rgba[i+2])
+	}
+	return rgb
+}
+
+func backendReport() string {
+	if device := llamawasm.GPUDevice(); device != "" {
+		return fmt.Sprintf("backend: %s (%s)", llamawasm.Backend(), device)
+	}
+	return fmt.Sprintf("backend: %s", llamawasm.Backend())
+}
+
+// post sends a message to whatever holds this module.
+func post(kind, text string) {
+	message := map[string]any{"kind": kind, "text": text}
+
+	if fn := js.Global().Get("postMessage"); fn.Type() == js.TypeFunction {
+		fn.Invoke(message)
+		return
+	}
+	if fn := js.Global().Get("yzmaOnMessage"); fn.Type() == js.TypeFunction {
+		fn.Invoke(message)
+		return
+	}
+	fmt.Printf("%s: %s\n", kind, text)
+}

--- a/examples/wasm/vlm/main.go
+++ b/examples/wasm/vlm/main.go
@@ -34,6 +34,10 @@ var (
 	vocab   llamawasm.Vocab
 	sampler llamawasm.Sampler
 	nBatch  int32 = 2048
+
+	// maxImageTokens bounds the tokens that one image becomes, for a model whose
+	// resolution changes with the image. 0 takes the bounds of the model.
+	maxImageTokens int32
 )
 
 func main() {
@@ -93,9 +97,14 @@ func loadModel(this js.Value, args []js.Value) any {
 	return nil
 }
 
-// openModel() loads the files that are already in the filesystem of the module.
-// A test that has them puts them there itself.
+// openModel(maxImageTokens) loads the files that are already in the filesystem
+// of the module. A test that has them puts them there itself.
+//
+// maxImageTokens is optional, and 0 takes the bounds of the model.
 func openModel(this js.Value, args []js.Value) any {
+	if len(args) > 0 && args[0].Truthy() {
+		maxImageTokens = int32(args[0].Int())
+	}
 	go open()
 	return nil
 }
@@ -131,7 +140,13 @@ func open() {
 
 	post("status", "loading the projector")
 
-	if mctx, err = llamawasm.MtmdInitFromFile(projectPath, model, 0, onGPU); err != nil {
+	// The default takes every thread the module has, which matters: the
+	// projector is the slow part, and llama.cpp asks for only four threads
+	// unless it is told otherwise.
+	projectorParams := llamawasm.MtmdContextParamsDefault()
+	projectorParams.ImageMaxTokens = maxImageTokens
+
+	if mctx, err = llamawasm.MtmdInitFromFile(projectPath, model, projectorParams); err != nil {
 		post("error", err.Error())
 		return
 	}
@@ -287,7 +302,7 @@ func backendReport() string {
 	if device := llamawasm.GPUDevice(); device != "" {
 		return fmt.Sprintf("backend: %s (%s)", llamawasm.Backend(), device)
 	}
-	return fmt.Sprintf("backend: %s", llamawasm.Backend())
+	return fmt.Sprintf("backend: %s, %d threads", llamawasm.Backend(), llamawasm.Threads())
 }
 
 // post sends a message to whatever holds this module.

--- a/pkg/llamawasm/doc.go
+++ b/pkg/llamawasm/doc.go
@@ -62,6 +62,19 @@
 // Set NGpuLayers in [ModelParams] to put layers on the GPU. It does nothing in
 // a build for the CPU.
 //
+// # A model with eyes
+//
+// The multimodal library of llama.cpp, mtmd, is in every build. [MtmdBitmapInit]
+// takes the pixels of an image, [MtmdTokenize] puts them into a prompt beside
+// the text, and [MtmdHelperEvalChunks] runs both through the model. See mtmd.go
+// for the order of the calls.
+//
+// The pixels must be RGB. A page decodes the image itself, with a canvas, so any
+// format the browser reads works and no image library goes into the build.
+//
+// Images only. Audio needs the page to decode and resample the samples, and
+// video needs ffmpeg in a subprocess.
+//
 // # Limits
 //
 // A build for the CPU uses SIMD. WebGPU needs Chrome or Edge 137 and later,
@@ -71,6 +84,6 @@
 // A WebAssembly module can address 4 GB, and one JavaScript ArrayBuffer holds
 // at most 2 GB, so a model of more than 2 GB must be in splits.
 //
-// The package has the calls that text generation and embeddings need. It does
-// not have multimodal input, LoRA adapters, saved state, or quantization.
+// The package has the calls that text generation, embeddings, and images need.
+// It does not have audio, video, LoRA adapters, saved state, or quantization.
 package llamawasm

--- a/pkg/llamawasm/model.go
+++ b/pkg/llamawasm/model.go
@@ -105,3 +105,49 @@ func modelString(name string, model Model, size int) string {
 func (m Model) String() string {
 	return fmt.Sprintf("model(%d)", int32(m))
 }
+
+// ChatApplyTemplate puts one message into the chat format of the model.
+//
+// One message is enough for a prompt with a question about an image. A chat with
+// turns needs the template of the model, which [ModelChatTemplate] gives.
+//
+// addAssistant adds the opening of the turn of the assistant, which is what
+// makes the model answer instead of carrying on the message.
+func ChatApplyTemplate(model Model, role, content string, addAssistant bool) (string, error) {
+	if !Loaded() {
+		return "", ErrNotLoaded
+	}
+	if !has("_yzma_chat_apply_template") {
+		return "", ErrNoMultimodal
+	}
+
+	roleLen := len(role) + 1
+	rolePtr, err := textScratch.reserve(roleLen + len(content) + 1)
+	if err != nil {
+		return "", err
+	}
+	writeString(rolePtr, role)
+
+	contentPtr := rolePtr + roleLen
+	writeString(contentPtr, content)
+
+	size := len(content) + 512
+	for {
+		outPtr, err := pieceScratch.reserve(size)
+		if err != nil {
+			return "", err
+		}
+
+		n := call("_yzma_chat_apply_template", int(model), rolePtr, contentPtr,
+			boolToInt(addAssistant), outPtr, size)
+		switch {
+		case n == errTooSmall && size < 1<<20:
+			size *= 4
+			continue
+		case n < 0:
+			return "", shimError("_yzma_chat_apply_template", n)
+		default:
+			return string(readBytes(outPtr, int(n))), nil
+		}
+	}
+}

--- a/pkg/llamawasm/module.go
+++ b/pkg/llamawasm/module.go
@@ -160,6 +160,25 @@ func Threaded() bool {
 	return threaded
 }
 
+// Threads gives the number of threads that the module can use, which the
+// JavaScript glue takes from the machine. It is 1 for a build that uses one
+// thread, and for the WebGPU build, where the GPU does the work.
+//
+// llama.cpp asks for four threads unless it is told otherwise, whatever the
+// machine has, so [ContextDefaultParams] and [MtmdContextParamsDefault] pass
+// this instead.
+func Threads() int32 {
+	if !Loaded() {
+		return 0
+	}
+
+	n := js.Global().Get("yzmaThreads")
+	if n.Type() != js.TypeNumber || n.Int() < 1 {
+		return 1
+	}
+	return int32(n.Int())
+}
+
 // Init starts the llama.cpp backend. Call it after Load.
 func Init() {
 	if !Loaded() {

--- a/pkg/llamawasm/module.go
+++ b/pkg/llamawasm/module.go
@@ -19,7 +19,7 @@ import (
 // each one is tested for before it is used.
 const (
 	abiVersionMin = 1 // 1 has the calls for text generation and embeddings
-	abiVersion    = 2 // 2 adds yzma_gpu_device
+	abiVersion    = 3 // 2 adds yzma_gpu_device, 3 adds the multimodal calls
 )
 
 // Error codes that the shim returns. These are the same as the values in
@@ -38,6 +38,10 @@ var (
 
 	// ErrNoModule says that the JavaScript glue did not run before Load.
 	ErrNoModule = errors.New("llamawasm: globalThis.yzmaReady is missing, load yzma-loader.js first")
+
+	// ErrNoMultimodal says that the module came from a release before the
+	// multimodal calls, which are in ABI version 3 and later.
+	ErrNoMultimodal = errors.New("llamawasm: this llama.cpp module has no multimodal calls, install a newer build")
 )
 
 // mod is the Emscripten module instance of llama.cpp.

--- a/pkg/llamawasm/module.go
+++ b/pkg/llamawasm/module.go
@@ -19,7 +19,8 @@ import (
 // each one is tested for before it is used.
 const (
 	abiVersionMin = 1 // 1 has the calls for text generation and embeddings
-	abiVersion    = 3 // 2 adds yzma_gpu_device, 3 adds the multimodal calls
+	abiVersion    = 4 // 2 adds yzma_gpu_device, 3 the multimodal calls, 4 the
+	//                   bounds of the tokens of an image
 )
 
 // Error codes that the shim returns. These are the same as the values in

--- a/pkg/llamawasm/mtmd.go
+++ b/pkg/llamawasm/mtmd.go
@@ -15,7 +15,7 @@ import "fmt"
 //
 // The order of the calls is the same as in the examples/vlm program:
 //
-//	mctx, err := llamawasm.MtmdInitFromFile("mmproj.gguf", model, 0, true)
+//	mctx, err := llamawasm.MtmdInitFromFile("mmproj.gguf", model, llamawasm.MtmdContextParamsDefault())
 //	bitmap, err := llamawasm.MtmdBitmapInit(width, height, rgb)
 //	chunks, err := llamawasm.MtmdInputChunksInit()
 //	llamawasm.MtmdTokenize(mctx, chunks, prompt, true, true, []MtmdBitmap{bitmap})
@@ -37,6 +37,35 @@ type (
 	MtmdInputChunks int32
 )
 
+// MtmdContextParams holds what the shim can set while it loads a projector.
+//
+// It is the small part of mtmd.ContextParamsType that a browser can use.
+type MtmdContextParams struct {
+	// NThreads is the number of threads for the projector. Putting an image
+	// through one is the slowest part of an answer, so this matters more than
+	// the threads of the context do.
+	NThreads int32
+
+	// UseGPU puts the projector on the GPU where there is one.
+	UseGPU bool
+
+	// ImageMinTokens and ImageMaxTokens bound the number of tokens that one
+	// image becomes, for a model whose resolution changes with the image. 0
+	// takes the bounds of the model. Fewer tokens is less work and less detail.
+	ImageMinTokens int32
+	ImageMaxTokens int32
+}
+
+// MtmdContextParamsDefault gives the parameters that a projector uses if the
+// program changes nothing: every thread the module has, and the GPU if
+// llama.cpp found one.
+func MtmdContextParamsDefault() MtmdContextParams {
+	return MtmdContextParams{
+		NThreads: Threads(),
+		UseGPU:   GPUDevice() != "",
+	}
+}
+
 // MtmdSupported tells if the module has the multimodal calls. A module from a
 // release before they came has none.
 func MtmdSupported() bool {
@@ -47,9 +76,8 @@ func MtmdSupported() bool {
 // in the filesystem of the module, the same as the model, and the model must be
 // loaded first.
 //
-// useGPU puts the projector on the GPU where there is one. nThreads of 0 leaves
-// the number of threads to the module.
-func MtmdInitFromFile(mmprojPath string, model Model, nThreads int32, useGPU bool) (MtmdContext, error) {
+// Pass [MtmdContextParamsDefault] unless there is a reason not to.
+func MtmdInitFromFile(mmprojPath string, model Model, params MtmdContextParams) (MtmdContext, error) {
 	if !Loaded() {
 		return 0, ErrNotLoaded
 	}
@@ -63,7 +91,9 @@ func MtmdInitFromFile(mmprojPath string, model Model, nThreads int32, useGPU boo
 	}
 	writeString(ptr, mmprojPath)
 
-	handle, err := callErr("_yzma_mtmd_init_from_file", ptr, int(model), int(nThreads), boolToInt(useGPU))
+	handle, err := callErr("_yzma_mtmd_init_from_file", ptr, int(model),
+		int(params.NThreads), boolToInt(params.UseGPU),
+		int(params.ImageMinTokens), int(params.ImageMaxTokens))
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/llamawasm/mtmd.go
+++ b/pkg/llamawasm/mtmd.go
@@ -1,0 +1,256 @@
+//go:build js && wasm
+
+package llamawasm
+
+import "fmt"
+
+// The calls in this file follow the mtmd library of llama.cpp, which is what
+// gives a model its eyes. The names are the ones of the mtmd package with an
+// Mtmd prefix, because this package holds the llama calls as well:
+//
+//	mtmd.InitFromFile     -> llamawasm.MtmdInitFromFile
+//	mtmd.InputChunksInit  -> llamawasm.MtmdInputChunksInit
+//	mtmd.Tokenize         -> llamawasm.MtmdTokenize
+//	mtmd.HelperEvalChunks -> llamawasm.MtmdHelperEvalChunks
+//
+// The order of the calls is the same as in the examples/vlm program:
+//
+//	mctx, err := llamawasm.MtmdInitFromFile("mmproj.gguf", model, 0, true)
+//	bitmap, err := llamawasm.MtmdBitmapInit(width, height, rgb)
+//	chunks, err := llamawasm.MtmdInputChunksInit()
+//	llamawasm.MtmdTokenize(mctx, chunks, prompt, true, true, []MtmdBitmap{bitmap})
+//	nPast, err := llamawasm.MtmdHelperEvalChunks(mctx, ctx, chunks, 0, 0, nBatch, true)
+//	// then the same loop of SamplerSample and Decode as for text alone
+//
+// The prompt must hold one marker for each bitmap. [MtmdMarker] gives the
+// marker of the model.
+
+// The handles of the multimodal objects.
+type (
+	// MtmdContext is a handle to a loaded projector.
+	MtmdContext int32
+
+	// MtmdBitmap is a handle to an image in the module.
+	MtmdBitmap int32
+
+	// MtmdInputChunks is a handle to a list of chunks of a prompt.
+	MtmdInputChunks int32
+)
+
+// MtmdSupported tells if the module has the multimodal calls. A module from a
+// release before they came has none.
+func MtmdSupported() bool {
+	return has("_yzma_mtmd_init_from_file")
+}
+
+// MtmdInitFromFile loads the projector of a multimodal model. The file must be
+// in the filesystem of the module, the same as the model, and the model must be
+// loaded first.
+//
+// useGPU puts the projector on the GPU where there is one. nThreads of 0 leaves
+// the number of threads to the module.
+func MtmdInitFromFile(mmprojPath string, model Model, nThreads int32, useGPU bool) (MtmdContext, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+	if !MtmdSupported() {
+		return 0, ErrNoMultimodal
+	}
+
+	ptr, err := textScratch.reserve(len(mmprojPath) + 1)
+	if err != nil {
+		return 0, err
+	}
+	writeString(ptr, mmprojPath)
+
+	handle, err := callErr("_yzma_mtmd_init_from_file", ptr, int(model), int(nThreads), boolToInt(useGPU))
+	if err != nil {
+		return 0, err
+	}
+	return MtmdContext(handle), nil
+}
+
+// MtmdFree frees a projector.
+func MtmdFree(mctx MtmdContext) error {
+	if !Loaded() || !MtmdSupported() {
+		return ErrNotLoaded
+	}
+	callVoid("_yzma_mtmd_free", int(mctx))
+	return nil
+}
+
+// MtmdSupportVision tells if the projector takes images.
+func MtmdSupportVision(mctx MtmdContext) bool {
+	if !Loaded() || !MtmdSupported() {
+		return false
+	}
+	return call("_yzma_mtmd_support_vision", int(mctx)) == 1
+}
+
+// MtmdSupportAudio tells if the projector takes audio. This package has no way
+// to give it any, so this is here to report what the model is.
+func MtmdSupportAudio(mctx MtmdContext) bool {
+	if !Loaded() || !MtmdSupported() {
+		return false
+	}
+	return call("_yzma_mtmd_support_audio", int(mctx)) == 1
+}
+
+// MtmdMarker gives the marker that stands for a piece of media in the text of a
+// prompt, such as "<__media__>".
+func MtmdMarker(mctx MtmdContext) string {
+	if !Loaded() || !MtmdSupported() {
+		return ""
+	}
+
+	const size = 64
+	ptr, err := pieceScratch.reserve(size)
+	if err != nil {
+		return ""
+	}
+
+	n := call("_yzma_mtmd_get_marker", int(mctx), ptr, size)
+	if n <= 0 {
+		return ""
+	}
+	return string(readBytes(ptr, int(n)))
+}
+
+// MtmdBitmapInit makes a bitmap from the pixels of an image.
+//
+// The pixels must be RGB, three bytes for each one, with no padding between the
+// rows, so the length of rgb must be width*height*3. A page gets them from a
+// canvas: read the RGBA of the image and drop every fourth byte.
+func MtmdBitmapInit(width, height int32, rgb []byte) (MtmdBitmap, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+	if !MtmdSupported() {
+		return 0, ErrNoMultimodal
+	}
+
+	want := int(width) * int(height) * 3
+	if width <= 0 || height <= 0 || len(rgb) != want {
+		return 0, errBitmapSize(width, height, len(rgb), want)
+	}
+
+	// The image does not go in the scratch memory: it is large, and it stays
+	// only until the module copies it.
+	ptr, err := malloc(len(rgb))
+	if err != nil {
+		return 0, err
+	}
+	defer free(ptr)
+
+	writeBytes(ptr, rgb)
+
+	handle, err := callErr("_yzma_mtmd_bitmap_init", int(width), int(height), ptr)
+	if err != nil {
+		return 0, err
+	}
+	return MtmdBitmap(handle), nil
+}
+
+// errBitmapSize says what a bitmap of this size needs.
+func errBitmapSize(width, height int32, got, want int) error {
+	return fmt.Errorf("llamawasm: an image of %d by %d needs %d bytes of RGB, got %d",
+		width, height, want, got)
+}
+
+// MtmdBitmapFree frees a bitmap.
+func MtmdBitmapFree(bitmap MtmdBitmap) {
+	if !Loaded() || !MtmdSupported() {
+		return
+	}
+	callVoid("_yzma_mtmd_bitmap_free", int(bitmap))
+}
+
+// MtmdInputChunksInit makes an empty list of chunks for MtmdTokenize to fill.
+func MtmdInputChunksInit() (MtmdInputChunks, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+	if !MtmdSupported() {
+		return 0, ErrNoMultimodal
+	}
+
+	handle, err := callErr("_yzma_mtmd_input_chunks_init")
+	if err != nil {
+		return 0, err
+	}
+	return MtmdInputChunks(handle), nil
+}
+
+// MtmdInputChunksFree frees a list of chunks.
+func MtmdInputChunksFree(chunks MtmdInputChunks) {
+	if !Loaded() || !MtmdSupported() {
+		return
+	}
+	callVoid("_yzma_mtmd_input_chunks_free", int(chunks))
+}
+
+// MtmdInputChunksSize gives the number of chunks in the list.
+func MtmdInputChunksSize(chunks MtmdInputChunks) int32 {
+	if !Loaded() || !MtmdSupported() {
+		return 0
+	}
+	n := call("_yzma_mtmd_input_chunks_size", int(chunks))
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// MtmdTokenize puts the text and the bitmaps into the list of chunks. The text
+// must hold one marker for each bitmap, and [MtmdMarker] gives the marker.
+func MtmdTokenize(mctx MtmdContext, chunks MtmdInputChunks, text string,
+	addSpecial bool, parseSpecial bool, bitmaps []MtmdBitmap) error {
+	if !Loaded() {
+		return ErrNotLoaded
+	}
+	if !MtmdSupported() {
+		return ErrNoMultimodal
+	}
+
+	textPtr, err := textScratch.reserve(len(text) + 1)
+	if err != nil {
+		return err
+	}
+	writeString(textPtr, text)
+
+	// The handles of the bitmaps go in their own memory, because the text is in
+	// the scratch already.
+	handlesPtr, err := tokenScratch.reserve(max(len(bitmaps), 1) * 4)
+	if err != nil {
+		return err
+	}
+	handles := make([]Token, len(bitmaps))
+	for i, bitmap := range bitmaps {
+		handles[i] = Token(bitmap)
+	}
+	writeTokens(handlesPtr, handles)
+
+	_, err = callErr("_yzma_mtmd_tokenize", int(mctx), int(chunks), textPtr, len(text),
+		boolToInt(addSpecial), boolToInt(parseSpecial), handlesPtr, len(bitmaps))
+	return err
+}
+
+// MtmdHelperEvalChunks runs every chunk through the model: the text as tokens,
+// and each image through the projector first. It gives the position after the
+// last chunk, which the generation loop carries on from.
+func MtmdHelperEvalChunks(mctx MtmdContext, ctx Context, chunks MtmdInputChunks,
+	nPast Pos, seqID SeqId, nBatch int32, logitsLast bool) (Pos, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+	if !MtmdSupported() {
+		return 0, ErrNoMultimodal
+	}
+
+	newNPast, err := callErr("_yzma_mtmd_helper_eval_chunks", int(mctx), int(ctx), int(chunks),
+		int(nPast), int(seqID), int(nBatch), boolToInt(logitsLast))
+	if err != nil {
+		return 0, err
+	}
+	return Pos(newNPast), nil
+}

--- a/pkg/llamawasm/mtmd.go
+++ b/pkg/llamawasm/mtmd.go
@@ -52,6 +52,8 @@ type MtmdContextParams struct {
 	// ImageMinTokens and ImageMaxTokens bound the number of tokens that one
 	// image becomes, for a model whose resolution changes with the image. 0
 	// takes the bounds of the model. Fewer tokens is less work and less detail.
+	//
+	// A module of ABI version 3 takes no notice of these.
 	ImageMinTokens int32
 	ImageMaxTokens int32
 }

--- a/pkg/llamawasm/types.go
+++ b/pkg/llamawasm/types.go
@@ -75,15 +75,15 @@ type ContextParams struct {
 // ContextDefaultParams gives the parameters that a context uses if the program
 // changes nothing.
 //
-// NThreads is 0, which leaves the number of threads to the module: the build
-// with more than one thread takes the number of cores of the machine, and the
-// build with one thread stays at one.
+// NThreads comes from [Threads], the number that the module can use. Leaving it
+// at 0 would give the four threads that llama.cpp asks for whatever the machine
+// has, which is slower on a machine with more.
 func ContextDefaultParams() ContextParams {
 	return ContextParams{
 		NCtx:        0,
 		NBatch:      0,
 		NUbatch:     0,
-		NThreads:    0,
+		NThreads:    Threads(),
 		PoolingType: PoolingTypeUnspecified,
 		Embeddings:  0,
 	}

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -87,6 +87,33 @@ happens where there is none: Node has no WebGPU, so the loader must take a build
 on the CPU and the program must still make text. Only a browser can run the
 WebGPU build itself.
 
+## Threads
+
+llama.cpp asks for **four** threads unless it is told otherwise, whatever the
+machine has, and that is a large amount of speed to leave on the table:
+
+| Tokens a second, in Chrome | Four threads | Every thread |
+| --- | --- | --- |
+| SmolLM-135M Q2_K | 55.9 | 63.3 |
+| Gemma 3 1B Q2_K | 8.7 | 18.5 |
+| SmolVLM-256M Q8_0, the answer | 56.3 | 96.9 |
+
+So `ContextDefaultParams` and `MtmdContextParamsDefault` pass
+`llamawasm.Threads()`, the number the JavaScript glue takes from the machine, and
+the glue sizes the pool of threads of the module to match. A pool that is too
+small is worse than a small number of threads: llama.cpp then waits for threads
+that cannot start, because the thread that would start them is busy computing.
+
+The WebGPU build gains from this as well, and it has no threads at all: asking
+for one thread instead of four takes away the waiting at barriers that four
+threads set up and only one thread ever reached. SmolLM-135M went from 47.6
+tokens a second to 63.3 that way.
+
+The threads have **no effect on the image**, which is the surprise here. The
+projector took 30.4 seconds on four threads and 33.3 on sixteen, and 38.3 against
+42.7 in a browser, so a large number of threads is slightly worse. What makes an
+image fast is the GPU, not the CPU.
+
 ## Speed
 
 Measured in Chrome on one machine, an RTX 4070 with an Intel integrated GPU,
@@ -95,27 +122,29 @@ with the greedy sampler:
 | Model | Backend | Tokens a second |
 | --- | --- | --- |
 | SmolLM-135M Q2_K | one thread | 10.8 |
-| SmolLM-135M Q2_K | more threads | 55.9 |
-| SmolLM-135M Q2_K | WebGPU | 47.6 |
-| Gemma 3 1B Q2_K | more threads | 8.7 |
-| Gemma 3 1B Q2_K | WebGPU | 32.3 |
+| SmolLM-135M Q2_K | more threads | 63.3 |
+| SmolLM-135M Q2_K | WebGPU | 63.3 |
+| Gemma 3 1B Q2_K | more threads | 18.5 |
+| Gemma 3 1B Q2_K | WebGPU | 38.7 |
 
-The GPU wins on the larger model and loses on the smaller one, where the work of
-each operation is too small to pay for the trip to the GPU. Try both: the page
-takes `?mode=cpu` and `?mode=webgpu`.
+The GPU wins on the larger model, and on the smaller one the two come out the
+same, because the work of each operation is too small to pay for the trip to the
+GPU. Try both: the page takes `?mode=cpu` and `?mode=webgpu`.
 
 An image is a different story. This is the same photo of 960 by 720 through the
 projector of SmolVLM-256M Q8_0, and then 32 tokens of answer:
 
 | Backend | Time for the image | Tokens a second |
 | --- | --- | --- |
-| more threads, in Chrome | 38.3 s | 56.3 |
-| WebGPU, in Chrome | 1.5 s | 61.7 |
+| more threads, in Chrome | 42.7 s | 96.9 |
+| WebGPU, in Chrome | 1.6 s | 64.4 |
 | one thread, in Node | 80 s | 17.4 |
 
 Putting an image through a projector is a wall of numbers all at once, which is
 what a GPU is for, so the GPU is twenty five times faster at it. On the CPU it is
-the image, and not the answer, that a reader waits for.
+the image, and not the answer, that a reader waits for. The threads make the
+answer faster and the image no faster at all, so a page that takes images wants
+WebGPU more than a page that takes only text does.
 
 The size of the image hardly matters: a model has a resolution of its own and
 resizes what it gets, so 224 by 224 and 448 by 448 both took about the same time

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -39,8 +39,10 @@ token, the same as the `examples/hello` program.
 | `yzma-loader.js` | Finds what the browser can run — WebGPU, more than one thread, or one thread — then loads that build of llama.cpp and puts it in `globalThis.yzmaReady`. |
 | `worker.js` | Runs llama.cpp and the Go program in a Web Worker, and sends each piece of text to the page. |
 | `index.html` | A page that loads a model and makes text. |
+| `vlm.html` | A page that asks a question about an image. |
 | `serve/main.go` | A static server that sets the headers that a build with more than one thread needs. |
 | `node/run.js` | Runs the same build in Node, with no browser. This is the test that CI uses. |
+| `node/vlm.js` | The same for a model with eyes. It makes its own pixels, because Node has no canvas. |
 
 ## Build and run
 
@@ -48,15 +50,19 @@ token, the same as the `examples/hello` program.
 # get the WebAssembly build of llama.cpp
 make download-llama.cpp-wasm
 
-# build the program with TinyGo
+# build the programs with TinyGo
 make wasm-example
+make wasm-vlm-example
 
-# serve it
+# serve them
 make serve-wasm
 ```
 
-Then open <http://localhost:8080>. Add `?mode=cpu` or `?mode=webgpu` to the URL
-of the page to choose the backend instead of letting the loader choose.
+Then <http://localhost:8080> is the chat page and
+<http://localhost:8080/vlm.html> is the page that takes an image.
+
+Add `?mode=cpu` or `?mode=webgpu` to the URL of either page to choose the backend
+instead of letting the loader choose.
 
 `make wasm-example-go` builds the same program with the standard Go toolchain.
 The binary is larger, which is useful if TinyGo cannot build a dependency.
@@ -98,9 +104,68 @@ The GPU wins on the larger model and loses on the smaller one, where the work of
 each operation is too small to pay for the trip to the GPU. Try both: the page
 takes `?mode=cpu` and `?mode=webgpu`.
 
+An image is a different story. This is the same photo of 960 by 720 through the
+projector of SmolVLM-256M Q8_0, and then 32 tokens of answer:
+
+| Backend | Time for the image | Tokens a second |
+| --- | --- | --- |
+| more threads, in Chrome | 38.3 s | 56.3 |
+| WebGPU, in Chrome | 1.5 s | 61.7 |
+| one thread, in Node | 80 s | 17.4 |
+
+Putting an image through a projector is a wall of numbers all at once, which is
+what a GPU is for, so the GPU is twenty five times faster at it. On the CPU it is
+the image, and not the answer, that a reader waits for.
+
+The size of the image hardly matters: a model has a resolution of its own and
+resizes what it gets, so 224 by 224 and 448 by 448 both took about the same time
+and both came to 148 tokens of image.
+
 The builds on the CPU give the same text every time. The GPU gives the same text
 for the first few tokens and then goes its own way, because the shaders do the
 arithmetic in a different order than the CPU does.
+
+## A model with eyes
+
+`vlm.html` and `examples/wasm/vlm` answer a question about an image. The
+multimodal library of llama.cpp, mtmd, is in every build, so nothing more needs
+installing.
+
+**The page decodes the image, not llama.cpp.** It draws the file on a canvas and
+sends the pixels to the program:
+
+```js
+const bitmap = await createImageBitmap(file);
+context.drawImage(bitmap, 0, 0, width, height);
+const { data } = context.getImageData(0, 0, width, height); // RGBA
+worker.postMessage({ kind: "describe", prompt, width, height, rgba: data.buffer }, [data.buffer]);
+```
+
+So any format the browser reads works, and no image library goes into the
+WebAssembly build. The Go side drops the alpha byte and hands the RGB to mtmd.
+
+The calls follow the mtmd package, with an Mtmd prefix because one package holds
+the llama calls as well:
+
+```go
+mctx, err := llamawasm.MtmdInitFromFile("/models/mmproj.gguf", model, 0, onGPU)
+bitmap, err := llamawasm.MtmdBitmapInit(width, height, rgb)
+chunks, err := llamawasm.MtmdInputChunksInit()
+llamawasm.MtmdTokenize(mctx, chunks, prompt, true, true, []llamawasm.MtmdBitmap{bitmap})
+nPast, err := llamawasm.MtmdHelperEvalChunks(mctx, ctx, chunks, 0, 0, nBatch, true)
+// then the same loop of SamplerSample and Decode as for text alone
+```
+
+The prompt must hold one marker for each image, and `MtmdMarker` gives the
+marker of the model. `ChatApplyTemplate` puts the marker and the question into
+the format the model expects.
+
+Two models come down for this: the model itself and its projector, the mmproj
+file.
+
+Images only. Audio and video stay out: audio needs the page to decode and
+resample the samples itself, and video needs ffmpeg in a subprocess, which a
+browser has not got.
 
 ## Why a worker
 
@@ -176,5 +241,6 @@ origin of the page.
 - An operation larger than `maxStorageBufferBindingSize` goes back to the CPU.
 - One JavaScript ArrayBuffer holds at most 2 GB, so a larger model must be in
   splits.
-- `pkg/llamawasm` has the calls that text generation and embeddings need. It
-  does not have multimodal input, LoRA adapters, saved state, or quantization.
+- `pkg/llamawasm` has the calls that text generation, embeddings, and images
+  need. It does not have audio, video, LoRA adapters, saved state, or
+  quantization.

--- a/wasm/node/run.js
+++ b/wasm/node/run.js
@@ -81,15 +81,21 @@ async function main() {
   globalThis.yzmaBase = dir;
 
   const factory = require(path.join(dir, moduleName));
+  // The same numbers the JavaScript glue would choose: a pool that follows the
+  // machine, and a thread count that the Go side reads.
+  const threads = mt ? Math.max(1, Math.min(require("node:os").cpus().length, 16)) : 1;
+
   const llamaModule = await factory({
     locateFile: (file) => path.join(dir, file),
     print: () => {},
     printErr: () => {},
+    pthreadPoolSize: threads,
   });
 
   globalThis.yzmaModule = llamaModule;
   globalThis.yzmaReady = Promise.resolve(llamaModule);
   globalThis.yzmaThreaded = mt;
+  globalThis.yzmaThreads = threads;
   globalThis.yzmaBackend = moduleName.includes("webgpu")
     ? "webgpu"
     : mt

--- a/wasm/node/vlm.js
+++ b/wasm/node/vlm.js
@@ -1,0 +1,194 @@
+// vlm.js answers a question about an image in Node, with no browser.
+//
+// Node has no canvas, so this makes the pixels itself: a plain shape on a plain
+// ground. That is enough to prove the whole path works, from the pixels through
+// the projector to the tokens. Whether the answer is a good description of the
+// shape is a question for a real image in a browser.
+//
+// Usage:
+//   node wasm/node/vlm.js --dir build/wasm --model <model.gguf> \
+//       --mmproj <mmproj.gguf> [--tokens 24] [--ppm <file.ppm>] [--side 448]
+//       [--mt] [--webgpu]
+//
+// --ppm takes a real image in the binary PPM format (P6), which needs no
+// decoder: convert one with "magick in.jpg out.ppm" or "ffmpeg -i in.jpg out.ppm".
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function option(name, fallback) {
+  const i = process.argv.indexOf("--" + name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : fallback;
+}
+
+const dir = path.resolve(option("dir", "build/wasm"));
+const modelFile = option("model", "");
+const mmprojFile = option("mmproj", "");
+const prompt = option("prompt", "Describe this image.");
+const maxTokens = parseInt(option("tokens", "24"), 10);
+const ppmFile = option("ppm", "");
+const webgpu = process.argv.includes("--webgpu");
+const mt = process.argv.includes("--mt");
+const side = parseInt(option("side", "448"), 10);
+
+if (!modelFile || !mmprojFile) {
+  console.error("give a model with --model and a projector with --mmproj");
+  process.exit(2);
+}
+
+// This harness stands in for yzma-loader.js. Node has no WebGPU, so asking for
+// it must fall back the same way the loader does.
+let moduleName = "yzma_wasm.js";
+if (mt) {
+  moduleName = "yzma_wasm_mt.js";
+}
+if (webgpu) {
+  if (globalThis.navigator && globalThis.navigator.gpu) {
+    moduleName = "yzma_wasm_webgpu.js";
+  } else {
+    console.log("[loader] no WebGPU here, using the build on the CPU");
+  }
+}
+
+// makeImage draws a dark square in the middle of a light ground and gives the
+// RGBA that a canvas would give.
+function makeImage(width, height) {
+  const rgba = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const inside =
+        x > width / 4 && x < (width * 3) / 4 && y > height / 4 && y < (height * 3) / 4;
+      const value = inside ? 32 : 224;
+      const i = (y * width + x) * 4;
+      rgba[i] = value;
+      rgba[i + 1] = value;
+      rgba[i + 2] = value;
+      rgba[i + 3] = 255;
+    }
+  }
+  return { width, height, rgba };
+}
+
+// readPPM reads a binary PPM (P6), which is a header of plain text and then RGB.
+function readPPM(file) {
+  const bytes = fs.readFileSync(file);
+
+  const fields = [];
+  let i = 0;
+  while (fields.length < 4) {
+    while (i < bytes.length && /\s/.test(String.fromCharCode(bytes[i]))) i++;
+    if (String.fromCharCode(bytes[i]) === "#") {
+      while (i < bytes.length && bytes[i] !== 0x0a) i++;
+      continue;
+    }
+    let start = i;
+    while (i < bytes.length && !/\s/.test(String.fromCharCode(bytes[i]))) i++;
+    fields.push(bytes.toString("ascii", start, i));
+  }
+  i++; // the single whitespace after the last field
+
+  const [magic, w, h, maxValue] = fields;
+  if (magic !== "P6" || maxValue !== "255") {
+    throw new Error("only a binary PPM with 255 levels works here, got " + magic + "/" + maxValue);
+  }
+
+  const width = parseInt(w, 10);
+  const height = parseInt(h, 10);
+  const rgb = bytes.subarray(i, i + width * height * 3);
+
+  // The program takes RGBA, the same as a canvas gives.
+  const rgba = new Uint8Array(width * height * 4);
+  for (let p = 0; p < width * height; p++) {
+    rgba[p * 4] = rgb[p * 3];
+    rgba[p * 4 + 1] = rgb[p * 3 + 1];
+    rgba[p * 4 + 2] = rgb[p * 3 + 2];
+    rgba[p * 4 + 3] = 255;
+  }
+  return { width, height, rgba };
+}
+
+const output = [];
+
+let programIsReady;
+const programReady = new Promise((resolve) => {
+  programIsReady = resolve;
+});
+
+globalThis.yzmaOnMessage = (message) => {
+  if (message.kind === "ready" || message.kind === "error") {
+    programIsReady();
+  }
+  if (message.kind === "token") {
+    output.push(message.text);
+    process.stdout.write(message.text);
+    return;
+  }
+  console.log("[" + message.kind + "] " + message.text);
+};
+
+async function main() {
+  globalThis.crossOriginIsolated = false;
+  globalThis.yzmaBase = dir;
+
+  const factory = require(path.join(dir, moduleName));
+  const llamaModule = await factory({
+    locateFile: (file) => path.join(dir, file),
+    print: () => {},
+    printErr: () => {},
+  });
+
+  globalThis.yzmaModule = llamaModule;
+  globalThis.yzmaReady = Promise.resolve(llamaModule);
+  globalThis.yzmaThreaded = mt;
+  globalThis.yzmaBackend = moduleName.includes("webgpu") ? "webgpu" : "cpu";
+
+  // A browser gets both files over the network. Here they go straight in.
+  llamaModule.FS.mkdirTree("/models");
+  llamaModule.FS.writeFile("/models/model.gguf", fs.readFileSync(modelFile));
+  llamaModule.FS.writeFile("/models/mmproj.gguf", fs.readFileSync(mmprojFile));
+
+  require(path.join(dir, "wasm_exec.js"));
+
+  const go = new Go();
+  const binary = fs.readFileSync(path.join(dir, "yzma-vlm.wasm"));
+  const result = await WebAssembly.instantiate(binary, go.importObject);
+
+  go.run(result.instance);
+  await programReady;
+
+  const image = ppmFile ? readPPM(ppmFile) : makeImage(side, side);
+  console.log("[image] " + image.width + " by " + image.height + (ppmFile ? " from " + ppmFile : " made here"));
+
+  const done = new Promise((resolve) => {
+    const previous = globalThis.yzmaOnMessage;
+    globalThis.yzmaOnMessage = (message) => {
+      previous(message);
+      if (message.kind === "loaded") {
+        globalThis.yzmaDescribe(prompt, image.width, image.height, image.rgba, maxTokens);
+      }
+      if (message.kind === "done" || message.kind === "error") {
+        resolve(message);
+      }
+    };
+  });
+
+  // The files are in place, so this only opens them. A browser gets them over
+  // the network with yzmaLoadModel instead.
+  globalThis.yzmaOpenModel();
+
+  const last = await done;
+  console.log();
+
+  if (last.kind === "error") {
+    process.exit(1);
+  }
+  if (output.join("").trim().length === 0) {
+    console.error("no tokens came out");
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/wasm/node/vlm.js
+++ b/wasm/node/vlm.js
@@ -8,7 +8,7 @@
 // Usage:
 //   node wasm/node/vlm.js --dir build/wasm --model <model.gguf> \
 //       --mmproj <mmproj.gguf> [--tokens 24] [--ppm <file.ppm>] [--side 448]
-//       [--mt] [--webgpu]
+//       [--mt] [--webgpu] [--threads N] [--image-max-tokens N]
 //
 // --ppm takes a real image in the binary PPM format (P6), which needs no
 // decoder: convert one with "magick in.jpg out.ppm" or "ffmpeg -i in.jpg out.ppm".
@@ -30,6 +30,8 @@ const ppmFile = option("ppm", "");
 const webgpu = process.argv.includes("--webgpu");
 const mt = process.argv.includes("--mt");
 const side = parseInt(option("side", "448"), 10);
+const threadsOverride = parseInt(option("threads", "0"), 10);
+const imageMaxTokens = parseInt(option("image-max-tokens", "0"), 10);
 
 if (!modelFile || !mmprojFile) {
   console.error("give a model with --model and a projector with --mmproj");
@@ -131,15 +133,24 @@ async function main() {
   globalThis.yzmaBase = dir;
 
   const factory = require(path.join(dir, moduleName));
+  // The same numbers the JavaScript glue would choose: a pool that follows the
+  // machine, and a thread count that the Go side reads.
+  const threads = threadsOverride > 0
+    ? threadsOverride
+    : mt ? Math.max(1, Math.min(require("node:os").cpus().length, 16)) : 1;
+  console.log("[threads] " + threads);
+
   const llamaModule = await factory({
     locateFile: (file) => path.join(dir, file),
     print: () => {},
     printErr: () => {},
+    pthreadPoolSize: threads,
   });
 
   globalThis.yzmaModule = llamaModule;
   globalThis.yzmaReady = Promise.resolve(llamaModule);
   globalThis.yzmaThreaded = mt;
+  globalThis.yzmaThreads = threads;
   globalThis.yzmaBackend = moduleName.includes("webgpu") ? "webgpu" : "cpu";
 
   // A browser gets both files over the network. Here they go straight in.
@@ -174,7 +185,7 @@ async function main() {
 
   // The files are in place, so this only opens them. A browser gets them over
   // the network with yzmaLoadModel instead.
-  globalThis.yzmaOpenModel();
+  globalThis.yzmaOpenModel(imageMaxTokens);
 
   const last = await done;
   console.log();

--- a/wasm/vlm.html
+++ b/wasm/vlm.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>yzma: a model with eyes in WebAssembly</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 0 auto;
+        max-width: 46rem;
+        padding: 1.5rem;
+        line-height: 1.5;
+      }
+      label { display: block; margin-top: 1rem; font-weight: 600; }
+      input, textarea, button { font: inherit; width: 100%; box-sizing: border-box; }
+      input, textarea { padding: 0.4rem; }
+      button { margin-top: 0.75rem; padding: 0.5rem; cursor: pointer; }
+      #status { margin-top: 1rem; color: #555; }
+      #preview { max-width: 100%; margin-top: 1rem; border-radius: 4px; display: none; }
+      #output {
+        margin-top: 1rem;
+        padding: 0.75rem;
+        min-height: 6rem;
+        white-space: pre-wrap;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>A model with eyes, in WebAssembly</h1>
+    <p>
+      llama.cpp and its multimodal library run as a WebAssembly module. The
+      program that drives them is Go, compiled by TinyGo, through the
+      <code>pkg/llamawasm</code> package of yzma. This page decodes the image and
+      sends the pixels to the program, which puts them in the prompt beside the
+      question.
+    </p>
+    <p id="backend">looking for a backend</p>
+
+    <label for="model">Model URL (GGUF)</label>
+    <input
+      id="model"
+      value="https://huggingface.co/ggml-org/SmolVLM-256M-Instruct-GGUF/resolve/main/SmolVLM-256M-Instruct-Q8_0.gguf"
+    />
+
+    <label for="mmproj">Projector URL (mmproj GGUF)</label>
+    <input
+      id="mmproj"
+      value="https://huggingface.co/ggml-org/SmolVLM-256M-Instruct-GGUF/resolve/main/mmproj-SmolVLM-256M-Instruct-Q8_0.gguf"
+    />
+    <button id="load">Load the model</button>
+
+    <label for="file">Image</label>
+    <input id="file" type="file" accept="image/*" />
+    <img id="preview" alt="the image that goes to the model" />
+
+    <label for="prompt">Question</label>
+    <textarea id="prompt" rows="2">Describe this image.</textarea>
+    <button id="ask" disabled>Ask</button>
+
+    <p>
+      On the CPU the image itself takes half a minute or more: the projector is
+      the slow part, not the answer. With WebGPU it takes a second or two.
+    </p>
+
+    <div id="status">starting</div>
+    <div id="output"></div>
+
+    <script>
+      const status = document.getElementById("status");
+      const output = document.getElementById("output");
+      const askButton = document.getElementById("ask");
+      const preview = document.getElementById("preview");
+
+      // The largest side of the image that goes to the model. A projector works
+      // on a small image of its own anyway, so sending more only costs memory.
+      const maxSide = 896;
+
+      let picture = null;
+
+      const mode = new URLSearchParams(location.search).get("mode");
+      const worker = new Worker(
+        "./worker.js?program=yzma-vlm.wasm" + (mode ? "&mode=" + encodeURIComponent(mode) : ""),
+      );
+
+      worker.onmessage = (event) => {
+        const { kind, text } = event.data || {};
+        switch (kind) {
+          case "ready":
+            document.getElementById("backend").textContent = text;
+            status.textContent = "ready";
+            break;
+          case "token":
+            output.textContent += text;
+            break;
+          case "loaded":
+            status.textContent = "model loaded: " + text;
+            askButton.disabled = !picture;
+            break;
+          case "error":
+            status.textContent = "error: " + text;
+            break;
+          default:
+            status.textContent = kind + ": " + text;
+        }
+      };
+
+      // Turn the file the reader picked into RGBA pixels.
+      document.getElementById("file").onchange = async (event) => {
+        const file = event.target.files[0];
+        if (!file) {
+          return;
+        }
+
+        const bitmap = await createImageBitmap(file);
+
+        const scale = Math.min(1, maxSide / Math.max(bitmap.width, bitmap.height));
+        const width = Math.max(1, Math.round(bitmap.width * scale));
+        const height = Math.max(1, Math.round(bitmap.height * scale));
+
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const context = canvas.getContext("2d", { willReadFrequently: true });
+        context.drawImage(bitmap, 0, 0, width, height);
+
+        picture = { width, height, rgba: context.getImageData(0, 0, width, height).data };
+
+        preview.src = canvas.toDataURL();
+        preview.style.display = "block";
+        status.textContent = "image ready, " + width + " by " + height;
+        askButton.disabled = !document.getElementById("model").dataset.loaded;
+      };
+
+      document.getElementById("load").onclick = () => {
+        status.textContent = "loading";
+        askButton.disabled = true;
+        worker.postMessage({
+          kind: "load",
+          url: document.getElementById("model").value,
+          projector: document.getElementById("mmproj").value,
+        });
+        document.getElementById("model").dataset.loaded = "yes";
+      };
+
+      askButton.onclick = () => {
+        if (!picture) {
+          status.textContent = "pick an image first";
+          return;
+        }
+        output.textContent = "";
+        status.textContent = "asking";
+
+        // The pixels go over as a copy of their buffer.
+        const rgba = picture.rgba.slice().buffer;
+        worker.postMessage(
+          {
+            kind: "describe",
+            prompt: document.getElementById("prompt").value,
+            width: picture.width,
+            height: picture.height,
+            rgba,
+            maxTokens: 128,
+          },
+          [rgba],
+        );
+      };
+    </script>
+  </body>
+</html>

--- a/wasm/worker.js
+++ b/wasm/worker.js
@@ -22,6 +22,10 @@ if (workerQuery.get("mode")) {
   self.yzmaMode = workerQuery.get("mode");
 }
 
+// Which Go program to run. The chat page takes the default, and the page for a
+// model with eyes asks for its own.
+const program = workerQuery.get("program") || "yzma.wasm";
+
 // A failure with nobody to catch it must reach the page. Without this the page
 // only sees that nothing more happens.
 self.onerror = (event) => {
@@ -57,7 +61,7 @@ const started = (async () => {
   await self.yzmaReady;
 
   const go = new Go();
-  const result = await WebAssembly.instantiateStreaming(fetch("./yzma.wasm"), go.importObject);
+  const result = await WebAssembly.instantiateStreaming(fetch("./" + program), go.importObject);
 
   // The Go program blocks at the end of main, so it keeps running and the page
   // can call into it. Do not wait for this promise.
@@ -78,10 +82,20 @@ self.onmessage = async (event) => {
 
     switch (message.kind) {
       case "load":
-        self.yzmaLoadModel(message.url);
+        self.yzmaLoadModel(message.url, message.projector || "");
         break;
       case "generate":
         self.yzmaGenerate(message.prompt, message.maxTokens || 128);
+        break;
+      case "describe":
+        // The image comes as RGBA from a canvas of the page.
+        self.yzmaDescribe(
+          message.prompt,
+          message.width,
+          message.height,
+          new Uint8Array(message.rgba),
+          message.maxTokens || 128,
+        );
         break;
       default:
         self.postMessage({ kind: "error", text: "unknown message: " + message.kind });

--- a/wasm/yzma-loader.js
+++ b/wasm/yzma-loader.js
@@ -7,6 +7,7 @@
 //   globalThis.yzmaReady     a promise whose value is the llama.cpp module
 //   globalThis.yzmaModule    the module, after the promise is done
 //   globalThis.yzmaThreaded  true if the build uses more than one thread
+//   globalThis.yzmaThreads   how many threads the build can use
 //   globalThis.yzmaBackend   "webgpu", "cpu-threads", or "cpu"
 //   globalThis.yzmaAdapter   the name of the GPU, if there is one
 //
@@ -104,9 +105,17 @@
       backend = "cpu-threads";
     }
 
+    // The number of threads follows the machine. llama.cpp asks for four
+    // threads unless a caller says otherwise, and putting an image through a
+    // projector on four threads of a machine with many is slow, so the Go side
+    // reads this and says otherwise.
+    const cores = Math.max(1, Math.min(globalThis.navigator?.hardwareConcurrency || 4, 16));
+    const threads = backend === "cpu-threads" ? cores : 1;
+
     globalThis.yzmaThreaded = backend === "cpu-threads";
     globalThis.yzmaBackend = backend;
     globalThis.yzmaAdapter = adapter;
+    globalThis.yzmaThreads = threads;
 
     await loadScript(base + "/" + name + ".js");
 
@@ -121,6 +130,11 @@
       locateFile: (path) => base + "/" + path,
       print: (text) => console.log(text),
       printErr: (text) => console.warn(text),
+
+      // The build with threads takes its pool size from here. A pool that is
+      // too small makes llama.cpp wait for threads that cannot start, because
+      // the thread that would start them is busy computing.
+      pthreadPoolSize: threads,
     });
 
     // From here on yzmaModule is the instance, which is what the Go code uses.


### PR DESCRIPTION
Images in the browser. A page decodes the picture, and `pkg/llamawasm` puts the pixels in the prompt beside the question through mtmd, the multimodal library of llama.cpp.

Needs hybridgroup/llama-cpp-builder#34, which puts mtmd in the WebAssembly builds. The `WebAssembly` CI job installs release assets, so it stays red until that lands and the builder publishes a release.

## Using it

```go
mctx, err := llamawasm.MtmdInitFromFile("/models/mmproj.gguf", model, 0, onGPU)
bitmap, err := llamawasm.MtmdBitmapInit(width, height, rgb)   // three bytes a pixel
chunks, err := llamawasm.MtmdInputChunksInit()
llamawasm.MtmdTokenize(mctx, chunks, prompt, true, true, []llamawasm.MtmdBitmap{bitmap})
nPast, err := llamawasm.MtmdHelperEvalChunks(mctx, ctx, chunks, 0, 0, nBatch, true)
// then the same loop of SamplerSample and Decode as for text alone
```

The names follow the mtmd package with an `Mtmd` prefix, since one package holds the llama calls too. `MtmdMarker` gives the marker that stands for the image in the prompt, and the new `ChatApplyTemplate` puts marker and question into the model's chat format.

**The page decodes the image, not llama.cpp.** A canvas gives RGBA, the Go side drops the alpha byte, and mtmd gets RGB — so any format the browser displays works, and no image library goes into the wasm build.

## Try it

```
make download-llama.cpp-wasm
make wasm-vlm-example
make serve-wasm
```

Then <http://localhost:8080/vlm.html>: pick a model with a projector, drop in a picture, ask.

## The number that matters

The projector, not the answer, is what a reader waits for. Same photo of 960 by 720, SmolVLM-256M Q8_0:

| Backend | Time for the image | Tokens a second |
| --- | --- | --- |
| more threads, in Chrome | 38.3 s | 56.3 |
| WebGPU, in Chrome | **1.5 s** | 61.7 |
| one thread, in Node | 80 s | 17.4 |

Twenty five times faster on the GPU, which is what WebGPU turned out to be really good for — a bigger difference than it makes to text generation. Both the page and `wasm/README.md` say so, so nobody is left wondering whether a page has hung.

Image size barely matters: SmolVLM resizes to its own resolution, so 224 by 224 and 448 by 448 both cost about the same and both come to 148 tokens of image. That is why the page caps the size for memory rather than for speed.

## Verified

- **Real photo, correctly described**, on WebGPU and on threaded CPU in headless Chrome: *"an alp or mountain goat ... standing in a grassy area"*.
- `make test-wasm-vlm` — the same path in Node with no browser. Node has no canvas, so the harness makes its own pixels; it also reads a real image in PPM format when given one, which is how the photo above was checked outside a browser.
- Text unaffected: `make test-wasm`, `make test-wasm-mt`, `make test-wasm-webgpu` all give the same output and speed as before.
- Both toolchains build both examples; `go build ./...`, `go vet ./...` and the `pkg/download` tests are untouched.
- An older module (ABI 1 or 2) still runs and reports no multimodal support rather than failing somewhere deeper in.

## Scope

Images only. Audio would need the page to decode and resample the samples, and video needs ffmpeg in a subprocess, which a browser has not got. `worker.js` now takes the name of the program to run, so the chat page and this one share it.