### PR TITLE
download: follow the llama.cpp ROCm asset rename at b10356

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,12 @@ test:
 	export YZMA_TEST_SPLIT_MODELS="$(MODELS_DIR)/stories15M-q8_0-00001-of-00003.gguf,$(MODELS_DIR)/stories15M-q8_0-00002-of-00003.gguf,$(MODELS_DIR)/stories15M-q8_0-00003-of-00003.gguf" && \
 	go test -count=1 ./...
 
+# make test-manifest to check the download resolver against a real llama.cpp release,
+# which catches upstream asset renames. It talks to the GitHub API, so it is not part
+# of `make test`. Set YZMA_TEST_LLAMA_TAG to check a build other than the newest one.
+test-manifest:
+	go test -count=1 -tags manifest -run TestDefaultResolverMatchesRelease ./pkg/download/
+
 # make wasm-example to build the browser example with TinyGo. Run
 # make download-llama.cpp-wasm first to get the WebAssembly build of llama.cpp.
 wasm-example: wasm-assets

--- a/pkg/download/manifest_test.go
+++ b/pkg/download/manifest_test.go
@@ -1,0 +1,127 @@
+//go:build manifest
+
+// This file holds the check that the built-in platform table still names assets that
+// llama.cpp publishes. It talks to the GitHub API, so it stays behind the "manifest"
+// build tag and out of the ordinary test run: run it with `make test-manifest`, or
+// with `go test -tags manifest -run TestDefaultResolverMatchesRelease ./pkg/download/`.
+//
+// Set YZMA_TEST_LLAMA_TAG to check a build other than the newest one.
+
+package download
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// llamaReleaseAssets lists the asset names published for a llama.cpp release tag.
+func llamaReleaseAssets(tag string) (map[string]bool, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://api.github.com/repos/ggml-org/llama.cpp/releases/tags/%s", tag), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("received status code %d for release %s: %s", resp.StatusCode, tag, body)
+	}
+
+	var result struct {
+		Assets []struct {
+			Name string `json:"name"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	names := make(map[string]bool, len(result.Assets))
+	for _, asset := range result.Assets {
+		names[asset.Name] = true
+	}
+	return names, nil
+}
+
+// TestDefaultResolverMatchesRelease catches upstream filename drift, which tests that
+// only assert hard-coded strings cannot see. It checks every target the built-in table
+// sends to the llama.cpp release page; the targets served by llama-cpp-builder are
+// built by this project and are not part of that release.
+func TestDefaultResolverMatchesRelease(t *testing.T) {
+	tag := os.Getenv("YZMA_TEST_LLAMA_TAG")
+	if tag == "" {
+		latest, err := LlamaLatestVersion()
+		if err != nil {
+			t.Fatalf("LlamaLatestVersion() failed: %v", err)
+		}
+		tag = latest
+	}
+	if IsTaggedRelease(tag) {
+		upstream, err := LlamaNightlyTag(tag)
+		if err != nil {
+			t.Fatalf("LlamaNightlyTag(%s) failed: %v", tag, err)
+		}
+		tag = upstream
+	}
+
+	assets, err := llamaReleaseAssets(tag)
+	if err != nil {
+		t.Fatalf("listing the assets of %s failed: %v", tag, err)
+	}
+	if len(assets) == 0 {
+		t.Fatalf("release %s publishes no assets", tag)
+	}
+
+	targets := []Target{
+		{Arch: AMD64, OS: Linux, Processor: CPU},
+		{Arch: AMD64, OS: Linux, Processor: Vulkan},
+		{Arch: AMD64, OS: Linux, Processor: ROCm},
+		{Arch: AMD64, OS: Trixie, Processor: CPU},
+		{Arch: AMD64, OS: Trixie, Processor: Vulkan},
+		{Arch: ARM64, OS: Darwin, Processor: Metal},
+		{Arch: ARM64, OS: Darwin, Processor: CPU},
+		{Arch: AMD64, OS: Darwin, Processor: CPU},
+		{Arch: AMD64, OS: Windows, Processor: CPU},
+		{Arch: ARM64, OS: Windows, Processor: CPU},
+		{Arch: AMD64, OS: Windows, Processor: CUDA},
+		{Arch: AMD64, OS: Windows, Processor: Vulkan},
+		{Arch: AMD64, OS: Windows, Processor: ROCm},
+	}
+
+	const releasePrefix = "https://github.com/ggml-org/llama.cpp/releases/download/"
+	for _, target := range targets {
+		target.Version = tag
+		name := fmt.Sprintf("%s/%s/%s", target.OS, target.Arch, target.Processor)
+		t.Run(name, func(t *testing.T) {
+			urls, err := DefaultResolver.Resolve(target)
+			if err != nil {
+				t.Fatalf("Resolve(%+v) failed: %v", target, err)
+			}
+			for _, url := range urls {
+				if !strings.HasPrefix(url, releasePrefix) {
+					continue
+				}
+				asset := url[strings.LastIndex(url, "/")+1:]
+				if !assets[asset] {
+					t.Errorf("release %s does not publish %q", tag, asset)
+				}
+			}
+		})
+	}
+}

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	getter "github.com/hashicorp/go-getter"
 )
@@ -41,6 +42,26 @@ func (f ResolverFunc) Resolve(target Target) ([]string, error) { return f(target
 // DefaultResolver resolves the assets published on the llama.cpp and llama-cpp-builder
 // release pages. [Install] uses it when no resolver is given.
 var DefaultResolver Resolver = ResolverFunc(defaultResolve)
+
+// rocmRenameBuild is the first llama.cpp nightly build that names its ROCm assets
+// after the ROCm version on both platforms. Builds before it publish
+// "ubuntu-rocm-7.2-x64.tar.gz" and "win-hip-radeon-x64.zip"; b10356 and newer
+// publish "ubuntu-rocm-7.14-x64.tar.gz" and "win-rocm-7.14-x64.zip".
+const rocmRenameBuild = 10356
+
+// legacyROCmNames tells whether tag is a nightly build old enough to carry the ROCm
+// asset names used before [rocmRenameBuild]. A tag that is not a nightly build, such
+// as a tagged release resolved without its upstream build, takes the current names.
+func legacyROCmNames(tag string) bool {
+	if !nightlyPattern.MatchString(tag) {
+		return false
+	}
+	build, err := strconv.Atoi(tag[1:])
+	if err != nil {
+		return false
+	}
+	return build < rocmRenameBuild
+}
 
 // defaultResolve is the built-in platform table.
 func defaultResolve(target Target) ([]string, error) {
@@ -88,7 +109,11 @@ func defaultResolve(target Target) ([]string, error) {
 			if arch != AMD64 {
 				return nil, errors.New("precompiled binaries for Linux ARM64 ROCm are not available")
 			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-rocm-7.2-x64.tar.gz", tag)
+			if legacyROCmNames(tag) {
+				filename = fmt.Sprintf("llama-%s-bin-ubuntu-rocm-7.2-x64.tar.gz", tag)
+				break
+			}
+			filename = fmt.Sprintf("llama-%s-bin-ubuntu-rocm-7.14-x64.tar.gz", tag)
 		default:
 			return nil, ErrUnknownProcessor
 		}
@@ -197,7 +222,11 @@ func defaultResolve(target Target) ([]string, error) {
 			if arch != AMD64 {
 				return nil, errors.New("precompiled binaries for Windows ARM64 ROCm are not available")
 			}
-			filename = fmt.Sprintf("llama-%s-bin-win-hip-radeon-x64.zip", tag)
+			if legacyROCmNames(tag) {
+				filename = fmt.Sprintf("llama-%s-bin-win-hip-radeon-x64.zip", tag)
+				break
+			}
+			filename = fmt.Sprintf("llama-%s-bin-win-rocm-7.14-x64.zip", tag)
 		default:
 			return nil, ErrUnknownProcessor
 		}

--- a/pkg/download/resolver_test.go
+++ b/pkg/download/resolver_test.go
@@ -334,3 +334,50 @@ func TestInstallDefaultVersionDoesNotFallBack(t *testing.T) {
 		t.Fatalf("Install() error = %v, want %v", err, ErrFileNotFound)
 	}
 }
+
+// llama.cpp renamed its ROCm assets at build b10356, so resolution has to follow the
+// naming that the requested build actually published.
+func TestDefaultResolverROCmNaming(t *testing.T) {
+	tests := []struct {
+		name    string
+		os      OS
+		version string
+		want    string
+	}{
+		{"linux before the rename", Linux, "b10355", "llama-b10355-bin-ubuntu-rocm-7.2-x64.tar.gz"},
+		{"linux at the rename", Linux, "b10356", "llama-b10356-bin-ubuntu-rocm-7.14-x64.tar.gz"},
+		{"linux after the rename", Linux, "b10705", "llama-b10705-bin-ubuntu-rocm-7.14-x64.tar.gz"},
+		{"windows before the rename", Windows, "b10355", "llama-b10355-bin-win-hip-radeon-x64.zip"},
+		{"windows at the rename", Windows, "b10356", "llama-b10356-bin-win-rocm-7.14-x64.zip"},
+		{"windows after the rename", Windows, "b10705", "llama-b10705-bin-win-rocm-7.14-x64.zip"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			urls, err := DefaultResolver.Resolve(Target{
+				Arch: AMD64, OS: tt.os, Processor: ROCm, Version: tt.version,
+			})
+			if err != nil {
+				t.Fatalf("Resolve() failed: %v", err)
+			}
+			want := "https://github.com/ggml-org/llama.cpp/releases/download/" + tt.version + "/" + tt.want
+			if len(urls) != 1 || urls[0] != want {
+				t.Fatalf("Resolve() = %v, want [%s]", urls, want)
+			}
+		})
+	}
+}
+
+// A tagged release carries its binaries under a nightly build tag, so that tag, not
+// the release name, decides the ROCm asset names.
+func TestDefaultResolverROCmTaggedRelease(t *testing.T) {
+	urls, err := DefaultResolver.Resolve(Target{
+		Arch: AMD64, OS: Linux, Processor: ROCm, Version: "v0.3.0", UpstreamVersion: "b10355",
+	})
+	if err != nil {
+		t.Fatalf("Resolve() failed: %v", err)
+	}
+	want := "https://github.com/ggml-org/llama.cpp/releases/download/b10355/llama-b10355-bin-ubuntu-rocm-7.2-x64.tar.gz"
+	if len(urls) != 1 || urls[0] != want {
+		t.Fatalf("Resolve() = %v, want [%s]", urls, want)
+	}
+}


### PR DESCRIPTION
Fixes #309.

## The drift

llama.cpp renamed its ROCm release assets at nightly build **b10356** (published 2026-08-11). Bisecting the release API pins the boundary exactly:

| | b10355 and older | b10356 and newer |
|---|---|---|
| Linux amd64 | `llama-<tag>-bin-ubuntu-rocm-7.2-x64.tar.gz` | `llama-<tag>-bin-ubuntu-rocm-7.14-x64.tar.gz` |
| Windows amd64 | `llama-<tag>-bin-win-hip-radeon-x64.zip` | `llama-<tag>-bin-win-rocm-7.14-x64.zip` |

The rest of the built-in table was checked against the full `b10705` asset list: CPU, Vulkan, macOS and Windows CUDA (`cuda-13.3` plus the matching `cudart`) all still match. ROCm was the only drift.

## Changes

`pkg/download/resolver.go` picks the ROCm names from the nightly build number instead of replacing the literals, so explicit installs of older tags keep resolving. The tag it reads is the upstream nightly one, so a tagged release resolves off the build that actually holds its binaries.

`pkg/download/manifest_test.go` is new and behind the `manifest` build tag. It pulls the real asset list from a llama.cpp release and asserts that every llama.cpp-hosted URL the resolver generates exists there, across 13 targets. Tests that only assert hard-coded strings cannot see upstream drift. It talks to the GitHub API, so it stays out of `go test ./...`; `make test-manifest` runs it, `GITHUB_TOKEN` and `YZMA_TEST_LLAMA_TAG` are honored.

`pkg/download/resolver_test.go` gains a table test over b10355 / b10356 / b10705 on both platforms, plus a tagged-release case asserting that `UpstreamVersion` drives the naming.

## Verification

- `make test-manifest` passes against the newest build, `b10705`, and `b10355` (legacy names).
- `go test ./pkg/download/` passes; the existing `b7974` ROCm assertions in `download_test.go` still hold through the legacy path.
