### PR TITLE
wasm: start the threads of llama.cpp correctly

### DIFF
--- a/examples/wasm/chat/main.go
+++ b/examples/wasm/chat/main.go
@@ -2,19 +2,19 @@
 
 // Chat runs llama.cpp inference in a browser.
 //
-// The program is the same shape as examples/hello, but it uses the llamawasm
-// package instead of the llama package, and it sends each piece of text to the
-// page instead of printing it.
+// The program has the same structure as examples/hello. It uses the llamawasm
+// package in place of the llama package, and it sends each piece of text to the
+// page in place of a print.
 //
-// Build it with TinyGo:
+// Build it with TinyGo.
 //
 //	tinygo build -target wasm -o build/wasm/yzma.wasm ./examples/wasm/chat
 //
-// or with the standard toolchain:
+// Or build it with the standard toolchain.
 //
 //	GOOS=js GOARCH=wasm go build -o build/wasm/yzma.wasm ./examples/wasm/chat
 //
-// See wasm/README.md for how to serve the result.
+// See wasm/README.md for the method to serve the result.
 package main
 
 import (
@@ -82,7 +82,7 @@ func loadModel(this js.Value, args []js.Value) any {
 }
 
 // openModel(path) loads a model that is already in the filesystem of the
-// llama.cpp module. A test that has the file puts it there itself.
+// llama.cpp module. A test puts the file there itself.
 func openModel(this js.Value, args []js.Value) any {
 	path := modelPath
 	if len(args) > 0 && args[0].Truthy() {
@@ -100,8 +100,8 @@ func open(path string) {
 
 	params := llamawasm.ModelDefaultParams()
 
-	// A build with WebGPU has a device, so put every layer on it. A build on the
-	// CPU has none, and the value does nothing there.
+	// A WebGPU build has a device, thus put each layer on it. A CPU build has no
+	// device and ignores this value.
 	if llamawasm.GPUDevice() != "" {
 		params.NGpuLayers = 999
 	}
@@ -126,7 +126,7 @@ func open(path string) {
 	post("loaded", llamawasm.ModelDesc(model)+", "+backendReport())
 }
 
-// backendReport says what does the computation.
+// backendReport gives the name of the backend that computes.
 func backendReport() string {
 	if device := llamawasm.GPUDevice(); device != "" {
 		return fmt.Sprintf("backend: %s (%s)", llamawasm.Backend(), device)
@@ -207,8 +207,8 @@ func generate(this js.Value, args []js.Value) any {
 	return nil
 }
 
-// post sends a message to whatever holds this module. In a worker that is the
-// page, and in Node it is the console.
+// post sends a message to the container of this module. In a worker that is
+// the page, and in Node it is the console.
 func post(kind, text string) {
 	message := map[string]any{"kind": kind, "text": text}
 

--- a/examples/wasm/vlm/main.go
+++ b/examples/wasm/vlm/main.go
@@ -2,16 +2,16 @@
 
 // Vlm answers a question about an image in a browser.
 //
-// It is the same shape as examples/wasm/chat, with the multimodal calls of
-// pkg/llamawasm added: the page decodes the image and sends the pixels, and this
-// program turns them into a bitmap, puts them in the prompt beside the text, and
-// then runs the same loop of sampling and decoding.
+// It has the same structure as examples/wasm/chat and adds the multimodal calls
+// of pkg/llamawasm. The page decodes the image and sends the pixels. This
+// program makes a bitmap, puts it in the prompt with the text, and then runs the
+// same loop of sampling and decoding.
 //
-// Build it with TinyGo:
+// Build it with TinyGo.
 //
 //	tinygo build -target wasm -o build/wasm/yzma-vlm.wasm ./examples/wasm/vlm
 //
-// See wasm/README.md for how to serve the result.
+// See wasm/README.md for the method to serve the result.
 package main
 
 import (
@@ -35,8 +35,8 @@ var (
 	sampler llamawasm.Sampler
 	nBatch  int32 = 2048
 
-	// maxImageTokens bounds the tokens that one image becomes, for a model whose
-	// resolution changes with the image. 0 takes the bounds of the model.
+	// maxImageTokens limits the tokens of one image, for a model with a variable
+	// resolution. A value of 0 uses the limits of the model.
 	maxImageTokens int32
 )
 
@@ -98,9 +98,9 @@ func loadModel(this js.Value, args []js.Value) any {
 }
 
 // openModel(maxImageTokens) loads the files that are already in the filesystem
-// of the module. A test that has them puts them there itself.
+// of the module. A test puts them there itself.
 //
-// maxImageTokens is optional, and 0 takes the bounds of the model.
+// maxImageTokens is optional. A value of 0 uses the limits of the model.
 func openModel(this js.Value, args []js.Value) any {
 	if len(args) > 0 && args[0].Truthy() {
 		maxImageTokens = int32(args[0].Int())
@@ -125,8 +125,8 @@ func open() {
 		return
 	}
 
-	// A model with eyes needs room for the tokens of the image as well as the
-	// text, so the context is larger than the one the chat example uses.
+	// An image model needs space for the tokens of the image and of the text,
+	// thus the context is larger than in the chat example.
 	ctxParams := llamawasm.ContextDefaultParams()
 	ctxParams.NCtx = 4096
 	ctxParams.NBatch = uint32(nBatch)
@@ -140,9 +140,8 @@ func open() {
 
 	post("status", "loading the projector")
 
-	// The default takes every thread the module has, which matters: the
-	// projector is the slow part, and llama.cpp asks for only four threads
-	// unless it is told otherwise.
+	// The default uses each thread of the module. The projector is slow and
+	// llama.cpp asks for only four threads unless a caller changes it.
 	projectorParams := llamawasm.MtmdContextParamsDefault()
 	projectorParams.ImageMaxTokens = maxImageTokens
 
@@ -160,7 +159,7 @@ func open() {
 }
 
 // describe(prompt, width, height, rgba, maxTokens) answers a question about an
-// image. The pixels come from a canvas of the page, so they are RGBA.
+// image. The pixels come from a canvas of the page, thus they are RGBA.
 func describe(this js.Value, args []js.Value) any {
 	if len(args) < 4 {
 		post("error", "describe needs a prompt, a size, and the pixels")
@@ -219,9 +218,8 @@ func run(prompt string, width, height int32, rgba []byte, maxTokens int32) {
 		return
 	}
 
-	// This is where the image goes through the projector and into the model. It
-	// is the slow part, so it is timed on its own: putting it into the rate of
-	// the tokens would say nothing about either.
+	// Here the image goes through the projector and into the model. This step is
+	// slow, thus it has its own time and stays out of the token rate.
 	encodeStart := time.Now()
 
 	nPast, err := llamawasm.MtmdHelperEvalChunks(mctx, ctx, chunks, 0, 0, nBatch, true)
@@ -256,7 +254,7 @@ func run(prompt string, width, height int32, rgba []byte, maxTokens int32) {
 		}
 		count++
 
-		// The positions carry on from the chunks, which the module knows.
+		// The positions continue from the chunks, which the module knows.
 		if _, err := llamawasm.Decode(ctx, llamawasm.BatchGetOne([]llamawasm.Token{token})); err != nil {
 			post("error", err.Error())
 			return
@@ -272,8 +270,8 @@ func run(prompt string, width, height int32, rgba []byte, maxTokens int32) {
 	post("done", fmt.Sprintf("%d tokens, and %.1fs for the image", count, encode))
 }
 
-// buildPrompt puts the marker of the model and the question into the chat format
-// of the model. The marker is where the image goes.
+// buildPrompt puts the marker of the model and the question into the chat
+// format. The image goes at the marker.
 func buildPrompt(question string) string {
 	marker := llamawasm.MtmdMarker(mctx)
 	if marker == "" {
@@ -282,14 +280,14 @@ func buildPrompt(question string) string {
 
 	text := marker + "\n" + question
 
-	// A model with no chat template takes the text as it is.
+	// A model with no chat template uses the text without a change.
 	if formatted, err := llamawasm.ChatApplyTemplate(model, "user", text, true); err == nil && formatted != "" {
 		return formatted
 	}
 	return text
 }
 
-// dropAlpha turns the RGBA of a canvas into the RGB that a bitmap needs.
+// dropAlpha changes the RGBA of a canvas into the RGB that a bitmap needs.
 func dropAlpha(rgba []byte) []byte {
 	rgb := make([]byte, 0, len(rgba)/4*3)
 	for i := 0; i+3 < len(rgba); i += 4 {
@@ -305,7 +303,7 @@ func backendReport() string {
 	return fmt.Sprintf("backend: %s, %d threads", llamawasm.Backend(), llamawasm.Threads())
 }
 
-// post sends a message to whatever holds this module.
+// post sends a message to the container of this module.
 func post(kind, text string) {
 	message := map[string]any{"kind": kind, "text": text}
 

--- a/pkg/llamawasm/doc.go
+++ b/pkg/llamawasm/doc.go
@@ -3,14 +3,13 @@
 // Package llamawasm runs llama.cpp inference in a browser.
 //
 // The [llama] package loads the llama.cpp shared libraries with libffi. A
-// WebAssembly module cannot do this: it has no dlopen and no libffi, and TinyGo
-// cannot compile the C++ of llama.cpp. This package therefore uses a different
-// way to reach the same library. llama.cpp is a second WebAssembly module, made
-// by Emscripten, and this package calls it through JavaScript.
+// WebAssembly module cannot do this. It has no dlopen and no libffi, and TinyGo
+// cannot compile the C++ of llama.cpp. Thus llama.cpp is a second WebAssembly
+// module, made by Emscripten, and this package calls it through JavaScript.
 //
-// The names and the order of the calls are the same as in the [llama] package
-// for the part of the API that this package has, so a program moves from one to
-// the other with a change of the import:
+// The names and the order of the calls agree with the [llama] package for the
+// part of the API that this package has. Thus a program moves from one package
+// to the other with a change of the import.
 //
 //	llamawasm.Load("")
 //	llamawasm.LogSet(llamawasm.LogSilent())
@@ -29,60 +28,59 @@
 // # What the page must do first
 //
 // The JavaScript glue in the wasm directory of yzma must run before [Load]. It
-// finds out if the page can use more than one thread, takes the correct
+// finds out if the page can use more than one thread, selects the correct
 // llama.cpp module, and puts the result in globalThis.yzmaReady. [Load] waits
 // for that promise.
 //
 // # Run it in a worker
 //
-// Every call into llama.cpp is synchronous, and one token takes milliseconds.
-// A call from the main thread of a page stops the page. Put this code and the
-// llama.cpp module in a Web Worker, and send the result to the page with
-// postMessage. One [Decode] does one batch, so the worker can send each token
-// as it comes.
+// Each call into llama.cpp is synchronous and one token takes milliseconds.
+// A call from the main thread stops the page. Put this code and the llama.cpp
+// module in a Web Worker, and send the result to the page with postMessage. One
+// [Decode] does one batch, thus the worker can send each token immediately.
 //
 // # One call at a time
 //
 // The package keeps scratch memory in the llama.cpp module for the calls that
-// pass tokens and text, so only one goroutine may call into it at a time. This
-// is not a limit in practice: llama.cpp itself takes one call at a time, and
-// the generation loop is one goroutine.
+// pass tokens and text. Thus only one goroutine can call into it at a time.
+// This is not a limit in practice, because llama.cpp accepts one call at a time
+// and the generation loop is one goroutine.
 //
 // # WebGPU
 //
-// There are three builds of llama.cpp, and the JavaScript glue takes the best
-// one that the browser can run: WebGPU, the CPU with more than one thread, or
-// the CPU with one thread. [Backend] says which one it took, and [GPUDevice]
-// names the GPU that llama.cpp found.
+// There are three builds of llama.cpp. The JavaScript glue selects the best one
+// that the browser can run, which is WebGPU, the CPU with more than one thread,
+// or the CPU with one thread. [Backend] gives the selection and [GPUDevice]
+// gives the name of the GPU that llama.cpp found.
 //
 // A page can have WebGPU while llama.cpp has no device, because the backend
-// needs an adapter with f16 shaders. Ask [GPUDevice], which reports what
-// llama.cpp really has.
+// needs an adapter with f16 shaders. Use [GPUDevice], which gives the true
+// condition of llama.cpp.
 //
-// Set NGpuLayers in [ModelParams] to put layers on the GPU. It does nothing in
-// a build for the CPU.
+// Set NGpuLayers in [ModelParams] to put layers on the GPU. A CPU build ignores
+// this value.
 //
-// # A model with eyes
+// # Images
 //
-// The multimodal library of llama.cpp, mtmd, is in every build. [MtmdBitmapInit]
-// takes the pixels of an image, [MtmdTokenize] puts them into a prompt beside
-// the text, and [MtmdHelperEvalChunks] runs both through the model. See mtmd.go
-// for the order of the calls.
+// The multimodal library of llama.cpp, mtmd, is in each build. [MtmdBitmapInit]
+// takes the pixels of an image, [MtmdTokenize] puts them into a prompt with the
+// text, and [MtmdHelperEvalChunks] runs both through the model. See mtmd.go for
+// the order of the calls.
 //
-// The pixels must be RGB. A page decodes the image itself, with a canvas, so any
-// format the browser reads works and no image library goes into the build.
+// The pixels must be RGB. A page decodes the image with a canvas, thus each
+// format that the browser reads is usable and the build needs no image library.
 //
 // Images only. Audio needs the page to decode and resample the samples, and
 // video needs ffmpeg in a subprocess.
 //
 // # Limits
 //
-// A build for the CPU uses SIMD. WebGPU needs Chrome or Edge 137 and later,
-// because the backend waits for the GPU inside a synchronous call and that
-// needs JavaScript Promise Integration.
+// A CPU build uses SIMD. WebGPU needs Chrome or Edge 137 or later, because the
+// backend waits for the GPU in a synchronous call and that needs JavaScript
+// Promise Integration.
 //
-// A WebAssembly module can address 4 GB, and one JavaScript ArrayBuffer holds
-// at most 2 GB, so a model of more than 2 GB must be in splits.
+// A WebAssembly module can address 4 GB and one JavaScript ArrayBuffer holds a
+// maximum of 2 GB. Thus a model of more than 2 GB must be in splits.
 //
 // The package has the calls that text generation, embeddings, and images need.
 // It does not have audio, video, LoRA adapters, saved state, or quantization.

--- a/pkg/llamawasm/fs.go
+++ b/pkg/llamawasm/fs.go
@@ -10,9 +10,9 @@ import (
 	"syscall/js"
 )
 
-// The llama.cpp module has its own filesystem in memory, and llama.cpp opens
-// the model as an ordinary file in it. A program must therefore put the file
-// there before ModelLoadFromFile.
+// The llama.cpp module has its own filesystem in memory and opens the model as
+// a usual file in it. Thus a program must put the file there before
+// ModelLoadFromFile.
 
 // WriteModelFile writes data to name in the filesystem of the llama.cpp
 // module. It makes the directories of the path that are not there.
@@ -32,8 +32,8 @@ func WriteModelFile(name string, data []byte) error {
 	return err
 }
 
-// RemoveModelFile removes name from the filesystem of the llama.cpp module,
-// which gives the memory of the file back.
+// RemoveModelFile removes name from the filesystem of the llama.cpp module and
+// releases the memory of the file.
 func RemoveModelFile(name string) error {
 	fs, err := filesystem()
 	if err != nil {
@@ -57,8 +57,8 @@ func filesystem() (js.Value, error) {
 }
 
 // makeDir makes the directories of the path of name. The filesystem of the
-// module starts with almost nothing in it, so a path such as
-// /models/model.gguf needs its directory first.
+// module is almost empty at the start, thus a path such as /models/model.gguf
+// needs its directory first.
 func makeDir(fs js.Value, name string) error {
 	dir := path.Dir(name)
 	if dir == "." || dir == "/" || dir == "" {
@@ -74,9 +74,9 @@ func makeDir(fs js.Value, name string) error {
 	return nil
 }
 
-// fsCall calls a function of the filesystem of the module and turns a
-// JavaScript exception into an error. A call that fails throws, and a throw in
-// a call from Go is a panic, which would stop the program.
+// fsCall calls a function of the filesystem of the module and changes a
+// JavaScript exception into an error. A failed call throws, and a throw in a
+// call from Go is a panic that stops the program.
 func fsCall(fs js.Value, name string, args ...any) (result js.Value, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -91,14 +91,15 @@ func fsCall(fs js.Value, name string, args ...any) (result js.Value, err error) 
 // filesystem of the llama.cpp module. It makes the directories of the path that
 // are not there.
 //
-// The body of the response goes into the file piece by piece, so the memory
-// that this needs stays near the size of the model and not twice that size.
-// The progress function, if it is not nil, is called with the number of bytes
-// so far and the total number of bytes. The total is 0 if the server does not
-// give a length.
+// The body of the response goes into the file in small parts. Thus the memory
+// stays near the size of the model and not two times that size.
 //
-// One JavaScript ArrayBuffer holds at most 2 GB, so a larger model must be in
-// splits.
+// If the progress function is not nil, it receives the number of bytes to this
+// point and the total number of bytes. The total is 0 if the server gives no
+// length.
+//
+// One JavaScript ArrayBuffer holds a maximum of 2 GB, thus a larger model must
+// be in splits.
 func FetchModelFile(name, url string, progress func(done, total int64)) error {
 	fs, err := filesystem()
 	if err != nil {
@@ -147,8 +148,8 @@ func FetchModelFile(name, url string, progress func(done, total int64)) error {
 		value := chunk.Get("value")
 		n := value.Get("length").Int()
 
-		// FS.write takes the position in the file, so the whole model never
-		// needs to be in memory at one time.
+		// FS.write takes the position in the file, thus the full model is never
+		// in memory at one time.
 		if _, err := fsCall(fs, "write", stream, value, 0, n, done); err != nil {
 			return err
 		}
@@ -162,9 +163,9 @@ func FetchModelFile(name, url string, progress func(done, total int64)) error {
 	return nil
 }
 
-// ReleaseScratch gives the scratch memory of this package back to the
-// llama.cpp module. The next call takes it again, so this is only useful after
-// the last inference.
+// ReleaseScratch returns the scratch memory of this package to the llama.cpp
+// module. The next call takes it again, thus use this only after the last
+// inference.
 func ReleaseScratch() {
 	if !Loaded() {
 		return

--- a/pkg/llamawasm/logs.go
+++ b/pkg/llamawasm/logs.go
@@ -2,10 +2,10 @@
 
 package llamawasm
 
-// The llama.cpp module cannot take a Go function as its log callback, so the
-// shim holds the callback and this package only sets how much it prints. The
-// values below stand in for the function pointer that llama.LogSet takes, so
-// that the same program builds for both.
+// The llama.cpp module cannot use a Go function as its log callback. Thus the
+// shim holds the callback and this package only sets the quantity of output.
+// The values below replace the function pointer of llama.LogSet, thus the same
+// program builds for both.
 const (
 	// LogNormal lets llama.cpp print its messages to the console.
 	LogNormal uintptr = 0

--- a/pkg/llamawasm/model.go
+++ b/pkg/llamawasm/model.go
@@ -75,8 +75,8 @@ func ModelChatTemplate(model Model, name string) string {
 	return modelString("_yzma_model_chat_template", model, 8192)
 }
 
-// modelString reads a string that the shim writes into a buffer, and takes a
-// larger buffer if the first one is too small.
+// modelString reads a string that the shim writes into a buffer. It uses a
+// larger buffer if the first buffer is too small.
 func modelString(name string, model Model, size int) string {
 	if !Loaded() {
 		return ""
@@ -101,18 +101,18 @@ func modelString(name string, model Model, size int) string {
 	}
 }
 
-// String gives the handle of the model as text, which helps while debugging.
+// String gives the handle of the model as text, which is an aid to debugging.
 func (m Model) String() string {
 	return fmt.Sprintf("model(%d)", int32(m))
 }
 
 // ChatApplyTemplate puts one message into the chat format of the model.
 //
-// One message is enough for a prompt with a question about an image. A chat with
-// turns needs the template of the model, which [ModelChatTemplate] gives.
+// One message is sufficient for a prompt with a question about an image. For a
+// chat with turns, use the template that [ModelChatTemplate] gives.
 //
-// addAssistant adds the opening of the turn of the assistant, which is what
-// makes the model answer instead of carrying on the message.
+// addAssistant adds the start of the turn of the assistant. This makes the model
+// answer and not continue the message.
 func ChatApplyTemplate(model Model, role, content string, addAssistant bool) (string, error) {
 	if !Loaded() {
 		return "", ErrNotLoaded

--- a/pkg/llamawasm/module.go
+++ b/pkg/llamawasm/module.go
@@ -13,17 +13,17 @@ import (
 // The version of the interface of the shim, which is YZMA_ABI_VERSION in
 // wasm/yzma_wasm.cpp of the llama-cpp-builder repo.
 //
-// This package drives a module of any version from abiVersionMin to
-// abiVersion, so a new yzma still works with the modules of an older release.
-// A call that came with a later version is there only if the module has it, so
-// each one is tested for before it is used.
+// This package drives a module of each version from abiVersionMin to
+// abiVersion. Thus a new yzma operates with the modules of an older release.
+// A call from a later version is present only in a module that has it, thus
+// this package makes a test before each use.
 const (
 	abiVersionMin = 1 // 1 has the calls for text generation and embeddings
 	abiVersion    = 4 // 2 adds yzma_gpu_device, 3 the multimodal calls, 4 the
 	//                   bounds of the tokens of an image
 )
 
-// Error codes that the shim returns. These are the same as the values in
+// Error codes that the shim returns. These agree with the values in
 // wasm/yzma_wasm.cpp.
 const (
 	errGeneric  = -1
@@ -40,7 +40,7 @@ var (
 	// ErrNoModule says that the JavaScript glue did not run before Load.
 	ErrNoModule = errors.New("llamawasm: globalThis.yzmaReady is missing, load yzma-loader.js first")
 
-	// ErrNoMultimodal says that the module came from a release before the
+	// ErrNoMultimodal says that the module is from a release before the
 	// multimodal calls, which are in ABI version 3 and later.
 	ErrNoMultimodal = errors.New("llamawasm: this llama.cpp module has no multimodal calls, install a newer build")
 )
@@ -48,21 +48,20 @@ var (
 // mod is the Emscripten module instance of llama.cpp.
 var mod js.Value
 
-// threaded tells if the module that the page took uses more than one thread.
+// threaded tells if the module of the page uses more than one thread.
 var threaded bool
 
 // moduleABI is the version of the interface of the module that is loaded.
 var moduleABI int
 
 // gpuDevice is the name of the device of llama.cpp that is not the CPU, or an
-// empty string if there is none. Init fills it in.
+// empty string if there is none. Init sets it.
 var gpuDevice string
 
 // Load waits for the llama.cpp WebAssembly module and attaches to it.
 //
-// The path argument is not used. It is here to keep the same shape as
-// llama.Load, so that the same code can build for a native platform and for a
-// browser.
+// The path argument is not used. It keeps the same form as llama.Load, thus the
+// same code builds for a native platform and for a browser.
 //
 // The JavaScript glue must run first. It puts a promise in
 // globalThis.yzmaReady, and the value of that promise is the module.
@@ -71,7 +70,7 @@ func Load(path string) error {
 
 	ready := global.Get("yzmaReady")
 	if ready.IsUndefined() || ready.IsNull() {
-		// The glue may have put the instance in place without a promise.
+		// The glue can put the instance in place without a promise.
 		if m := global.Get("yzmaModule"); !m.IsUndefined() && !m.IsNull() {
 			return attach(m)
 		}
@@ -117,8 +116,7 @@ func Load(path string) error {
 	return attach(r.value)
 }
 
-// attach keeps the module and makes sure that it has the interface that this
-// package needs.
+// attach keeps the module and makes sure that it has the necessary interface.
 func attach(m js.Value) error {
 	if m.IsUndefined() || m.IsNull() {
 		return ErrNoModule
@@ -143,8 +141,8 @@ func attach(m js.Value) error {
 	return nil
 }
 
-// has tells if the module has a call. A module of an earlier version does not
-// have the calls that came later.
+// has tells if the module has a call. An earlier module does not have the calls
+// of a later version.
 func has(name string) bool {
 	return Loaded() && mod.Get(name).Type() == js.TypeFunction
 }
@@ -154,20 +152,19 @@ func Loaded() bool {
 	return !mod.IsUndefined() && !mod.IsNull()
 }
 
-// Threaded tells if the module that the page took uses more than one thread. A
-// browser gives more than one thread only to a page that sets the
-// Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers.
+// Threaded tells if the module of the page uses more than one thread. A browser
+// gives more than one thread only to a page with the Cross-Origin-Opener-Policy
+// and Cross-Origin-Embedder-Policy headers.
 func Threaded() bool {
 	return threaded
 }
 
 // Threads gives the number of threads that the module can use, which the
-// JavaScript glue takes from the machine. It is 1 for a build that uses one
-// thread, and for the WebGPU build, where the GPU does the work.
+// JavaScript glue reads from the machine. The value is 1 for a build with one
+// thread and for the WebGPU build, where the GPU does the work.
 //
-// llama.cpp asks for four threads unless it is told otherwise, whatever the
-// machine has, so [ContextDefaultParams] and [MtmdContextParamsDefault] pass
-// this instead.
+// llama.cpp asks for four threads unless a caller changes it. Thus
+// [ContextDefaultParams] and [MtmdContextParamsDefault] send this value.
 func Threads() int32 {
 	if !Loaded() {
 		return 0
@@ -187,8 +184,8 @@ func Init() {
 	}
 	callVoid("_yzma_backend_init")
 
-	// The devices of llama.cpp exist only after the backend starts, and asking
-	// for them is what makes the WebGPU backend look for an adapter.
+	// The devices of llama.cpp exist only after the backend starts. This request
+	// makes the WebGPU backend look for an adapter.
 	gpuDevice = readGPUDevice()
 }
 
@@ -214,15 +211,14 @@ func readGPUDevice() string {
 // GPUDevice gives the name of the device of llama.cpp that is not the CPU, or
 // an empty string if the computation is on the CPU. Call it after Init.
 //
-// A page can ask for WebGPU and still land on the CPU, because the backend
-// needs an adapter that supports f16 shaders. This says what llama.cpp really
-// has.
+// A page can ask for WebGPU and still get the CPU, because the backend needs an
+// adapter with f16 shaders. This gives the true condition of llama.cpp.
 func GPUDevice() string {
 	return gpuDevice
 }
 
-// Backend gives the name of what does the computation: "webgpu", "cpu-threads"
-// for the build on the CPU that uses more than one thread, or "cpu". Call it
+// Backend gives the name of the part that computes. The values are "webgpu",
+// "cpu-threads" for the CPU build with more than one thread, and "cpu". Call it
 // after Init.
 func Backend() string {
 	switch {
@@ -269,16 +265,15 @@ func callVoid(name string, args ...any) {
 
 // callValue runs a function of the shim and gives the result.
 //
-// A module with the WebGPU backend needs the GPU of the browser, and the calls
-// that ask for a GPU are asynchronous. Emscripten builds that module with JSPI,
-// so such a call gives a promise instead of a number. This waits for the
-// promise. A build for the CPU gives the number itself, which stays the fast
-// path.
+// A module with the WebGPU backend needs the GPU of the browser, and a request
+// for a GPU is asynchronous. Emscripten builds that module with JSPI, thus such
+// a call gives a promise and not a number. This function waits for the promise.
+// A CPU build gives the number directly, which is the fast path.
 func callValue(name string, args ...any) js.Value {
 	return settle(mod.Call(name, args...))
 }
 
-// settle waits for a promise, or gives back a value that is not one.
+// settle waits for a promise. It returns a value that is not a promise.
 func settle(v js.Value) js.Value {
 	if v.Type() != js.TypeObject || v.Get("then").Type() != js.TypeFunction {
 		return v
@@ -286,15 +281,15 @@ func settle(v js.Value) js.Value {
 
 	resolved, err := await(v)
 	if err != nil {
-		// The shim has no way to report this, so leave the value undefined and
-		// let the caller see a result that is not a number.
+		// The shim cannot report this. Leave the value undefined, thus the
+		// caller sees a result that is not a number.
 		return js.Undefined()
 	}
 	return resolved
 }
 
-// callErr runs a function of the shim and turns a negative result into an
-// error that holds the text from the shim.
+// callErr runs a function of the shim and changes a negative result into an
+// error with the text of the shim.
 func callErr(name string, args ...any) (int32, error) {
 	rc := call(name, args...)
 	if rc < 0 {
@@ -328,10 +323,10 @@ func lastError() string {
 //
 // memory of the module
 //
-// The two WebAssembly modules do not share memory, so every value that goes
+// The two WebAssembly modules do not share memory, thus each value that goes
 // into llama.cpp is a copy. ALLOW_MEMORY_GROWTH makes a new buffer each time
-// the memory of the module grows, and that leaves the old views detached, so
-// each read and write takes the view again.
+// the memory increases, which detaches the old views. Thus each read and write
+// gets the view again.
 //
 
 func heapU8() js.Value {
@@ -374,8 +369,8 @@ func readBytes(ptr, n int) []byte {
 	return b
 }
 
-// writeString writes s and a zero byte at ptr. The room at ptr must be at
-// least len(s)+1 bytes.
+// writeString writes s and a zero byte at ptr. The space at ptr must be a
+// minimum of len(s)+1 bytes.
 func writeString(ptr int, s string) {
 	b := make([]byte, len(s)+1)
 	copy(b, s)
@@ -412,8 +407,8 @@ func readFloats(ptr, n int) []float32 {
 // scratch memory
 //
 // The loop that makes tokens calls into the module many times for each token.
-// A scratch area that stays keeps the loop from allocating in the module, which
-// also keeps the memory of the module from growing during generation.
+// A permanent scratch area prevents an allocation in the module, which also
+// prevents an increase of the module memory during generation.
 //
 
 type scratch struct {
@@ -421,7 +416,7 @@ type scratch struct {
 	size int
 }
 
-// reserve gives a pointer to at least n bytes. The contents of an earlier
+// reserve gives a pointer to a minimum of n bytes. The contents of an earlier
 // reserve on the same scratch are lost.
 func (s *scratch) reserve(n int) (int, error) {
 	if !Loaded() {
@@ -431,8 +426,8 @@ func (s *scratch) reserve(n int) (int, error) {
 		return s.ptr, nil
 	}
 
-	// Take room for more than the request, so that a loop that grows a little
-	// each time does not allocate each time.
+	// Get more space than the request, thus a loop that increases by a small
+	// quantity does not allocate each time.
 	size := n * 2
 	ptr, err := malloc(size)
 	if err != nil {
@@ -444,15 +439,15 @@ func (s *scratch) reserve(n int) (int, error) {
 	return ptr, nil
 }
 
-// release gives the memory of the scratch back to the module.
+// release returns the memory of the scratch to the module.
 func (s *scratch) release() {
 	free(s.ptr)
 	s.ptr, s.size = 0, 0
 }
 
-// Each purpose has its own scratch, because more than one is in use at the
-// same time. tokenScratch holds tokens on the way in, textScratch holds a
-// string on the way in, and pieceScratch holds bytes on the way out.
+// Each purpose has its own scratch, because more than one is in use at the same
+// time. tokenScratch holds input tokens, textScratch holds an input string, and
+// pieceScratch holds output bytes.
 var (
 	tokenScratch scratch
 	textScratch  scratch

--- a/pkg/llamawasm/mtmd.go
+++ b/pkg/llamawasm/mtmd.go
@@ -4,23 +4,23 @@ package llamawasm
 
 import "fmt"
 
-// The calls in this file follow the mtmd library of llama.cpp, which is what
-// gives a model its eyes. The names are the ones of the mtmd package with an
-// Mtmd prefix, because this package holds the llama calls as well:
+// The calls in this file follow the mtmd library of llama.cpp, which gives a
+// model the ability to read images. The names are the names of the mtmd package
+// with an Mtmd prefix, because this package also holds the llama calls.
 //
 //	mtmd.InitFromFile     -> llamawasm.MtmdInitFromFile
 //	mtmd.InputChunksInit  -> llamawasm.MtmdInputChunksInit
 //	mtmd.Tokenize         -> llamawasm.MtmdTokenize
 //	mtmd.HelperEvalChunks -> llamawasm.MtmdHelperEvalChunks
 //
-// The order of the calls is the same as in the examples/vlm program:
+// The order of the calls agrees with the examples/vlm program.
 //
 //	mctx, err := llamawasm.MtmdInitFromFile("mmproj.gguf", model, llamawasm.MtmdContextParamsDefault())
 //	bitmap, err := llamawasm.MtmdBitmapInit(width, height, rgb)
 //	chunks, err := llamawasm.MtmdInputChunksInit()
 //	llamawasm.MtmdTokenize(mctx, chunks, prompt, true, true, []MtmdBitmap{bitmap})
 //	nPast, err := llamawasm.MtmdHelperEvalChunks(mctx, ctx, chunks, 0, 0, nBatch, true)
-//	// then the same loop of SamplerSample and Decode as for text alone
+//	// then the usual loop of SamplerSample and Decode, as for text
 //
 // The prompt must hold one marker for each bitmap. [MtmdMarker] gives the
 // marker of the model.
@@ -41,25 +41,25 @@ type (
 //
 // It is the small part of mtmd.ContextParamsType that a browser can use.
 type MtmdContextParams struct {
-	// NThreads is the number of threads for the projector. Putting an image
-	// through one is the slowest part of an answer, so this matters more than
-	// the threads of the context do.
+	// NThreads is the number of threads for the projector. The projector is the
+	// slowest part of an answer, thus this value is more important than the
+	// threads of the context.
 	NThreads int32
 
-	// UseGPU puts the projector on the GPU where there is one.
+	// UseGPU puts the projector on the GPU if there is one.
 	UseGPU bool
 
-	// ImageMinTokens and ImageMaxTokens bound the number of tokens that one
-	// image becomes, for a model whose resolution changes with the image. 0
-	// takes the bounds of the model. Fewer tokens is less work and less detail.
+	// ImageMinTokens and ImageMaxTokens limit the number of tokens of one
+	// image, for a model with a variable resolution. A value of 0 uses the
+	// limits of the model. Fewer tokens give less work and less detail.
 	//
-	// A module of ABI version 3 takes no notice of these.
+	// A module of ABI version 3 ignores these values.
 	ImageMinTokens int32
 	ImageMaxTokens int32
 }
 
 // MtmdContextParamsDefault gives the parameters that a projector uses if the
-// program changes nothing: every thread the module has, and the GPU if
+// program changes nothing. These are each thread of the module and the GPU, if
 // llama.cpp found one.
 func MtmdContextParamsDefault() MtmdContextParams {
 	return MtmdContextParams{
@@ -68,17 +68,16 @@ func MtmdContextParamsDefault() MtmdContextParams {
 	}
 }
 
-// MtmdSupported tells if the module has the multimodal calls. A module from a
-// release before they came has none.
+// MtmdSupported tells if the module has the multimodal calls. A module from an
+// earlier release has none.
 func MtmdSupported() bool {
 	return has("_yzma_mtmd_init_from_file")
 }
 
-// MtmdInitFromFile loads the projector of a multimodal model. The file must be
-// in the filesystem of the module, the same as the model, and the model must be
-// loaded first.
+// MtmdInitFromFile loads the projector of a multimodal model. Put the file in
+// the filesystem of the module, as for the model, and load the model first.
 //
-// Pass [MtmdContextParamsDefault] unless there is a reason not to.
+// Use [MtmdContextParamsDefault] unless you have a reason for other values.
 func MtmdInitFromFile(mmprojPath string, model Model, params MtmdContextParams) (MtmdContext, error) {
 	if !Loaded() {
 		return 0, ErrNotLoaded
@@ -111,7 +110,7 @@ func MtmdFree(mctx MtmdContext) error {
 	return nil
 }
 
-// MtmdSupportVision tells if the projector takes images.
+// MtmdSupportVision tells if the projector accepts images.
 func MtmdSupportVision(mctx MtmdContext) bool {
 	if !Loaded() || !MtmdSupported() {
 		return false
@@ -119,8 +118,8 @@ func MtmdSupportVision(mctx MtmdContext) bool {
 	return call("_yzma_mtmd_support_vision", int(mctx)) == 1
 }
 
-// MtmdSupportAudio tells if the projector takes audio. This package has no way
-// to give it any, so this is here to report what the model is.
+// MtmdSupportAudio tells if the projector accepts audio. This package cannot
+// send audio, thus this call only gives a property of the model.
 func MtmdSupportAudio(mctx MtmdContext) bool {
 	if !Loaded() || !MtmdSupported() {
 		return false
@@ -128,8 +127,8 @@ func MtmdSupportAudio(mctx MtmdContext) bool {
 	return call("_yzma_mtmd_support_audio", int(mctx)) == 1
 }
 
-// MtmdMarker gives the marker that stands for a piece of media in the text of a
-// prompt, such as "<__media__>".
+// MtmdMarker gives the marker that replaces a media item in the text of a
+// prompt, for example "<__media__>".
 func MtmdMarker(mctx MtmdContext) string {
 	if !Loaded() || !MtmdSupported() {
 		return ""
@@ -150,9 +149,9 @@ func MtmdMarker(mctx MtmdContext) string {
 
 // MtmdBitmapInit makes a bitmap from the pixels of an image.
 //
-// The pixels must be RGB, three bytes for each one, with no padding between the
-// rows, so the length of rgb must be width*height*3. A page gets them from a
-// canvas: read the RGBA of the image and drop every fourth byte.
+// The pixels must be RGB, three bytes for each pixel, with no padding between
+// the rows. Thus the length of rgb must be width*height*3. A page reads the RGBA
+// of the image from a canvas and removes each fourth byte.
 func MtmdBitmapInit(width, height int32, rgb []byte) (MtmdBitmap, error) {
 	if !Loaded() {
 		return 0, ErrNotLoaded
@@ -166,8 +165,8 @@ func MtmdBitmapInit(width, height int32, rgb []byte) (MtmdBitmap, error) {
 		return 0, errBitmapSize(width, height, len(rgb), want)
 	}
 
-	// The image does not go in the scratch memory: it is large, and it stays
-	// only until the module copies it.
+	// The image is large and stays only until the module copies it, thus it
+	// does not go in the scratch memory.
 	ptr, err := malloc(len(rgb))
 	if err != nil {
 		return 0, err
@@ -183,7 +182,7 @@ func MtmdBitmapInit(width, height int32, rgb []byte) (MtmdBitmap, error) {
 	return MtmdBitmap(handle), nil
 }
 
-// errBitmapSize says what a bitmap of this size needs.
+// errBitmapSize gives the necessary length for a bitmap of this size.
 func errBitmapSize(width, height int32, got, want int) error {
 	return fmt.Errorf("llamawasm: an image of %d by %d needs %d bytes of RGB, got %d",
 		width, height, want, got)
@@ -197,7 +196,7 @@ func MtmdBitmapFree(bitmap MtmdBitmap) {
 	callVoid("_yzma_mtmd_bitmap_free", int(bitmap))
 }
 
-// MtmdInputChunksInit makes an empty list of chunks for MtmdTokenize to fill.
+// MtmdInputChunksInit makes an empty list of chunks for MtmdTokenize.
 func MtmdInputChunksInit() (MtmdInputChunks, error) {
 	if !Loaded() {
 		return 0, ErrNotLoaded
@@ -234,7 +233,7 @@ func MtmdInputChunksSize(chunks MtmdInputChunks) int32 {
 }
 
 // MtmdTokenize puts the text and the bitmaps into the list of chunks. The text
-// must hold one marker for each bitmap, and [MtmdMarker] gives the marker.
+// must hold one marker for each bitmap. [MtmdMarker] gives the marker.
 func MtmdTokenize(mctx MtmdContext, chunks MtmdInputChunks, text string,
 	addSpecial bool, parseSpecial bool, bitmaps []MtmdBitmap) error {
 	if !Loaded() {
@@ -250,8 +249,8 @@ func MtmdTokenize(mctx MtmdContext, chunks MtmdInputChunks, text string,
 	}
 	writeString(textPtr, text)
 
-	// The handles of the bitmaps go in their own memory, because the text is in
-	// the scratch already.
+	// The handles of the bitmaps go in their own memory, because the text is
+	// already in the scratch.
 	handlesPtr, err := tokenScratch.reserve(max(len(bitmaps), 1) * 4)
 	if err != nil {
 		return err
@@ -267,9 +266,9 @@ func MtmdTokenize(mctx MtmdContext, chunks MtmdInputChunks, text string,
 	return err
 }
 
-// MtmdHelperEvalChunks runs every chunk through the model: the text as tokens,
-// and each image through the projector first. It gives the position after the
-// last chunk, which the generation loop carries on from.
+// MtmdHelperEvalChunks runs each chunk through the model. The text goes as
+// tokens and each image goes through the projector first. It gives the position
+// after the last chunk, where the generation loop starts.
 func MtmdHelperEvalChunks(mctx MtmdContext, ctx Context, chunks MtmdInputChunks,
 	nPast Pos, seqID SeqId, nBatch int32, logitsLast bool) (Pos, error) {
 	if !Loaded() {

--- a/pkg/llamawasm/sampling.go
+++ b/pkg/llamawasm/sampling.go
@@ -12,9 +12,9 @@ func SamplerChainInit(params SamplerChainParams) Sampler {
 
 // SamplerChainAdd puts a sampler at the end of a chain.
 //
-// The chain then owns the sampler, so the handle of the sampler is no longer
-// valid and SamplerFree of that handle does nothing. Freeing the chain frees
-// every sampler in it.
+// The chain then owns the sampler. Thus the handle of the sampler is no longer
+// valid and SamplerFree of that handle has no result. When you free the chain,
+// you free each sampler in it.
 func SamplerChainAdd(chain Sampler, smpl Sampler) {
 	if !Loaded() {
 		return
@@ -74,8 +74,8 @@ func SamplerSample(smpl Sampler, ctx Context, idx int32) Token {
 	return Token(call("_yzma_sampler_sample", int(smpl), int(ctx), int(idx)))
 }
 
-// SamplerAccept tells the sampler which token the program took, which the
-// samplers that look at the tokens that came before need.
+// SamplerAccept gives the sampler the token that the program selected. The
+// samplers that examine the previous tokens need this.
 func SamplerAccept(smpl Sampler, token Token) {
 	if !Loaded() {
 		return

--- a/pkg/llamawasm/types.go
+++ b/pkg/llamawasm/types.go
@@ -3,8 +3,8 @@
 package llamawasm
 
 // The shim gives each object of llama.cpp a small int32 handle. A handle of 0
-// is never valid. The Go code never holds an address inside the llama.cpp
-// module, so the module is free to move or grow its memory.
+// is never valid. The Go code holds no address in the llama.cpp module, thus
+// the module can move or increase its memory.
 type (
 	// Token is one token of a vocabulary.
 	Token int32
@@ -49,7 +49,7 @@ type ModelParams struct {
 	// NGpuLayers is the number of layers to put on the GPU. A value larger than
 	// the number of layers of the model puts them all there.
 	//
-	// It does nothing in a build for the CPU. Test [GPUDevice] first: it is
+	// A CPU build ignores this value. Examine [GPUDevice] first, because it is
 	// empty when llama.cpp has no GPU.
 	NGpuLayers int32
 }
@@ -75,9 +75,9 @@ type ContextParams struct {
 // ContextDefaultParams gives the parameters that a context uses if the program
 // changes nothing.
 //
-// NThreads comes from [Threads], the number that the module can use. Leaving it
-// at 0 would give the four threads that llama.cpp asks for whatever the machine
-// has, which is slower on a machine with more.
+// NThreads comes from [Threads], which is the number that the module can use. A
+// value of 0 gives the four threads of llama.cpp, which is slow on a machine
+// with more cores.
 func ContextDefaultParams() ContextParams {
 	return ContextParams{
 		NCtx:        0,

--- a/pkg/llamawasm/vocab.go
+++ b/pkg/llamawasm/vocab.go
@@ -19,8 +19,8 @@ func Tokenize(vocab Vocab, text string, addSpecial bool, parseSpecial bool) []To
 	}
 	writeString(textPtr, text)
 
-	// One token holds at least one byte of text, so the number of bytes plus
-	// room for the special tokens is always enough.
+	// One token holds a minimum of one byte of text. Thus the number of bytes
+	// with space for the special tokens is always sufficient.
 	max := len(text) + 8
 
 	for {
@@ -47,8 +47,8 @@ func Tokenize(vocab Vocab, text string, addSpecial bool, parseSpecial bool) []To
 
 // Detokenize turns tokens back into text.
 //
-// The shim has no call for this, so the text comes from TokenToPiece of each
-// token, which is what a generation loop does.
+// The shim has no call for this. Thus the text comes from TokenToPiece of each
+// token, which is the method that a generation loop uses.
 func Detokenize(vocab Vocab, tokens []Token, removeSpecial bool, unparseSpecial bool) string {
 	if !Loaded() {
 		return ""

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,15 +1,15 @@
 # yzma in WebAssembly
 
-This directory holds what a browser needs to run yzma: the JavaScript glue that
-takes the correct WebAssembly build of llama.cpp, a Web Worker that holds the
-program, a page, a static server, and a test that runs in Node.
+This directory holds the parts that a browser needs to run yzma. These are the
+JavaScript glue that selects the correct WebAssembly build of llama.cpp, a Web
+Worker that holds the program, a page, a static server, and a test for Node.
 
-The Go code is in [`pkg/llamawasm`](../pkg/llamawasm), and the example is in
+The Go code is in [`pkg/llamawasm`](../pkg/llamawasm) and the example is in
 [`examples/wasm/chat`](../examples/wasm/chat).
 
 ## How it works
 
-There are two WebAssembly modules:
+There are two WebAssembly modules.
 
 ```
    page (index.html)
@@ -23,26 +23,25 @@ There are two WebAssembly modules:
 
 On a native platform yzma calls llama.cpp with libffi and loads the shared
 libraries at run time. A WebAssembly module has no `dlopen` and no libffi, and
-TinyGo cannot compile the C++ of llama.cpp. So llama.cpp becomes a second
+TinyGo cannot compile the C++ of llama.cpp. Thus llama.cpp becomes a second
 WebAssembly module, made by Emscripten with a small C shim, and the Go code
-calls that module through JavaScript. The shim is in the
-[llama-cpp-builder](https://github.com/hybridgroup/llama-cpp-builder) repo, in
-its `wasm` directory.
+calls that module through JavaScript. The shim is in the `wasm` directory of the
+[llama-cpp-builder](https://github.com/hybridgroup/llama-cpp-builder) repo.
 
-The generation loop stays in Go. One `Decode` and one `SamplerSample` for each
-token, the same as the `examples/hello` program.
+The generation loop stays in Go. It does one `Decode` and one `SamplerSample`
+for each token, as in the `examples/hello` program.
 
 ## Files
 
 | File | What it does |
 | --- | --- |
-| `yzma-loader.js` | Finds what the browser can run — WebGPU, more than one thread, or one thread — then loads that build of llama.cpp and puts it in `globalThis.yzmaReady`. |
-| `worker.js` | Runs llama.cpp and the Go program in a Web Worker, and sends each piece of text to the page. |
+| `yzma-loader.js` | Finds the best build that the browser can run, which is WebGPU, more than one thread, or one thread. It loads that build of llama.cpp and puts it in `globalThis.yzmaReady`. |
+| `worker.js` | Runs llama.cpp and the Go program in a Web Worker and sends each piece of text to the page. |
 | `index.html` | A page that loads a model and makes text. |
 | `vlm.html` | A page that asks a question about an image. |
-| `serve/main.go` | A static server that sets the headers that a build with more than one thread needs. |
-| `node/run.js` | Runs the same build in Node, with no browser. This is the test that CI uses. |
-| `node/vlm.js` | The same for a model with eyes. It makes its own pixels, because Node has no canvas. |
+| `serve/main.go` | A static server that sets the headers for a build with more than one thread. |
+| `node/run.js` | Runs the same build in Node with no browser. CI uses this test. |
+| `node/vlm.js` | The same test for an image model. It makes its own pixels, because Node has no canvas. |
 
 ## Build and run
 
@@ -61,11 +60,11 @@ make serve-wasm
 Then <http://localhost:8080> is the chat page and
 <http://localhost:8080/vlm.html> is the page that takes an image.
 
-Add `?mode=cpu` or `?mode=webgpu` to the URL of either page to choose the backend
-instead of letting the loader choose.
+Add `?mode=cpu` or `?mode=webgpu` to the URL of a page to select the backend
+yourself.
 
 `make wasm-example-go` builds the same program with the standard Go toolchain.
-The binary is larger, which is useful if TinyGo cannot build a dependency.
+The binary is larger, which is an aid if TinyGo cannot build a dependency.
 
 ## Run it without a browser
 
@@ -75,22 +74,21 @@ make test-wasm
 ```
 
 `node/run.js` loads a small model, makes tokens with the greedy sampler, and
-prints them. The greedy sampler always takes the most probable token, so the
-output does not change from one run to the next and a test can compare it.
+prints them. The greedy sampler always takes the most probable token, thus the
+output does not change between runs and a test can compare it.
 
 `make test-wasm-mt` does the same with the build that uses more than one thread.
-Node gives `SharedArrayBuffer` without the headers that a browser needs, so this
-tests that build outside a browser.
+Node gives `SharedArrayBuffer` without the headers that a browser needs, thus
+this tests that build outside a browser.
 
-`make test-wasm-webgpu` tests the other half of the WebGPU story, which is what
-happens where there is none: Node has no WebGPU, so the loader must take a build
-on the CPU and the program must still make text. Only a browser can run the
-WebGPU build itself.
+`make test-wasm-webgpu` tests the fallback from WebGPU. Node has no WebGPU, thus
+the loader must select a CPU build and the program must make text. Only a
+browser can run the WebGPU build.
 
 ## Threads
 
-llama.cpp asks for **four** threads unless it is told otherwise, whatever the
-machine has, and that is a large amount of speed to leave on the table:
+llama.cpp asks for **four** threads unless a caller changes it. On a machine
+with more cores this loses much speed.
 
 | Tokens a second, in Chrome | Four threads | Every thread |
 | --- | --- | --- |
@@ -98,26 +96,26 @@ machine has, and that is a large amount of speed to leave on the table:
 | Gemma 3 1B Q2_K | 8.7 | 18.5 |
 | SmolVLM-256M Q8_0, the answer | 56.3 | 96.9 |
 
-So `ContextDefaultParams` and `MtmdContextParamsDefault` pass
-`llamawasm.Threads()`, the number the JavaScript glue takes from the machine, and
-the glue sizes the pool of threads of the module to match. A pool that is too
-small is worse than a small number of threads: llama.cpp then waits for threads
-that cannot start, because the thread that would start them is busy computing.
+Thus `ContextDefaultParams` and `MtmdContextParamsDefault` send
+`llamawasm.Threads()`, which the JavaScript glue reads from the machine. The
+glue makes the thread pool of the module the same size. A pool that is too small
+is worse than a small number of threads, because llama.cpp then waits for threads
+that cannot start. The thread that starts them is busy with computation.
 
-The WebGPU build gains from this as well, and it has no threads at all: asking
-for one thread instead of four takes away the waiting at barriers that four
-threads set up and only one thread ever reached. SmolLM-135M went from 47.6
-tokens a second to 63.3 that way.
+The WebGPU build also gets an advantage, although it has no threads. A request
+for one thread in place of four removes the wait at the barriers that four
+threads make and only one thread reaches. SmolLM-135M changed from 47.6 tokens a
+second to 63.3.
 
-The threads have **no effect on the image**, which is the surprise here. The
-projector took 30.4 seconds on four threads and 33.3 on sixteen, and 38.3 against
-42.7 in a browser, so a large number of threads is slightly worse. What makes an
-image fast is the GPU, not the CPU.
+The threads have **no effect on the image**. The projector used 30.4 seconds on
+four threads and 33.3 seconds on sixteen, and 38.3 seconds against 42.7 seconds
+in a browser. Thus a large number of threads is a little worse. The GPU makes an
+image fast, not the CPU.
 
 ## Speed
 
 Measured in Chrome on one machine, an RTX 4070 with an Intel integrated GPU,
-with the greedy sampler:
+with the greedy sampler.
 
 | Model | Backend | Tokens a second |
 | --- | --- | --- |
@@ -127,12 +125,12 @@ with the greedy sampler:
 | Gemma 3 1B Q2_K | more threads | 18.5 |
 | Gemma 3 1B Q2_K | WebGPU | 38.7 |
 
-The GPU wins on the larger model, and on the smaller one the two come out the
-same, because the work of each operation is too small to pay for the trip to the
-GPU. Try both: the page takes `?mode=cpu` and `?mode=webgpu`.
+The GPU is faster on the larger model. On the smaller model the two results
+agree, because each operation is too small to justify the transfer to the GPU.
+Test both with `?mode=cpu` and `?mode=webgpu`.
 
-An image is a different story. This is the same photo of 960 by 720 through the
-projector of SmolVLM-256M Q8_0, and then 32 tokens of answer:
+An image gives a different result. This is the same photo of 960 by 720 through
+the projector of SmolVLM-256M Q8_0, and then 32 tokens of answer.
 
 | Backend | Time for the image | Tokens a second |
 | --- | --- | --- |
@@ -140,28 +138,28 @@ projector of SmolVLM-256M Q8_0, and then 32 tokens of answer:
 | WebGPU, in Chrome | 1.6 s | 64.4 |
 | one thread, in Node | 80 s | 17.4 |
 
-Putting an image through a projector is a wall of numbers all at once, which is
-what a GPU is for, so the GPU is twenty five times faster at it. On the CPU it is
-the image, and not the answer, that a reader waits for. The threads make the
-answer faster and the image no faster at all, so a page that takes images wants
-WebGPU more than a page that takes only text does.
+A projector computes many numbers at the same time, which is the function of a
+GPU. Thus the GPU is 25 times faster. On the CPU the reader waits for the image
+and not for the answer. The threads make the answer faster but do not change the
+time of the image. Thus a page with images needs WebGPU more than a page with
+only text.
 
-The size of the image hardly matters: a model has a resolution of its own and
-resizes what it gets, so 224 by 224 and 448 by 448 both took about the same time
-and both came to 148 tokens of image.
+The size of the image has almost no effect. A model has its own resolution and
+changes the size of the image. Thus 224 by 224 and 448 by 448 used almost the
+same time and both gave 148 tokens of image.
 
-The builds on the CPU give the same text every time. The GPU gives the same text
-for the first few tokens and then goes its own way, because the shaders do the
-arithmetic in a different order than the CPU does.
+The CPU builds give the same text each time. The GPU gives the same text for the
+first tokens and then gives different text, because the shaders do the
+calculations in a different order.
 
-## A model with eyes
+## Images
 
 `vlm.html` and `examples/wasm/vlm` answer a question about an image. The
-multimodal library of llama.cpp, mtmd, is in every build, so nothing more needs
-installing.
+multimodal library of llama.cpp, mtmd, is in each build, thus you install
+nothing more.
 
 **The page decodes the image, not llama.cpp.** It draws the file on a canvas and
-sends the pixels to the program:
+sends the pixels to the program.
 
 ```js
 const bitmap = await createImageBitmap(file);
@@ -170,11 +168,12 @@ const { data } = context.getImageData(0, 0, width, height); // RGBA
 worker.postMessage({ kind: "describe", prompt, width, height, rgba: data.buffer }, [data.buffer]);
 ```
 
-So any format the browser reads works, and no image library goes into the
-WebAssembly build. The Go side drops the alpha byte and hands the RGB to mtmd.
+Thus each format that the browser reads is usable and the WebAssembly build
+needs no image library. The Go side removes the alpha byte and sends the RGB to
+mtmd.
 
-The calls follow the mtmd package, with an Mtmd prefix because one package holds
-the llama calls as well:
+The calls follow the mtmd package with an Mtmd prefix, because one package also
+holds the llama calls.
 
 ```go
 mctx, err := llamawasm.MtmdInitFromFile("/models/mmproj.gguf", model, 0, onGPU)
@@ -182,94 +181,92 @@ bitmap, err := llamawasm.MtmdBitmapInit(width, height, rgb)
 chunks, err := llamawasm.MtmdInputChunksInit()
 llamawasm.MtmdTokenize(mctx, chunks, prompt, true, true, []llamawasm.MtmdBitmap{bitmap})
 nPast, err := llamawasm.MtmdHelperEvalChunks(mctx, ctx, chunks, 0, 0, nBatch, true)
-// then the same loop of SamplerSample and Decode as for text alone
+// then the usual loop of SamplerSample and Decode, as for text
 ```
 
-The prompt must hold one marker for each image, and `MtmdMarker` gives the
-marker of the model. `ChatApplyTemplate` puts the marker and the question into
-the format the model expects.
+The prompt must hold one marker for each image. `MtmdMarker` gives the marker of
+the model. `ChatApplyTemplate` puts the marker and the question into the correct
+format for the model.
 
-Two models come down for this: the model itself and its projector, the mmproj
-file.
+Two files come down for this, the model and its projector, the mmproj file.
 
-Images only. Audio and video stay out: audio needs the page to decode and
-resample the samples itself, and video needs ffmpeg in a subprocess, which a
-browser has not got.
+Images only. Audio needs the page to decode and resample the samples, and video
+needs ffmpeg in a subprocess, which a browser does not have.
 
 ## Why a worker
 
-Every call into llama.cpp is synchronous, and one token takes milliseconds. A
-call from the main thread stops the page. The worker also lets the page show
-each token as it comes, because one `Decode` handles one batch.
+Each call into llama.cpp is synchronous and one token takes milliseconds. A call
+from the main thread stops the page. The worker also lets the page show each
+token immediately, because one `Decode` does one batch.
 
 ## WebGPU
 
-There are three builds of llama.cpp, and `yzma-loader.js` takes the best one
-that the browser can run:
+There are three builds of llama.cpp. `yzma-loader.js` selects the best one that
+the browser can run.
 
 | Build | What it needs |
 | --- | --- |
-| `yzma_wasm_webgpu` | WebGPU with f16 shaders, and JSPI. Chrome and Edge 137 and later. |
-| `yzma_wasm_mt` | `SharedArrayBuffer`, so a page with the COOP and COEP headers. |
-| `yzma_wasm` | Nothing. It works everywhere. |
+| `yzma_wasm_webgpu` | WebGPU with f16 shaders, and JSPI. Chrome and Edge 137 or later. |
+| `yzma_wasm_mt` | `SharedArrayBuffer`, thus a page with the COOP and COEP headers. |
+| `yzma_wasm` | Nothing. It operates in all browsers. |
 
-A page can force the choice with `globalThis.yzmaMode`, which takes `auto` (the
-default), `webgpu`, or `cpu`. `webgpu` still falls back to the CPU if the
-browser cannot run that build, because a page that does not work at all is
-worse than a page that is slower.
+A page can set the choice with `globalThis.yzmaMode`, which accepts `auto` (the
+default), `webgpu`, or `cpu`. With `webgpu` the loader still falls back to the
+CPU if the browser cannot run that build, because a slow page is better than a
+page that does not operate.
 
-`llamawasm.Backend()` says what does the computation, and
-`llamawasm.GPUDevice()` names the GPU that llama.cpp found. Ask llama.cpp and
-not the browser: a page can have WebGPU while llama.cpp still has no device.
+`llamawasm.Backend()` gives the name of the part that computes and
+`llamawasm.GPUDevice()` gives the name of the GPU that llama.cpp found. Ask
+llama.cpp and not the browser, because a page can have WebGPU while llama.cpp
+has no device.
 
-### f16 shaders, and NVIDIA
+### f16 shaders and NVIDIA
 
-The backend of llama.cpp needs `shader-f16`, and it reports no device at all
-without it. Two things follow from how the backend asks for an adapter in a
-browser, where it takes the adapter of the browser with no options of its own:
+The backend of llama.cpp needs `shader-f16` and reports no device without it. In
+a browser the backend uses the adapter of the browser and sets no options. This
+gives two results.
 
-- An Intel integrated GPU gives f16, and the WebGPU build runs.
-- A discrete NVIDIA card does **not** give f16 in a browser. Dawn has a toggle
-  for it, `vulkan_enable_f16_on_nvidia`, and llama.cpp turns it on outside a
-  browser but cannot in one. A page cannot turn it on either: it is a flag of
-  the browser. So Chrome takes the CPU on such a machine unless somebody starts
-  it with:
+- An Intel integrated GPU gives f16 and the WebGPU build operates.
+- A discrete NVIDIA card does **not** give f16 in a browser. Dawn has the
+  `vulkan_enable_f16_on_nvidia` option and llama.cpp sets it outside a browser,
+  but not in one. A page also cannot set it, because it is a flag of the
+  browser. Thus Chrome uses the CPU on such a machine unless the user starts it
+  with this command.
 
   ```
   google-chrome --enable-dawn-features=vulkan_enable_f16_on_nvidia
   ```
 
-The fallback makes this a slower page and not a broken one.
+The fallback makes the page slow, but the page operates.
 
 ## More than one thread
 
-The faster build of llama.cpp needs `SharedArrayBuffer`, and a browser gives
-that only to a page that comes with these headers:
+The faster build of llama.cpp needs `SharedArrayBuffer`. A browser gives that
+only to a page with these headers.
 
 ```
 Cross-Origin-Opener-Policy: same-origin
 Cross-Origin-Embedder-Policy: require-corp
 ```
 
-`wasm/serve` sets them. If a host does not, `yzma-loader.js` takes the build
-with one thread, which is slower but works everywhere. `llamawasm.Threaded()`
-says which build the page took.
+`wasm/serve` sets them. If a host does not set them, `yzma-loader.js` selects
+the build with one thread, which is slower but operates in all browsers.
+`llamawasm.Threaded()` gives the selection.
 
-An isolated page can only get a model from another origin if that origin sends
-the CORS headers. Hugging Face does, so the model in `index.html` comes down as
-it is, but a model on a host that sends no CORS headers needs a copy on the
-origin of the page.
+An isolated page can get a model from another origin only if that origin sends
+the CORS headers. Hugging Face sends them, thus the model in `index.html` comes
+down without a change. A model on a host with no CORS headers needs a copy on
+the origin of the page.
 
 ## Limits
 
-- WebGPU needs Chrome or Edge 137 and later, and an adapter with f16 shaders.
-  Everything else runs on the CPU with SIMD.
-- A browser does not get the matrix instructions of a subgroup, which llama.cpp
-  uses only outside a browser, so the GPU is slower in a page than the same
-  backend is on a desktop.
-- An operation larger than `maxStorageBufferBindingSize` goes back to the CPU.
-- One JavaScript ArrayBuffer holds at most 2 GB, so a larger model must be in
-  splits.
-- `pkg/llamawasm` has the calls that text generation, embeddings, and images
-  need. It does not have audio, video, LoRA adapters, saved state, or
-  quantization.
+- WebGPU needs Chrome or Edge 137 or later, and an adapter with f16 shaders. All
+  other browsers use the CPU with SIMD.
+- A browser does not give the matrix instructions of a subgroup, which llama.cpp
+  uses only outside a browser. Thus the GPU is slower in a page than the same
+  backend on a desktop.
+- An operation larger than `maxStorageBufferBindingSize` returns to the CPU.
+- One JavaScript ArrayBuffer holds a maximum of 2 GB, thus a larger model must be
+  in splits.
+- `pkg/llamawasm` has the calls for text generation, embeddings, and images. It
+  does not have audio, video, LoRA adapters, saved state, or quantization.

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -57,8 +57,8 @@
       const output = document.getElementById("output");
       const generateButton = document.getElementById("generate");
 
-      // ?mode=cpu on the page passes through to the worker, which lets a
-      // reader compare the GPU with the CPU.
+      // ?mode=cpu on the page goes to the worker, thus a reader can compare
+      // the GPU with the CPU.
       const mode = new URLSearchParams(location.search).get("mode");
       const worker = new Worker("./worker.js" + (mode ? "?mode=" + encodeURIComponent(mode) : ""));
 

--- a/wasm/node/run.js
+++ b/wasm/node/run.js
@@ -1,22 +1,21 @@
 // run.js runs the WebAssembly build of yzma in Node, without a browser.
 //
-// It is the test that CI uses: it loads a small model, makes a fixed number of
-// tokens with the greedy sampler, and prints them. The greedy sampler always
-// takes the most probable token, so the output of a model does not change, and
-// a test can compare it.
+// CI uses this test. It loads a small model, makes a fixed number of tokens
+// with the greedy sampler, and prints them. The greedy sampler always takes the
+// most probable token, thus the output does not change and a test can compare
+// it.
 //
-// Usage:
+// Usage.
 //   node wasm/node/run.js --dir build/wasm --model ~/models/SmolLM-135M.Q2_K.gguf \
 //       --prompt "Are you ready to go?" --tokens 12 [--expect "<text>"] [--mt]
 //       [--webgpu]
 //
-// --mt takes the build with more than one thread. Node has SharedArrayBuffer
-// without the headers that a browser needs, so this is a way to test that build
-// outside a browser.
+// --mt selects the build with more than one thread. Node gives
+// SharedArrayBuffer without the headers that a browser needs, thus this tests
+// that build outside a browser.
 //
-// --webgpu asks for the WebGPU build. Node has no WebGPU, so this tests the
-// other half of that story: the loader must quietly take a build on the CPU and
-// the program must still make text.
+// --webgpu asks for the WebGPU build. Node has no WebGPU, thus this tests the
+// fallback. The loader must select a CPU build and the program must make text.
 
 const fs = require("node:fs");
 const path = require("node:path");
@@ -34,8 +33,8 @@ const expect = option("expect", "");
 const mt = process.argv.includes("--mt");
 const webgpu = process.argv.includes("--webgpu");
 
-// This harness stands in for yzma-loader.js, so it makes the same choice the
-// loader would make in a place that has no WebGPU: it falls back to the CPU.
+// This harness replaces yzma-loader.js. It makes the same choice as the loader
+// where there is no WebGPU, thus it falls back to the CPU.
 let moduleName = "yzma_wasm.js";
 if (mt) {
   moduleName = "yzma_wasm_mt.js";
@@ -53,8 +52,7 @@ if (!modelFile) {
   process.exit(2);
 }
 
-// The output of the Go program comes here, because a Node process has no
-// postMessage.
+// The output of the Go program comes here, because Node has no postMessage.
 const output = [];
 
 let programIsReady;
@@ -75,14 +73,14 @@ globalThis.yzmaOnMessage = (message) => {
 };
 
 async function main() {
-  // Take the build with one thread. Node has no crossOriginIsolated, so the
-  // loader would take it anyway, but this says so.
+  // Select the build with one thread. Node has no crossOriginIsolated, thus
+  // the loader makes the same choice.
   globalThis.crossOriginIsolated = mt;
   globalThis.yzmaBase = dir;
 
   const factory = require(path.join(dir, moduleName));
-  // The same numbers the JavaScript glue would choose: a pool that follows the
-  // machine, and a thread count that the Go side reads.
+  // The same values that the JavaScript glue selects. The pool follows the
+  // machine and the Go side reads the thread count.
   const threads = mt ? Math.max(1, Math.min(require("node:os").cpus().length, 16)) : 1;
 
   const llamaModule = await factory({
@@ -102,8 +100,8 @@ async function main() {
       ? "cpu-threads"
       : "cpu";
 
-  // Put the model in the filesystem of the module. A browser gets it over the
-  // network instead, with FetchModelFile.
+  // Put the model in the filesystem of the module. A browser instead gets it
+  // from the network with FetchModelFile.
   llamaModule.FS.mkdirTree("/models");
   llamaModule.FS.writeFile("/models/model.gguf", fs.readFileSync(modelFile));
 
@@ -113,11 +111,11 @@ async function main() {
   const binary = fs.readFileSync(path.join(dir, "yzma.wasm"));
   const result = await WebAssembly.instantiate(binary, go.importObject);
 
-  // The program blocks at the end of main, so do not wait for this.
+  // The program blocks at the end of main, thus do not wait for this.
   go.run(result.instance);
 
-  // Wait for the program to say it is ready. Starting the backend takes a
-  // moment, and longer with WebGPU.
+  // Wait for the ready message. The backend needs time to start, and more
+  // time with WebGPU.
   await programReady;
 
   const done = new Promise((resolve) => {

--- a/wasm/node/vlm.js
+++ b/wasm/node/vlm.js
@@ -1,17 +1,17 @@
 // vlm.js answers a question about an image in Node, with no browser.
 //
-// Node has no canvas, so this makes the pixels itself: a plain shape on a plain
-// ground. That is enough to prove the whole path works, from the pixels through
-// the projector to the tokens. Whether the answer is a good description of the
-// shape is a question for a real image in a browser.
+// Node has no canvas, thus this makes the pixels itself. A simple shape on a
+// simple ground is sufficient to test the full path, from the pixels through
+// the projector to the tokens. Use a browser and a real image to see if the
+// answer is a good description.
 //
-// Usage:
+// Usage.
 //   node wasm/node/vlm.js --dir build/wasm --model <model.gguf> \
 //       --mmproj <mmproj.gguf> [--tokens 24] [--ppm <file.ppm>] [--side 448]
 //       [--mt] [--webgpu] [--threads N] [--image-max-tokens N]
 //
 // --ppm takes a real image in the binary PPM format (P6), which needs no
-// decoder: convert one with "magick in.jpg out.ppm" or "ffmpeg -i in.jpg out.ppm".
+// decoder. Use "magick in.jpg out.ppm" or "ffmpeg -i in.jpg out.ppm".
 
 const fs = require("node:fs");
 const path = require("node:path");
@@ -38,8 +38,8 @@ if (!modelFile || !mmprojFile) {
   process.exit(2);
 }
 
-// This harness stands in for yzma-loader.js. Node has no WebGPU, so asking for
-// it must fall back the same way the loader does.
+// This harness replaces yzma-loader.js. Node has no WebGPU, thus a request for
+// it must fall back in the same way as the loader.
 let moduleName = "yzma_wasm.js";
 if (mt) {
   moduleName = "yzma_wasm_mt.js";
@@ -52,8 +52,8 @@ if (webgpu) {
   }
 }
 
-// makeImage draws a dark square in the middle of a light ground and gives the
-// RGBA that a canvas would give.
+// makeImage draws a dark square on a light ground and gives the same RGBA that
+// a canvas gives.
 function makeImage(width, height) {
   const rgba = new Uint8Array(width * height * 4);
   for (let y = 0; y < height; y++) {
@@ -71,7 +71,7 @@ function makeImage(width, height) {
   return { width, height, rgba };
 }
 
-// readPPM reads a binary PPM (P6), which is a header of plain text and then RGB.
+// readPPM reads a binary PPM (P6), which has a text header and then RGB.
 function readPPM(file) {
   const bytes = fs.readFileSync(file);
 
@@ -98,7 +98,7 @@ function readPPM(file) {
   const height = parseInt(h, 10);
   const rgb = bytes.subarray(i, i + width * height * 3);
 
-  // The program takes RGBA, the same as a canvas gives.
+  // The program takes RGBA, which is the format that a canvas gives.
   const rgba = new Uint8Array(width * height * 4);
   for (let p = 0; p < width * height; p++) {
     rgba[p * 4] = rgb[p * 3];
@@ -133,8 +133,8 @@ async function main() {
   globalThis.yzmaBase = dir;
 
   const factory = require(path.join(dir, moduleName));
-  // The same numbers the JavaScript glue would choose: a pool that follows the
-  // machine, and a thread count that the Go side reads.
+  // The same values that the JavaScript glue selects. The pool follows the
+  // machine and the Go side reads the thread count.
   const threads = threadsOverride > 0
     ? threadsOverride
     : mt ? Math.max(1, Math.min(require("node:os").cpus().length, 16)) : 1;
@@ -153,7 +153,7 @@ async function main() {
   globalThis.yzmaThreads = threads;
   globalThis.yzmaBackend = moduleName.includes("webgpu") ? "webgpu" : "cpu";
 
-  // A browser gets both files over the network. Here they go straight in.
+  // A browser gets both files from the network. Here they go in directly.
   llamaModule.FS.mkdirTree("/models");
   llamaModule.FS.writeFile("/models/model.gguf", fs.readFileSync(modelFile));
   llamaModule.FS.writeFile("/models/mmproj.gguf", fs.readFileSync(mmprojFile));
@@ -183,8 +183,8 @@ async function main() {
     };
   });
 
-  // The files are in place, so this only opens them. A browser gets them over
-  // the network with yzmaLoadModel instead.
+  // The files are in place, thus this only opens them. A browser instead gets
+  // them from the network with yzmaLoadModel.
   globalThis.yzmaOpenModel(imageMaxTokens);
 
   const last = await done;

--- a/wasm/serve/main.go
+++ b/wasm/serve/main.go
@@ -3,8 +3,8 @@
 //
 // The server sets the Cross-Origin-Opener-Policy and
 // Cross-Origin-Embedder-Policy headers. Without them a browser does not give
-// the page SharedArrayBuffer, and the build of llama.cpp that uses more than
-// one thread cannot run.
+// the page SharedArrayBuffer, and the build with more than one thread cannot
+// run.
 //
 //	go run ./wasm/serve -dir build/wasm -port 8080
 package main
@@ -34,12 +34,12 @@ func main() {
 	files := http.FileServer(http.Dir(path))
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// These two headers isolate the page, which is what gives it
-		// SharedArrayBuffer and therefore more than one thread.
+		// These two headers isolate the page, which gives it SharedArrayBuffer
+		// and thus more than one thread.
 		w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
 		w.Header().Set("Cross-Origin-Embedder-Policy", "require-corp")
 
-		// A browser runs a .wasm file only if the type is correct.
+		// A browser runs a .wasm file only with the correct type.
 		if filepath.Ext(r.URL.Path) == ".wasm" {
 			w.Header().Set("Content-Type", "application/wasm")
 		}

--- a/wasm/vlm.html
+++ b/wasm/vlm.html
@@ -75,8 +75,8 @@
       const askButton = document.getElementById("ask");
       const preview = document.getElementById("preview");
 
-      // The largest side of the image that goes to the model. A projector works
-      // on a small image of its own anyway, so sending more only costs memory.
+      // The maximum side of the image that goes to the model. A projector uses
+      // a small image, thus a larger image only uses more memory.
       const maxSide = 896;
 
       let picture = null;
@@ -108,7 +108,7 @@
         }
       };
 
-      // Turn the file the reader picked into RGBA pixels.
+      // Change the file that the reader selected into RGBA pixels.
       document.getElementById("file").onchange = async (event) => {
         const file = event.target.files[0];
         if (!file) {
@@ -154,7 +154,7 @@
         output.textContent = "";
         status.textContent = "asking";
 
-        // The pixels go over as a copy of their buffer.
+        // The pixels go to the worker as a copy of their buffer.
         const rgba = picture.rgba.slice().buffer;
         worker.postMessage(
           {

--- a/wasm/worker.js
+++ b/wasm/worker.js
@@ -12,6 +12,10 @@
 // The worker sends back { kind, text } messages, where kind is one of ready,
 // status, progress, loaded, token, done, or error.
 
+// Emscripten starts each thread with new Worker(_scriptName), which in a
+// classic worker is this file. A thread must only load llama.cpp.
+const isThread = globalThis.name === "em-pthread";
+
 self.yzmaBase = ".";
 
 // The page can choose the backend with a query on the URL of this worker, such
@@ -22,85 +26,100 @@ if (workerQuery.get("mode")) {
   self.yzmaMode = workerQuery.get("mode");
 }
 
+// Only the build with more than one thread has threads, so a thread does not
+// need to look for a GPU.
+if (isThread) {
+  self.yzmaMode = "cpu";
+}
+
 // Which Go program to run. The chat page takes the default, and the page for a
 // model with eyes asks for its own.
 const program = workerQuery.get("program") || "yzma.wasm";
 
-// A failure with nobody to catch it must reach the page. Without this the page
-// only sees that nothing more happens.
-self.onerror = (event) => {
-  self.postMessage({ kind: "error", text: String((event && event.message) || event) });
-};
-self.onunhandledrejection = (event) => {
-  self.postMessage({ kind: "error", text: String((event && event.reason) || event) });
-};
-
 importScripts("./yzma-loader.js");
-importScripts("./wasm_exec.js");
 
-// The Go program says when it is ready by sending its first message, which is
-// the one of kind "ready". Waiting for that is the only safe way to know that
-// it has set its functions: starting the backend takes a moment with the CPU
-// and much longer with WebGPU, where it has to find an adapter and make the
-// shaders.
-let programIsReady;
-const programReady = new Promise((resolve) => {
-  programIsReady = resolve;
-});
+// A thread stops here.
+if (!isThread) {
+  run();
+}
 
-const sendToPage = self.postMessage.bind(self);
-self.postMessage = (message) => {
-  if (message && (message.kind === "ready" || message.kind === "error")) {
-    programIsReady();
-  }
-  sendToPage(message);
-};
+// run starts llama.cpp and the Go program for the page.
+function run() {
+  // A failure with nobody to catch it must reach the page. Without this the page
+  // only sees that nothing more happens.
+  self.onerror = (event) => {
+    self.postMessage({ kind: "error", text: String((event && event.message) || event) });
+  };
+  self.onunhandledrejection = (event) => {
+    self.postMessage({ kind: "error", text: String((event && event.reason) || event) });
+  };
 
-const started = (async () => {
-  // llama.cpp must be ready before the Go program calls Load.
-  await self.yzmaReady;
+  importScripts("./wasm_exec.js");
 
-  const go = new Go();
-  const result = await WebAssembly.instantiateStreaming(fetch("./" + program), go.importObject);
+  // The Go program says when it is ready by sending its first message, which is
+  // the one of kind "ready". Waiting for that is the only safe way to know that
+  // it has set its functions: starting the backend takes a moment with the CPU
+  // and much longer with WebGPU, where it has to find an adapter and make the
+  // shaders.
+  let programIsReady;
+  const programReady = new Promise((resolve) => {
+    programIsReady = resolve;
+  });
 
-  // The Go program blocks at the end of main, so it keeps running and the page
-  // can call into it. Do not wait for this promise.
-  go.run(result.instance);
-
-  await programReady;
-
-  if (typeof self.yzmaLoadModel !== "function") {
-    throw new Error("the Go program did not set its functions");
-  }
-})();
-
-self.onmessage = async (event) => {
-  const message = event.data || {};
-
-  try {
-    await started;
-
-    switch (message.kind) {
-      case "load":
-        self.yzmaLoadModel(message.url, message.projector || "");
-        break;
-      case "generate":
-        self.yzmaGenerate(message.prompt, message.maxTokens || 128);
-        break;
-      case "describe":
-        // The image comes as RGBA from a canvas of the page.
-        self.yzmaDescribe(
-          message.prompt,
-          message.width,
-          message.height,
-          new Uint8Array(message.rgba),
-          message.maxTokens || 128,
-        );
-        break;
-      default:
-        self.postMessage({ kind: "error", text: "unknown message: " + message.kind });
+  const sendToPage = self.postMessage.bind(self);
+  self.postMessage = (message) => {
+    if (message && (message.kind === "ready" || message.kind === "error")) {
+      programIsReady();
     }
-  } catch (err) {
-    self.postMessage({ kind: "error", text: String(err) });
-  }
-};
+    sendToPage(message);
+  };
+
+  const started = (async () => {
+    // llama.cpp must be ready before the Go program calls Load.
+    await self.yzmaReady;
+
+    const go = new Go();
+    const result = await WebAssembly.instantiateStreaming(fetch("./" + program), go.importObject);
+
+    // The Go program blocks at the end of main, so it keeps running and the page
+    // can call into it. Do not wait for this promise.
+    go.run(result.instance);
+
+    await programReady;
+
+    if (typeof self.yzmaLoadModel !== "function") {
+      throw new Error("the Go program did not set its functions");
+    }
+  })();
+
+  self.onmessage = async (event) => {
+    const message = event.data || {};
+
+    try {
+      await started;
+
+      switch (message.kind) {
+        case "load":
+          self.yzmaLoadModel(message.url, message.projector || "");
+          break;
+        case "generate":
+          self.yzmaGenerate(message.prompt, message.maxTokens || 128);
+          break;
+        case "describe":
+          // The image comes as RGBA from a canvas of the page.
+          self.yzmaDescribe(
+            message.prompt,
+            message.width,
+            message.height,
+            new Uint8Array(message.rgba),
+            message.maxTokens || 128,
+          );
+          break;
+        default:
+          self.postMessage({ kind: "error", text: "unknown message: " + message.kind });
+      }
+    } catch (err) {
+      self.postMessage({ kind: "error", text: String(err) });
+    }
+  };
+}

--- a/wasm/worker.js
+++ b/wasm/worker.js
@@ -1,8 +1,7 @@
 // worker.js runs llama.cpp and the Go program in a Web Worker.
 //
-// Every call into llama.cpp is synchronous and one token takes milliseconds, so
-// this work cannot go on the main thread of the page: it would stop the page.
-// The worker sends each piece of text to the page as it comes.
+// Each call into llama.cpp is synchronous and one token takes milliseconds.
+// Thus this work cannot go on the main thread, because it would stop the page.
 //
 // The page sends these messages to the worker:
 //
@@ -18,9 +17,8 @@ const isThread = globalThis.name === "em-pthread";
 
 self.yzmaBase = ".";
 
-// The page can choose the backend with a query on the URL of this worker, such
-// as new Worker("./worker.js?mode=cpu"). The values are the ones that
-// yzma-loader.js takes: auto, webgpu, or cpu.
+// The page selects the backend with a query on the URL of this worker, for
+// example new Worker("./worker.js?mode=cpu"). yzma-loader.js has the values.
 const workerQuery = new URLSearchParams((self.location.search || "").slice(1));
 if (workerQuery.get("mode")) {
   self.yzmaMode = workerQuery.get("mode");
@@ -32,8 +30,8 @@ if (isThread) {
   self.yzmaMode = "cpu";
 }
 
-// Which Go program to run. The chat page takes the default, and the page for a
-// model with eyes asks for its own.
+// The Go program to run. The chat page uses the default and the image page
+// asks for its own.
 const program = workerQuery.get("program") || "yzma.wasm";
 
 importScripts("./yzma-loader.js");
@@ -45,8 +43,8 @@ if (!isThread) {
 
 // run starts llama.cpp and the Go program for the page.
 function run() {
-  // A failure with nobody to catch it must reach the page. Without this the page
-  // only sees that nothing more happens.
+  // A failure with no handler must reach the page. Without this the page only
+  // sees that nothing more occurs.
   self.onerror = (event) => {
     self.postMessage({ kind: "error", text: String((event && event.message) || event) });
   };
@@ -56,11 +54,8 @@ function run() {
 
   importScripts("./wasm_exec.js");
 
-  // The Go program says when it is ready by sending its first message, which is
-  // the one of kind "ready". Waiting for that is the only safe way to know that
-  // it has set its functions: starting the backend takes a moment with the CPU
-  // and much longer with WebGPU, where it has to find an adapter and make the
-  // shaders.
+  // The Go program sends a message of kind "ready" when it sets its functions.
+  // Wait for that message, because the backend can take a long time to start.
   let programIsReady;
   const programReady = new Promise((resolve) => {
     programIsReady = resolve;
@@ -81,8 +76,8 @@ function run() {
     const go = new Go();
     const result = await WebAssembly.instantiateStreaming(fetch("./" + program), go.importObject);
 
-    // The Go program blocks at the end of main, so it keeps running and the page
-    // can call into it. Do not wait for this promise.
+    // The Go program blocks at the end of main and continues to run, thus the
+    // page can call into it. Do not wait for this promise.
     go.run(result.instance);
 
     await programReady;

--- a/wasm/yzma-loader.js
+++ b/wasm/yzma-loader.js
@@ -1,51 +1,46 @@
-// yzma-loader.js takes the correct WebAssembly build of llama.cpp and makes it
-// ready for the pkg/llamawasm Go package.
+// yzma-loader.js selects the correct WebAssembly build of llama.cpp and
+// prepares it for the pkg/llamawasm Go package.
 //
-// It works in a Web Worker and in a page. Load it before the Go program runs.
-// It sets:
+// It operates in a Web Worker and in a page. Load it before the Go program.
+// It sets these globals.
 //
-//   globalThis.yzmaReady     a promise whose value is the llama.cpp module
-//   globalThis.yzmaModule    the module, after the promise is done
+//   globalThis.yzmaReady     a promise that gives the llama.cpp module
+//   globalThis.yzmaModule    the module, after the promise completes
 //   globalThis.yzmaThreaded  true if the build uses more than one thread
-//   globalThis.yzmaThreads   how many threads the build can use
+//   globalThis.yzmaThreads   the number of threads that the build can use
 //   globalThis.yzmaBackend   "webgpu", "cpu-threads", or "cpu"
 //   globalThis.yzmaAdapter   the name of the GPU, if there is one
 //
-// Set these before this file to change what it does:
+// Set these globals before this file to change the result.
 //
-//   globalThis.yzmaBase      where the files of llama.cpp are. The default is "."
+//   globalThis.yzmaBase      the location of the llama.cpp files, default "."
 //   globalThis.yzmaMode      "auto" (the default), "webgpu", or "cpu"
 //
-// There are three builds of llama.cpp. WebGPU puts the computation on the GPU
-// and needs a browser that has both WebGPU and JSPI, which today is Chrome and
-// Edge 137 and later. The two builds on the CPU work everywhere, and the one
-// that uses more than one thread needs a page that is isolated with the
-// Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers.
+// There are three builds of llama.cpp. The WebGPU build computes on the GPU and
+// needs a browser with WebGPU and JSPI, which is Chrome and Edge 137 or later.
+// The two CPU builds operate in all browsers. The build with more than one
+// thread needs an isolated page with the Cross-Origin-Opener-Policy and
+// Cross-Origin-Embedder-Policy headers.
 //
-// In "auto" the loader takes the best build that the browser can run, so a
-// browser without WebGPU still works.
+// In "auto" mode the loader selects the best build that the browser can run.
 
 (function () {
   const base = globalThis.yzmaBase || ".";
   const mode = globalThis.yzmaMode || "auto";
 
-  // A browser gives SharedArrayBuffer only to a page that is isolated. The
-  // build with more than one thread cannot run without it.
+  // A browser gives SharedArrayBuffer only to an isolated page. The build with
+  // more than one thread needs it.
   const canThread =
     typeof SharedArrayBuffer !== "undefined" && globalThis.crossOriginIsolated === true;
 
-  // webgpuAdapter gives the name of a GPU that the WebGPU build of llama.cpp
-  // can use, or an empty string.
-  //
-  // The test is not only for navigator.gpu. The backend of llama.cpp needs f16
-  // shaders, and it reports no device at all without them, and the build needs
-  // JSPI to wait for the GPU.
+  // webgpuAdapter gives the name of a usable GPU, or an empty string. llama.cpp
+  // needs f16 shaders and JSPI, so navigator.gpu alone is not sufficient.
   async function webgpuAdapter() {
     if (!globalThis.navigator || !navigator.gpu) {
       return "";
     }
     if (typeof WebAssembly.Suspending !== "function") {
-      // No JSPI, so the WebGPU build cannot run in this browser.
+      // Without JSPI the WebGPU build cannot run.
       return "";
     }
 
@@ -55,7 +50,7 @@
         return "";
       }
 
-      // The name of the GPU is only there if the browser gives it.
+      // The browser does not always give the name of the GPU.
       const info = adapter.info || {};
       return [info.vendor, info.architecture, info.device, info.description]
         .filter((part) => part)
@@ -66,7 +61,7 @@
   }
 
   function loadScript(url) {
-    // A classic worker takes importScripts. A page takes a script element.
+    // A classic worker uses importScripts. A page uses a script element.
     if (typeof importScripts === "function") {
       importScripts(url);
       return Promise.resolve();
@@ -93,8 +88,8 @@
       name = "yzma_wasm_webgpu";
       backend = "webgpu";
     } else if (mode === "webgpu") {
-      // The page asked for WebGPU and the browser cannot give it. Say so, and
-      // then go on with the CPU, which is what "auto" would do.
+      // The page asked for WebGPU, but the browser cannot give it. Continue
+      // with the CPU, which is the result that "auto" gives.
       console.warn("yzma: this browser has no WebGPU that llama.cpp can use, using the CPU");
       if (canThread) {
         name = "yzma_wasm_mt";
@@ -105,10 +100,8 @@
       backend = "cpu-threads";
     }
 
-    // The number of threads follows the machine. llama.cpp asks for four
-    // threads unless a caller says otherwise, and putting an image through a
-    // projector on four threads of a machine with many is slow, so the Go side
-    // reads this and says otherwise.
+    // llama.cpp uses four threads unless a caller changes it, which is slow on
+    // a machine with many cores. The Go side reads this value.
     const cores = Math.max(1, Math.min(globalThis.navigator?.hardwareConcurrency || 4, 16));
     const threads = backend === "cpu-threads" ? cores : 1;
 
@@ -131,13 +124,12 @@
       print: (text) => console.log(text),
       printErr: (text) => console.warn(text),
 
-      // The build with threads takes its pool size from here. A pool that is
-      // too small makes llama.cpp wait for threads that cannot start, because
-      // the thread that would start them is busy computing.
+      // A pool that is too small makes llama.cpp wait for threads that cannot
+      // start, because the thread that starts them is busy.
       pthreadPoolSize: threads,
     });
 
-    // From here on yzmaModule is the instance, which is what the Go code uses.
+    // From here yzmaModule is the instance, which the Go code uses.
     globalThis.yzmaModule = instance;
     return instance;
   })();


### PR DESCRIPTION
# Start the threads of llama.cpp correctly

The build of llama.cpp with more than one thread does not operate in a browser. The page loads the model, then it stops.

## The cause

Emscripten starts each thread with `new Worker(_scriptName)`.

```js
allocateUnusedWorker() {
  var pthreadMainJs = _scriptName;
  worker = new Worker(pthreadMainJs, { workerData: "em-pthread", name: "em-pthread" });
}
```

In a classic worker `_scriptName` is `self.location.href`. That is the URL of `wasm/worker.js` and not of `yzma_wasm_mt.js`. Each thread thus starts at the top of `worker.js` and runs all of it. It runs `yzma-loader.js` again, it starts a second Go program, and it replaces the `self.onmessage` handler that Emscripten set.

The threads do not register as threads. llama.cpp then waits at the first barrier for threads that cannot start. `wasm/README.md` gives a warning about this condition.

> A pool that is too small is worse than a small number of threads, because llama.cpp then waits for threads that cannot start.

In Chrome you see two signs. The WebGPU probe runs one time for each thread. Also, many `Uncaught Error: the Go program did not set its functions` messages occur at 0.2 s, before the model download starts.

## The correction

A thread has the name `em-pthread`. The module uses the same name for `ENVIRONMENT_IS_PTHREAD`. `worker.js` now runs `importScripts("./yzma-loader.js")`, which is all that a thread needs, and then stops. The page protocol and the Go program stay in the first worker.

`worker.js` also sets `yzmaMode = "cpu"` in a thread. Only the build with more than one thread has threads, so a thread does not need to look for a GPU. This decreases the WebGPU probe from one time for each thread to one time.

Most of the diff moves the existing code into a `run()` function. Use `git diff -w` to see the 21 lines that changed.

## Why the tests in Node did not find this fault

`wasm/node/run.js` makes the module itself and does not use `worker.js`. Thus `_scriptName` is `yzma_wasm_mt.js` and the threads start correctly. `make test-wasm-mt` passes before and after this change. Only a browser that uses `worker.js` has the fault.

# Tests

Chrome DevTools protocol, `wasm/index.html`, model Qwen2 0.5B Q4_K_M.

| Test | main | This branch |
| --- | --- | --- |
| Number of times that `yzma-loader.js` runs | 52 | 3 |
| Build with more than one thread | No answer | 53.3 tokens each second |
| Build with one thread, no COOP and COEP | Correct | Correct |
| Page at `?mode=cpu` | Correct | Correct |
| `make vet-wasm` | Pass | Pass |
| `make test-wasm` and `make test-wasm-mt` | Pass | Pass |

I found this fault when I made a chat page for GitHub Pages. A service worker gives the COOP and COEP headers there, thus the loader takes the build with more than one thread.

Note for later work. CI has no browser, thus no test protects this path. A test with Chrome in headless mode on `wasm/index.html` would find a fault of this type.