### PR TITLE
wasm: add chat templates and tool calling

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           make wasm-example
           make wasm-vlm-example
+          make wasm-tools-example
       - name: Cache test models
         id: cache-model
         uses: actions/cache@v4
@@ -86,5 +87,13 @@ jobs:
             --model $GITHUB_WORKSPACE/models/SmolVLM-256M-Instruct-Q8_0.gguf \
             --mmproj $GITHUB_WORKSPACE/models/mmproj-SmolVLM-256M-Instruct-Q8_0.gguf \
             --tokens 24 --mt
+      # A model of this size makes no tool call, thus this checks the round trip
+      # only: the chat template renders, tokens come out, and the program ends.
+      - name: Call tools in Node
+        run: |
+          node wasm/node/tools.js \
+            --dir $GITHUB_WORKSPACE/$WASM_DIR \
+            --model $GITHUB_WORKSPACE/models/SmolLM-135M.Q2_K.gguf \
+            --tokens 32
       - name: Build the examples with the standard toolchain
         run: make wasm-example-go

--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,17 @@ wasm-vlm-example: wasm-assets
 	tinygo build -target wasm -o $(WASM_DIR)/yzma-vlm.wasm ./examples/wasm/vlm
 	cp "$(shell tinygo env TINYGOROOT)/targets/wasm_exec.js" $(WASM_DIR)/
 
+# make wasm-tools-example to build the browser example that calls tools.
+wasm-tools-example: wasm-assets
+	tinygo build -target wasm -o $(WASM_DIR)/yzma-tools.wasm ./examples/wasm/tools
+	cp "$(shell tinygo env TINYGOROOT)/targets/wasm_exec.js" $(WASM_DIR)/
+
 # make wasm-example-go to build the same examples with the standard toolchain.
 # The binaries are larger, which helps when TinyGo cannot build a dependency.
 wasm-example-go: wasm-assets
 	GOOS=js GOARCH=wasm go build -o $(WASM_DIR)/yzma.wasm ./examples/wasm/chat
 	GOOS=js GOARCH=wasm go build -o $(WASM_DIR)/yzma-vlm.wasm ./examples/wasm/vlm
+	GOOS=js GOARCH=wasm go build -o $(WASM_DIR)/yzma-tools.wasm ./examples/wasm/tools
 	cp "$(shell go env GOROOT)/lib/wasm/wasm_exec.js" $(WASM_DIR)/
 
 # wasm-assets copies the JavaScript glue and the page into the build directory.
@@ -76,7 +82,7 @@ wasm-example-go: wasm-assets
 # program copies the correct one.
 wasm-assets:
 	mkdir -p $(WASM_DIR)
-	cp wasm/yzma-loader.js wasm/worker.js wasm/index.html wasm/vlm.html $(WASM_DIR)/
+	cp wasm/yzma-loader.js wasm/worker.js wasm/index.html wasm/vlm.html wasm/tools.html $(WASM_DIR)/
 
 # make download-llama.cpp-wasm to get the WebAssembly build of llama.cpp.
 download-llama.cpp-wasm:
@@ -93,7 +99,9 @@ serve-wasm:
 vet-wasm:
 	GOOS=js GOARCH=wasm go build -o /dev/null ./examples/wasm/chat
 	GOOS=js GOARCH=wasm go build -o /dev/null ./examples/wasm/vlm
-	GOOS=js GOARCH=wasm go vet ./pkg/llamawasm ./examples/wasm/chat ./examples/wasm/vlm
+	GOOS=js GOARCH=wasm go build -o /dev/null ./examples/wasm/tools
+	GOOS=js GOARCH=wasm go vet ./pkg/llamawasm ./pkg/message ./pkg/template \
+		./examples/wasm/chat ./examples/wasm/vlm ./examples/wasm/tools
 
 # make test-wasm to run the WebAssembly build in Node, with no browser.
 test-wasm:
@@ -120,6 +128,14 @@ test-wasm-vlm:
 		--model $(MODELS_DIR)/SmolVLM-256M-Instruct-Q8_0.gguf \
 		--mmproj $(MODELS_DIR)/mmproj-SmolVLM-256M-Instruct-Q8_0.gguf \
 		--tokens 24 --mt
+
+# make test-wasm-tools to call a tool in Node, with no browser.
+#
+# The default only checks the round trip, because a small model does not make a
+# tool call. Add --expect-tool get_weather with a model that is trained for it,
+# for example Qwen2.5-0.5B-Instruct.
+test-wasm-tools:
+	node wasm/node/tools.js --dir $(WASM_DIR) --model $(MODELS_DIR)/SmolLM-135M.Q2_K.gguf --tokens 32
 
 clean-wasm:
 	rm -rf $(WASM_DIR)

--- a/examples/wasm/tools/main.go
+++ b/examples/wasm/tools/main.go
@@ -1,0 +1,372 @@
+//go:build js && wasm
+
+// Tools calls functions with llama.cpp in a browser.
+//
+// The program has the same structure as examples/wasm/chat. It renders the chat
+// template of the model with the template package, offers the tools to it,
+// parses the tool calls that come back, runs them, and gives the results to the
+// model for a final answer.
+//
+// Build it with TinyGo.
+//
+//	tinygo build -target wasm -o build/wasm/yzma-tools.wasm ./examples/wasm/tools
+//
+// Or build it with the standard toolchain.
+//
+//	GOOS=js GOARCH=wasm go build -o build/wasm/yzma-tools.wasm ./examples/wasm/tools
+//
+// See wasm/README.md for the method to serve the result.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"syscall/js"
+	"time"
+
+	"github.com/hybridgroup/yzma/pkg/llamawasm"
+	"github.com/hybridgroup/yzma/pkg/message"
+	"github.com/hybridgroup/yzma/pkg/template"
+)
+
+// maxTurns is the number of times that the model can call a tool before it must
+// answer. A turn in a browser is slow, thus this is small.
+const maxTurns = 3
+
+const modelPath = "/models/model.gguf"
+
+var (
+	model   llamawasm.Model
+	ctx     llamawasm.Context
+	vocab   llamawasm.Vocab
+	sampler llamawasm.Sampler
+
+	// format is how this model writes a tool call. It comes from the name of
+	// the file of the model.
+	format message.Format
+)
+
+func main() {
+	if err := llamawasm.Load(""); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	llamawasm.LogSet(llamawasm.LogSilent())
+	llamawasm.Init()
+
+	// The page calls these.
+	js.Global().Set("yzmaLoadModel", js.FuncOf(loadModel))
+	js.Global().Set("yzmaOpenModel", js.FuncOf(openModel))
+	js.Global().Set("yzmaAsk", js.FuncOf(ask))
+
+	post("ready", backendReport())
+
+	// Keep the program alive so that the page can call into it.
+	<-make(chan struct{})
+}
+
+// loadModel(url) gets a model over the network and makes a context for it.
+func loadModel(this js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		post("error", "loadModel needs a URL")
+		return nil
+	}
+	url := args[0].String()
+
+	go func() {
+		post("status", "downloading the model")
+
+		err := llamawasm.FetchModelFile(modelPath, url, func(done, total int64) {
+			if total > 0 {
+				post("progress", fmt.Sprintf("%d%%", done*100/total))
+			}
+		})
+		if err != nil {
+			post("error", err.Error())
+			return
+		}
+
+		open(modelPath, url)
+	}()
+
+	return nil
+}
+
+// openModel(path) loads a model that is already in the filesystem of the
+// llama.cpp module. A test puts the file there itself.
+func openModel(this js.Value, args []js.Value) any {
+	path := modelPath
+	if len(args) > 0 && args[0].Truthy() {
+		path = args[0].String()
+	}
+
+	// The second argument gives the name of the original file, because the path
+	// in the filesystem of the module says nothing about the model.
+	name := path
+	if len(args) > 1 && args[1].Truthy() {
+		name = args[1].String()
+	}
+
+	go open(path, name)
+
+	return nil
+}
+
+// open loads the model at path and makes a context for it. The name tells which
+// format of tool call to expect.
+func open(path, name string) {
+	post("status", "loading the model")
+
+	params := llamawasm.ModelDefaultParams()
+
+	// A WebGPU build has a device, thus put each layer on it. A CPU build has no
+	// device and ignores this value.
+	if llamawasm.GPUDevice() != "" {
+		params.NGpuLayers = 999
+	}
+
+	var err error
+	if model, err = llamawasm.ModelLoadFromFile(path, params); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	ctxParams := llamawasm.ContextDefaultParams()
+
+	// Each turn repeats the whole conversation and the tools, thus this context
+	// is larger than the one of the chat example.
+	ctxParams.NCtx = 4096
+	ctxParams.NBatch = 512
+
+	if ctx, err = llamawasm.InitFromModel(model, ctxParams); err != nil {
+		post("error", err.Error())
+		return
+	}
+
+	vocab = llamawasm.ModelGetVocab(model)
+	format = message.DetectFormatFromPath(name)
+
+	post("loaded", llamawasm.ModelDesc(model)+", "+backendReport())
+}
+
+// backendReport gives the name of the backend that computes.
+func backendReport() string {
+	if device := llamawasm.GPUDevice(); device != "" {
+		return fmt.Sprintf("backend: %s (%s)", llamawasm.Backend(), device)
+	}
+	return fmt.Sprintf("backend: %s, %d threads", llamawasm.Backend(), llamawasm.Threads())
+}
+
+// ask(question, maxTokens) answers a question and calls tools if it needs them.
+func ask(this js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		post("error", "ask needs a question")
+		return nil
+	}
+	question := args[0].String()
+
+	maxTokens := int32(256)
+	if len(args) > 1 && args[1].Truthy() {
+		maxTokens = int32(args[1].Int())
+	}
+
+	go converse(question, maxTokens)
+
+	return nil
+}
+
+// converse asks the model, runs the tools that it calls, and asks again with
+// the results until the model gives an answer.
+func converse(question string, maxTokens int32) {
+	if model == 0 || ctx == 0 {
+		post("error", "load a model first")
+		return
+	}
+
+	tmpl, tools, messages := start(question)
+	began := time.Now()
+
+	var total int32
+
+	for turn := 0; turn < maxTurns; turn++ {
+		prompt, err := template.ApplyWithTools(tmpl, messages, tools, true)
+		if err != nil {
+			post("error", err.Error())
+			return
+		}
+
+		response, count, err := generate(prompt, maxTokens)
+		total += count
+		if err != nil {
+			post("error", err.Error())
+			return
+		}
+
+		calls := message.ParseToolCalls(response)
+		if len(calls) == 0 {
+			post("answer", message.StripMarkup(response))
+			break
+		}
+
+		messages = append(messages, message.Tool{
+			Role:      "assistant",
+			Content:   message.StripMarkup(response),
+			ToolCalls: calls,
+		})
+
+		for _, call := range calls {
+			messages = append(messages, run(call))
+		}
+	}
+
+	elapsed := time.Since(began).Seconds()
+	if elapsed > 0 {
+		post("done", fmt.Sprintf("%d tokens, %.2f tokens/s", total, float64(total)/elapsed))
+		return
+	}
+	post("done", fmt.Sprintf("%d tokens", total))
+}
+
+// start gives the template, the tools, and the first messages of a
+// conversation.
+func start(question string) (string, []message.ToolDefinition, []message.Message) {
+	tools := toolDefinitions()
+
+	tmpl := llamawasm.ModelChatTemplate(model, "")
+	if tmpl != "" {
+		return tmpl, tools, []message.Message{
+			message.Chat{Role: "user", Content: question},
+		}
+	}
+
+	// A model with no template of its own takes chatml, which has no tools
+	// branch. Thus the tools go in a system message instead.
+	tmpl, _ = template.BuiltinTemplate("chatml")
+
+	return tmpl, tools, []message.Message{
+		message.Chat{Role: "system", Content: toolsPrompt(tools)},
+		message.Chat{Role: "user", Content: question},
+	}
+}
+
+// toolsPrompt describes the tools for a template that cannot show them itself.
+func toolsPrompt(tools []message.ToolDefinition) string {
+	list, err := json.Marshal(tools)
+	if err != nil {
+		return ""
+	}
+
+	return "You can call these tools:\n" + string(list) +
+		"\n\nTo call one, answer with <tool_call>{\"name\": \"...\", \"arguments\": {...}}</tool_call>." +
+		" After you get the result, answer the question."
+}
+
+// run calls one tool and makes the message that holds its result.
+func run(call message.ToolCall) message.Message {
+	args, _ := json.Marshal(call.Function.Arguments)
+	post("tool", call.Function.Name+" "+string(args))
+
+	result, err := executeToolCall(call)
+	if err != nil {
+		result = "error: " + err.Error()
+	}
+	post("result", result)
+
+	return message.ToolResponse{
+		Role:    "tool",
+		Name:    call.Function.Name,
+		Content: result,
+	}
+}
+
+// generate makes text for a prompt and sends each piece to the page. It stops
+// at the end of the turn of the model.
+func generate(prompt string, maxTokens int32) (string, int32, error) {
+	// Each turn starts from an empty state, because the prompt holds the whole
+	// conversation.
+	if err := llamawasm.MemoryClear(ctx, true); err != nil {
+		return "", 0, err
+	}
+
+	if sampler != 0 {
+		llamawasm.SamplerFree(sampler)
+	}
+	sampler = llamawasm.SamplerChainInit(llamawasm.SamplerChainDefaultParams())
+	llamawasm.SamplerChainAdd(sampler, llamawasm.SamplerInitGreedy())
+
+	tokens := llamawasm.Tokenize(vocab, prompt, true, true)
+	if len(tokens) == 0 {
+		return "", 0, fmt.Errorf("the prompt has no tokens")
+	}
+
+	markers := message.StopMarkers(vocab, format)
+	batch := llamawasm.BatchGetOne(tokens)
+	buf := make([]byte, 64)
+
+	var text strings.Builder
+	var count int32
+
+	for pos := int32(0); pos < maxTokens; pos += batch.NTokens {
+		if _, err := llamawasm.Decode(ctx, batch); err != nil {
+			return text.String(), count, err
+		}
+
+		token := llamawasm.SamplerSample(sampler, ctx, -1)
+		if llamawasm.VocabIsEOG(vocab, token) {
+			break
+		}
+		llamawasm.SamplerAccept(sampler, token)
+
+		if n := llamawasm.TokenToPiece(vocab, token, buf, 0, true); n > 0 {
+			piece := string(buf[:n])
+			text.WriteString(piece)
+			post("token", piece)
+		}
+
+		count++
+
+		// A small model can write the next turn itself. Cut the text at the
+		// first marker and stop.
+		if cut, found := trim(text.String(), markers); found {
+			return cut, count, nil
+		}
+
+		batch = llamawasm.BatchGetOne([]llamawasm.Token{token})
+	}
+
+	return text.String(), count, nil
+}
+
+// trim cuts the text at the first marker that it holds.
+func trim(text string, markers []string) (string, bool) {
+	cut := -1
+	for _, marker := range markers {
+		if i := strings.Index(text, marker); i >= 0 && (cut < 0 || i < cut) {
+			cut = i
+		}
+	}
+
+	if cut < 0 {
+		return text, false
+	}
+
+	return text[:cut], true
+}
+
+// post sends a message to the container of this module. In a worker that is
+// the page, and in Node it is the console.
+func post(kind, text string) {
+	message := map[string]any{"kind": kind, "text": text}
+
+	if fn := js.Global().Get("postMessage"); fn.Type() == js.TypeFunction {
+		fn.Invoke(message)
+		return
+	}
+	if fn := js.Global().Get("yzmaOnMessage"); fn.Type() == js.TypeFunction {
+		fn.Invoke(message)
+		return
+	}
+	fmt.Printf("%s: %s\n", kind, text)
+}

--- a/examples/wasm/tools/tools.go
+++ b/examples/wasm/tools/tools.go
@@ -1,0 +1,124 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hybridgroup/yzma/pkg/message"
+)
+
+// toolDefinitions gives the tools that the model can call. They make their
+// answer from the arguments alone, thus a test always gets the same result.
+func toolDefinitions() []message.ToolDefinition {
+	return []message.ToolDefinition{
+		{
+			Type: "function",
+			Function: message.ToolFunctionDefinition{
+				Name:        "get_weather",
+				Description: "Get the current weather of a place",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"location": map[string]interface{}{
+							"type":        "string",
+							"description": "The name of the city",
+						},
+					},
+					"required": []string{"location"},
+				},
+			},
+		},
+		{
+			Type: "function",
+			Function: message.ToolFunctionDefinition{
+				Name:        "calculate",
+				Description: "Do arithmetic on two numbers",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"a": map[string]interface{}{
+							"type":        "number",
+							"description": "The first number",
+						},
+						"b": map[string]interface{}{
+							"type":        "number",
+							"description": "The second number",
+						},
+						"op": map[string]interface{}{
+							"type":        "string",
+							"description": "One of add, subtract, multiply, divide",
+						},
+					},
+					"required": []string{"a", "b", "op"},
+				},
+			},
+		},
+	}
+}
+
+// executeToolCall runs one tool call and gives its result as text.
+func executeToolCall(call message.ToolCall) (string, error) {
+	switch call.Function.Name {
+	case "get_weather":
+		location, ok := call.Function.Arguments["location"]
+		if !ok || location == "" {
+			return "", fmt.Errorf("get_weather needs a location")
+		}
+		return fmt.Sprintf("The weather in %s is 22 degrees Celsius and sunny.", location), nil
+
+	case "calculate":
+		a, err := argumentAsFloat(call.Function.Arguments, "a")
+		if err != nil {
+			return "", err
+		}
+		b, err := argumentAsFloat(call.Function.Arguments, "b")
+		if err != nil {
+			return "", err
+		}
+		return calculate(a, b, call.Function.Arguments["op"])
+
+	default:
+		return "", fmt.Errorf("unknown function %s", call.Function.Name)
+	}
+}
+
+// calculate does one operation on two numbers.
+func calculate(a, b float64, op string) (string, error) {
+	var result float64
+
+	switch op {
+	case "add", "+":
+		result = a + b
+	case "subtract", "-":
+		result = a - b
+	case "multiply", "*":
+		result = a * b
+	case "divide", "/":
+		if b == 0 {
+			return "", fmt.Errorf("cannot divide by zero")
+		}
+		result = a / b
+	default:
+		return "", fmt.Errorf("unknown operation %s", op)
+	}
+
+	return strconv.FormatFloat(result, 'f', -1, 64), nil
+}
+
+// argumentAsFloat reads one argument as a number. Every argument of a tool call
+// is text, thus this must parse it.
+func argumentAsFloat(args map[string]string, key string) (float64, error) {
+	value, ok := args[key]
+	if !ok {
+		return 0, fmt.Errorf("no argument %s", key)
+	}
+
+	f, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, fmt.Errorf("argument %s is not a number: %s", key, value)
+	}
+
+	return f, nil
+}

--- a/pkg/llamawasm/doc.go
+++ b/pkg/llamawasm/doc.go
@@ -73,6 +73,15 @@
 // Images only. Audio needs the page to decode and resample the samples, and
 // video needs ffmpeg in a subprocess.
 //
+// # Chat templates and tool calling
+//
+// [ModelChatTemplate] gives the template that the GGUF holds. The template and
+// message packages of yzma are pure Go, thus they render a conversation with
+// turns and parse the tool calls that come back. See examples/wasm/tools.
+//
+// [ChatApplyTemplate] takes one message only, which is sufficient for a
+// question about an image.
+//
 // # Limits
 //
 // A CPU build uses SIMD. WebGPU needs Chrome or Edge 137 or later, because the
@@ -84,4 +93,7 @@
 //
 // The package has the calls that text generation, embeddings, and images need.
 // It does not have audio, video, LoRA adapters, saved state, or quantization.
+//
+// The shim gives no end of turn token and no grammar sampler. Thus StopMarkers
+// of the message package approximates, and a grammar cannot force a tool call.
 package llamawasm

--- a/pkg/llamawasm/model.go
+++ b/pkg/llamawasm/model.go
@@ -109,7 +109,8 @@ func (m Model) String() string {
 // ChatApplyTemplate puts one message into the chat format of the model.
 //
 // One message is sufficient for a prompt with a question about an image. For a
-// chat with turns, use the template that [ModelChatTemplate] gives.
+// chat with turns or for tool calling, render the template that
+// [ModelChatTemplate] gives with the template package of yzma.
 //
 // addAssistant adds the start of the turn of the assistant. This makes the model
 // answer and not continue the message.

--- a/pkg/message/stopmarkers.go
+++ b/pkg/message/stopmarkers.go
@@ -1,22 +1,16 @@
 package message
 
-import (
-	"github.com/hybridgroup/yzma/pkg/llama"
-)
-
-// StopMarkers returns the set of string markers that should halt text generation
-// when any of them appears in the accumulated output.
+// StopMarkersFor returns the set of string markers that should halt text
+// generation when any of them appears in the accumulated output.
 //
-// It combines two sources:
-//  1. The model's own EOT (end-of-turn) token text, obtained directly from the
-//     vocabulary via VocabEOT so it works for any model regardless of format.
-//  2. Format-specific role/turn-boundary tokens that signal the model has started
-//     simulating the next conversation turn (fabricated Q&A).
+// The eot argument holds the end of turn text of the model, which a caller gets
+// from the vocabulary. StopMarkers gives it for a vocabulary of the backend of
+// the build.
 //
 // The caller should stop generation and discard everything from the first
 // matching marker onwards.
-func StopMarkers(vocab llama.Vocab, format Format) []string {
-	markers := eotMarkers(vocab)
+func StopMarkersFor(eot []string, format Format) []string {
+	markers := append([]string(nil), eot...)
 
 	switch format {
 	case FormatGemma3:
@@ -69,32 +63,15 @@ func StopMarkers(vocab llama.Vocab, format Format) []string {
 	return markers
 }
 
-// eotMarkers returns a deduplicated list of strings for the model's EOT token.
-// It uses TokenToPiece (the decoded form that appears in the output stream) as
-// the primary value, with VocabGetText as a fallback, so the returned string
-// matches exactly what will appear in accumulated output chunks.
-func eotMarkers(vocab llama.Vocab) []string {
-	eot := llama.VocabEOT(vocab)
-	if eot < 0 {
-		return nil
-	}
-
-	buf := make([]byte, 64)
-	n := llama.TokenToPiece(vocab, eot, buf, 0, true)
-	piece := ""
-	if n > 0 {
-		piece = string(buf[:n])
-	}
-
-	text := llama.VocabGetText(vocab, eot)
-
+// dedupe removes the empty strings and the repeated values, and keeps the order.
+func dedupe(values []string) []string {
 	seen := map[string]bool{}
-	var markers []string
-	for _, s := range []string{piece, text} {
+	var out []string
+	for _, s := range values {
 		if s != "" && !seen[s] {
 			seen[s] = true
-			markers = append(markers, s)
+			out = append(out, s)
 		}
 	}
-	return markers
+	return out
 }

--- a/pkg/message/stopmarkers_core_test.go
+++ b/pkg/message/stopmarkers_core_test.go
@@ -1,0 +1,76 @@
+package message
+
+import (
+	"slices"
+	"testing"
+)
+
+// allFormats holds each format, so a test covers the whole switch.
+var allFormats = []Format{
+	FormatAuto, FormatStandard, FormatQwen, FormatGLM,
+	FormatMistral, FormatGemma3, FormatGemma, FormatGPT, FormatPhi,
+}
+
+func TestStopMarkersForKeepsEOT(t *testing.T) {
+	eot := []string{"<|im_end|>", "<end_of_turn>"}
+
+	for _, format := range allFormats {
+		markers := StopMarkersFor(eot, format)
+		for _, want := range eot {
+			if !slices.Contains(markers, want) {
+				t.Errorf("format %d: no marker %q in %v", format, want, markers)
+			}
+		}
+	}
+}
+
+func TestStopMarkersForAlwaysHasToolResults(t *testing.T) {
+	for _, format := range allFormats {
+		markers := StopMarkersFor(nil, format)
+		if !slices.Contains(markers, "<tool_response") {
+			t.Errorf("format %d: no tool result marker in %v", format, markers)
+		}
+	}
+}
+
+func TestStopMarkersForFormatMarkers(t *testing.T) {
+	tests := []struct {
+		format Format
+		want   string
+	}{
+		{FormatGemma3, "<start_of_turn>user"},
+		{FormatGemma, "<|turn>user"},
+		{FormatQwen, "<|im_start|>"},
+		{FormatPhi, "<|end|>"},
+		{FormatStandard, "<|im_end|>"},
+		{FormatAuto, "<|im_end|>"},
+	}
+
+	for _, tt := range tests {
+		markers := StopMarkersFor(nil, tt.format)
+		if !slices.Contains(markers, tt.want) {
+			t.Errorf("format %d: no marker %q in %v", tt.format, tt.want, markers)
+		}
+	}
+}
+
+// StopMarkersFor must not write into the slice of the caller.
+func TestStopMarkersForCopiesEOT(t *testing.T) {
+	eot := make([]string, 1, 8)
+	eot[0] = "<|im_end|>"
+
+	StopMarkersFor(eot, FormatQwen)
+
+	if len(eot) != 1 || eot[0] != "<|im_end|>" {
+		t.Errorf("the eot slice changed: %v", eot)
+	}
+}
+
+func TestDedupe(t *testing.T) {
+	got := dedupe([]string{"a", "", "b", "a", "", "c"})
+	want := []string{"a", "b", "c"}
+
+	if !slices.Equal(got, want) {
+		t.Errorf("dedupe = %v, want %v", got, want)
+	}
+}

--- a/pkg/message/stopmarkers_llama.go
+++ b/pkg/message/stopmarkers_llama.go
@@ -1,0 +1,33 @@
+//go:build !(js && wasm)
+
+package message
+
+import (
+	"github.com/hybridgroup/yzma/pkg/llama"
+)
+
+// StopMarkers returns the markers that should halt generation for a vocabulary
+// and a format. See StopMarkersFor.
+func StopMarkers(vocab llama.Vocab, format Format) []string {
+	return StopMarkersFor(eotMarkers(vocab), format)
+}
+
+// eotMarkers returns a deduplicated list of strings for the model's EOT token.
+// It uses TokenToPiece (the decoded form that appears in the output stream) as
+// the primary value, with VocabGetText as a fallback, so the returned string
+// matches exactly what will appear in accumulated output chunks.
+func eotMarkers(vocab llama.Vocab) []string {
+	eot := llama.VocabEOT(vocab)
+	if eot < 0 {
+		return nil
+	}
+
+	buf := make([]byte, 64)
+	n := llama.TokenToPiece(vocab, eot, buf, 0, true)
+	piece := ""
+	if n > 0 {
+		piece = string(buf[:n])
+	}
+
+	return dedupe([]string{piece, llama.VocabGetText(vocab, eot)})
+}

--- a/pkg/message/stopmarkers_test.go
+++ b/pkg/message/stopmarkers_test.go
@@ -1,3 +1,5 @@
+//go:build !(js && wasm)
+
 package message
 
 import (

--- a/pkg/message/stopmarkers_wasm.go
+++ b/pkg/message/stopmarkers_wasm.go
@@ -1,0 +1,48 @@
+//go:build js && wasm
+
+package message
+
+import (
+	"github.com/hybridgroup/yzma/pkg/llamawasm"
+)
+
+// eotCandidates are the end of turn tokens of the usual instruct models. The
+// shim has no call that gives this token, thus the vocabulary decides which of
+// these are real.
+var eotCandidates = []string{
+	"<|im_end|>",
+	"<end_of_turn>",
+	"<|eot_id|>",
+	"<|end|>",
+	"<|endoftext|>",
+}
+
+// StopMarkers returns the markers that should halt generation for a vocabulary
+// and a format. See StopMarkersFor.
+func StopMarkers(vocab llamawasm.Vocab, format Format) []string {
+	return StopMarkersFor(eotMarkers(vocab), format)
+}
+
+// eotMarkers gives the end of turn text of the model.
+//
+// The shim has no VocabEOT and no VocabGetText, thus this takes the text of the
+// end of sequence token, which is the same token for most instruct models, and
+// adds each candidate that the vocabulary holds as one token.
+func eotMarkers(vocab llamawasm.Vocab) []string {
+	buf := make([]byte, 64)
+
+	var markers []string
+	if eos := llamawasm.VocabEOS(vocab); eos >= 0 {
+		if n := llamawasm.TokenToPiece(vocab, eos, buf, 0, true); n > 0 {
+			markers = append(markers, string(buf[:n]))
+		}
+	}
+
+	for _, s := range eotCandidates {
+		if len(llamawasm.Tokenize(vocab, s, false, true)) == 1 {
+			markers = append(markers, s)
+		}
+	}
+
+	return dedupe(markers)
+}

--- a/pkg/template/jinja.go
+++ b/pkg/template/jinja.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"embed"
+	"encoding/json"
 	"strings"
 
 	"github.com/ardanlabs/jinja"
@@ -30,6 +31,10 @@ type Options struct {
 	// directly. Models whose templates do not use this variable ignore it.
 	// Defaults to true (thinking enabled) so existing callers are unaffected.
 	EnableThinking bool
+
+	// Tools are the tool definitions offered to the model. When empty the tools
+	// variable stays undefined, thus a template takes its plain path.
+	Tools []message.ToolDefinition
 }
 
 // DefaultOptions returns Options with all fields set to their defaults.
@@ -65,9 +70,45 @@ func ApplyWithOptions(tmpl string, messages []message.Message, addAssistantPromp
 		msgs[i] = msg
 	}
 
-	return t.Render(map[string]any{
+	vars := map[string]any{
 		"messages":              msgs,
 		"add_generation_prompt": addAssistantPrompt,
 		"enable_thinking":       opts.EnableThinking,
-	})
+	}
+
+	if len(opts.Tools) > 0 {
+		tools, err := toolsContext(opts.Tools)
+		if err != nil {
+			return "", err
+		}
+		vars["tools"] = tools
+	}
+
+	return t.Render(vars)
+}
+
+// ApplyWithTools applies a jinja chat template and offers the tool definitions
+// to it. A template that has no tools branch ignores them.
+func ApplyWithTools(tmpl string, messages []message.Message, tools []message.ToolDefinition, addAssistantPrompt bool) (string, error) {
+	opts := DefaultOptions()
+	opts.Tools = tools
+
+	return ApplyWithOptions(tmpl, messages, addAssistantPrompt, opts)
+}
+
+// toolsContext turns the tool definitions into the plain values that a template
+// needs. It goes through JSON, thus tojson gives the form that the templates of
+// the models expect.
+func toolsContext(tools []message.ToolDefinition) ([]any, error) {
+	raw, err := json.Marshal(tools)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
 }

--- a/pkg/template/tools_test.go
+++ b/pkg/template/tools_test.go
@@ -1,0 +1,119 @@
+package template
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hybridgroup/yzma/pkg/message"
+)
+
+func testTools() []message.ToolDefinition {
+	return []message.ToolDefinition{
+		{
+			Type: "function",
+			Function: message.ToolFunctionDefinition{
+				Name:        "get_weather",
+				Description: "Get the weather of a place",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"location": map[string]interface{}{"type": "string"},
+					},
+					"required": []interface{}{"location"},
+				},
+			},
+		},
+	}
+}
+
+func qwenTemplate(t *testing.T) string {
+	t.Helper()
+
+	tmpl, ok := BuiltinTemplate("qwen2.5-instruct")
+	if !ok {
+		t.Fatal("no qwen2.5-instruct template")
+	}
+
+	return tmpl
+}
+
+func TestApplyWithToolsRendersTools(t *testing.T) {
+	msgs := []message.Message{message.Chat{Role: "user", Content: "weather in Paris?"}}
+
+	got, err := ApplyWithTools(qwenTemplate(t), msgs, testTools(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"<tools>", "get_weather", "location"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("no %q in the prompt:\n%s", want, got)
+		}
+	}
+}
+
+// A template must take its plain path when there are no tools.
+func TestApplyWithoutToolsHasNoToolsBlock(t *testing.T) {
+	msgs := []message.Message{message.Chat{Role: "user", Content: "weather in Paris?"}}
+	tmpl := qwenTemplate(t)
+
+	got, err := Apply(tmpl, msgs, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(got, "<tools>") {
+		t.Errorf("a tools block with no tools:\n%s", got)
+	}
+
+	// An empty slice must give the same result as none at all.
+	empty, err := ApplyWithTools(tmpl, msgs, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if empty != got {
+		t.Errorf("nil tools changed the prompt:\n%s\n\n%s", got, empty)
+	}
+}
+
+// The template writes each tool with tojson, thus the result must parse and
+// must keep the fields of the definition.
+func TestToolsContextKeepsFields(t *testing.T) {
+	got, err := toolsContext(testTools())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d tools, want 1", len(got))
+	}
+
+	raw, err := json.Marshal(got[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var tool struct {
+		Type     string `json:"type"`
+		Function struct {
+			Name        string                 `json:"name"`
+			Description string                 `json:"description"`
+			Parameters  map[string]interface{} `json:"parameters"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(raw, &tool); err != nil {
+		t.Fatal(err)
+	}
+
+	if tool.Type != "function" {
+		t.Errorf("type = %q, want function", tool.Type)
+	}
+	if tool.Function.Name != "get_weather" {
+		t.Errorf("name = %q, want get_weather", tool.Function.Name)
+	}
+	if tool.Function.Parameters["type"] != "object" {
+		t.Errorf("no parameters in %v", tool.Function.Parameters)
+	}
+}

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -39,9 +39,11 @@ for each token, as in the `examples/hello` program.
 | `worker.js` | Runs llama.cpp and the Go program in a Web Worker and sends each piece of text to the page. |
 | `index.html` | A page that loads a model and makes text. |
 | `vlm.html` | A page that asks a question about an image. |
+| `tools.html` | A page where the model calls tools. |
 | `serve/main.go` | A static server that sets the headers for a build with more than one thread. |
 | `node/run.js` | Runs the same build in Node with no browser. CI uses this test. |
 | `node/vlm.js` | The same test for an image model. It makes its own pixels, because Node has no canvas. |
+| `node/tools.js` | The same test for tool calling. |
 
 ## Build and run
 
@@ -52,13 +54,15 @@ make download-llama.cpp-wasm
 # build the programs with TinyGo
 make wasm-example
 make wasm-vlm-example
+make wasm-tools-example
 
 # serve them
 make serve-wasm
 ```
 
-Then <http://localhost:8080> is the chat page and
-<http://localhost:8080/vlm.html> is the page that takes an image.
+Then <http://localhost:8080> is the chat page,
+<http://localhost:8080/vlm.html> is the page that takes an image, and
+<http://localhost:8080/tools.html> is the page where the model calls tools.
 
 Add `?mode=cpu` or `?mode=webgpu` to the URL of a page to select the backend
 yourself.
@@ -258,6 +262,40 @@ the CORS headers. Hugging Face sends them, thus the model in `index.html` comes
 down without a change. A model on a host with no CORS headers needs a copy on
 the origin of the page.
 
+## Tool calling
+
+`tools.html` and `examples/wasm/tools` let the model call a function. The
+`pkg/template` and `pkg/message` packages are pure Go, thus they build for
+WebAssembly and the browser gets the same tool calling as the host.
+
+`llamawasm.ModelChatTemplate` gives the template that the GGUF holds.
+`template.ApplyWithTools` renders it with the whole conversation and the tool
+definitions, so a template that has a `tools` branch writes the tools itself.
+
+```go
+tmpl := llamawasm.ModelChatTemplate(model, "")
+prompt, err := template.ApplyWithTools(tmpl, messages, tools, true)
+```
+
+`message.ParseToolCalls` reads the calls out of the answer. The program runs
+them, appends a `message.Tool` and a `message.ToolResponse`, and renders again
+for the final answer.
+
+A model must be trained for tool calls to make one. Qwen2.5-0.5B-Instruct is
+about the smallest that works. `make test-wasm-tools` uses a smaller model and
+checks the round trip only, because that model makes no call. Add
+`--expect-tool get_weather` to require one.
+
+`llamawasm.ChatApplyTemplate` takes one message only. Use `pkg/template` for a
+conversation with turns.
+
+### Stop markers
+
+`message.StopMarkers` cuts the text where a model starts to write the next turn.
+The shim has no call for the end of turn token, thus the WebAssembly build takes
+the text of the end of sequence token and probes a short list of the usual
+markers. The host build reads the token itself.
+
 ## Limits
 
 - WebGPU needs Chrome or Edge 137 or later, and an adapter with f16 shaders. All
@@ -270,3 +308,6 @@ the origin of the page.
   in splits.
 - `pkg/llamawasm` has the calls for text generation, embeddings, and images. It
   does not have audio, video, LoRA adapters, saved state, or quantization.
+- The shim gives no end of turn token and no grammar sampler. Thus
+  `message.StopMarkers` approximates, and a tool call cannot be forced by a
+  grammar as it can on a host.

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -36,6 +36,10 @@
       <code>pkg/llamawasm</code> package of yzma. Everything runs in a Web
       Worker in this browser.
     </p>
+    <p>
+      <a href="./vlm.html">A model with eyes</a> asks a question about an image,
+      and <a href="./tools.html">tool calling</a> lets the model call a function.
+    </p>
     <p id="backend">looking for a backend</p>
 
     <label for="model">Model URL (GGUF, less than 2 GB)</label>

--- a/wasm/node/tools.js
+++ b/wasm/node/tools.js
@@ -1,0 +1,161 @@
+// tools.js runs the tool calling build of yzma in Node, without a browser.
+//
+// CI uses this test. It loads a model, asks a question, and checks that the
+// round trip works: the chat template renders, tokens come out, and the program
+// finishes. A model that is trained for tool calls also calls one, which
+// --expect-tool checks.
+//
+// Usage.
+//   node wasm/node/tools.js --dir build/wasm --model ~/models/model.gguf \
+//       --question "What is the weather in Paris?" --tokens 96 \
+//       [--expect-tool get_weather] [--mt] [--webgpu]
+//
+// --mt selects the build with more than one thread, and --webgpu asks for the
+// WebGPU build. See run.js for what those mean in Node.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function option(name, fallback) {
+  const i = process.argv.indexOf("--" + name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : fallback;
+}
+
+const dir = path.resolve(option("dir", "build/wasm"));
+const modelFile = option("model", "");
+const question = option("question", "What is the weather in Paris?");
+const maxTokens = parseInt(option("tokens", "96"), 10);
+const expectTool = option("expect-tool", "");
+const mt = process.argv.includes("--mt");
+const webgpu = process.argv.includes("--webgpu");
+
+// This harness replaces yzma-loader.js. It makes the same choice as the loader
+// where there is no WebGPU, thus it falls back to the CPU.
+let moduleName = "yzma_wasm.js";
+if (mt) {
+  moduleName = "yzma_wasm_mt.js";
+}
+if (webgpu) {
+  if (globalThis.navigator && globalThis.navigator.gpu) {
+    moduleName = "yzma_wasm_webgpu.js";
+  } else {
+    console.log("[loader] no WebGPU here, using the build on the CPU");
+  }
+}
+
+if (!modelFile) {
+  console.error("give a model with --model");
+  process.exit(2);
+}
+
+// The output of the Go program comes here, because Node has no postMessage.
+const output = [];
+const toolCalls = [];
+
+let programIsReady;
+const programReady = new Promise((resolve) => {
+  programIsReady = resolve;
+});
+
+globalThis.yzmaOnMessage = (message) => {
+  if (message.kind === "ready" || message.kind === "error") {
+    programIsReady();
+  }
+  if (message.kind === "token") {
+    output.push(message.text);
+    process.stdout.write(message.text);
+    return;
+  }
+  if (message.kind === "tool") {
+    toolCalls.push(message.text);
+  }
+  console.log("\n[" + message.kind + "] " + message.text);
+};
+
+async function main() {
+  // Select the build with one thread. Node has no crossOriginIsolated, thus
+  // the loader makes the same choice.
+  globalThis.crossOriginIsolated = mt;
+  globalThis.yzmaBase = dir;
+
+  const factory = require(path.join(dir, moduleName));
+  // The same values that the JavaScript glue selects. The pool follows the
+  // machine and the Go side reads the thread count.
+  const threads = mt ? Math.max(1, Math.min(require("node:os").cpus().length, 16)) : 1;
+
+  const llamaModule = await factory({
+    locateFile: (file) => path.join(dir, file),
+    print: () => {},
+    printErr: () => {},
+    pthreadPoolSize: threads,
+  });
+
+  globalThis.yzmaModule = llamaModule;
+  globalThis.yzmaReady = Promise.resolve(llamaModule);
+  globalThis.yzmaThreaded = mt;
+  globalThis.yzmaThreads = threads;
+  globalThis.yzmaBackend = moduleName.includes("webgpu")
+    ? "webgpu"
+    : mt
+      ? "cpu-threads"
+      : "cpu";
+
+  // Put the model in the filesystem of the module. A browser instead gets it
+  // from the network with FetchModelFile.
+  llamaModule.FS.mkdirTree("/models");
+  llamaModule.FS.writeFile("/models/model.gguf", fs.readFileSync(modelFile));
+
+  require(path.join(dir, "wasm_exec.js"));
+
+  const go = new Go();
+  const binary = fs.readFileSync(path.join(dir, "yzma-tools.wasm"));
+  const result = await WebAssembly.instantiate(binary, go.importObject);
+
+  // The program blocks at the end of main, thus do not wait for this.
+  go.run(result.instance);
+
+  // Wait for the ready message. The backend needs time to start, and more
+  // time with WebGPU.
+  await programReady;
+
+  const done = new Promise((resolve) => {
+    const previous = globalThis.yzmaOnMessage;
+    globalThis.yzmaOnMessage = (message) => {
+      previous(message);
+      if (message.kind === "loaded") {
+        globalThis.yzmaAsk(question, maxTokens);
+      }
+      if (message.kind === "done" || message.kind === "error") {
+        resolve(message);
+      }
+    };
+  });
+
+  // The name of the file of the model selects the format of the tool calls.
+  globalThis.yzmaOpenModel("/models/model.gguf", path.basename(modelFile));
+
+  const last = await done;
+  console.log();
+
+  if (last.kind === "error") {
+    process.exit(1);
+  }
+
+  if (output.join("").length === 0) {
+    console.error("no tokens came out");
+    process.exit(1);
+  }
+
+  // Only a model that is trained for tool calls makes one, thus this is a
+  // choice of the caller and not the default.
+  if (expectTool && !toolCalls.some((call) => call.startsWith(expectTool))) {
+    console.error("the model did not call " + expectTool);
+    console.error("  calls: " + JSON.stringify(toolCalls));
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/wasm/tools.html
+++ b/wasm/tools.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>yzma: tool calling in WebAssembly</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 0 auto;
+        max-width: 46rem;
+        padding: 1.5rem;
+        line-height: 1.5;
+      }
+      label { display: block; margin-top: 1rem; font-weight: 600; }
+      input, textarea, button { font: inherit; width: 100%; box-sizing: border-box; }
+      input, textarea { padding: 0.4rem; }
+      button { margin-top: 0.75rem; padding: 0.5rem; cursor: pointer; }
+      #status { margin-top: 1rem; color: #555; }
+      #trace { margin-top: 1rem; }
+      .step {
+        margin-bottom: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        border-left: 3px solid #ccc;
+        white-space: pre-wrap;
+        font-family: ui-monospace, monospace;
+        font-size: 0.9rem;
+        background: #fafafa;
+      }
+      .step.tool { border-color: #b8860b; }
+      .step.result { border-color: #2e8b57; }
+      .step .kind { display: block; font-weight: 600; color: #555; }
+      #output {
+        margin-top: 1rem;
+        padding: 0.75rem;
+        min-height: 6rem;
+        white-space: pre-wrap;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Tool calling, in WebAssembly</h1>
+    <p>
+      llama.cpp runs as a WebAssembly module. The program that drives it is Go,
+      compiled by TinyGo, through the <code>pkg/llamawasm</code> package of yzma.
+      The <code>pkg/template</code> package renders the chat template of the
+      model and offers it the tools, and <code>pkg/message</code> parses the tool
+      calls that come back. The page runs no model logic itself.
+    </p>
+    <p>
+      Two tools are available. <code>get_weather</code> gives the weather of a
+      city, and <code>calculate</code> does arithmetic on two numbers. Both
+      answer from their arguments alone.
+    </p>
+    <p id="backend">looking for a backend</p>
+
+    <label for="model">Model URL (GGUF)</label>
+    <input
+      id="model"
+      value="https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q8_0.gguf"
+    />
+    <button id="load">Load the model</button>
+
+    <label for="question">Question</label>
+    <textarea id="question" rows="2">What is the weather in Paris?</textarea>
+    <button id="ask" disabled>Ask</button>
+
+    <p>
+      A model must be trained for tool calls to make one. A small chat model
+      answers in plain text instead, which the page shows as the answer.
+    </p>
+
+    <div id="status">starting</div>
+    <div id="trace"></div>
+    <div id="output"></div>
+
+    <script>
+      const status = document.getElementById("status");
+      const output = document.getElementById("output");
+      const trace = document.getElementById("trace");
+      const askButton = document.getElementById("ask");
+
+      const mode = new URLSearchParams(location.search).get("mode");
+      const worker = new Worker(
+        "./worker.js?program=yzma-tools.wasm" + (mode ? "&mode=" + encodeURIComponent(mode) : ""),
+      );
+
+      // step adds one line of the round trip, so a reader sees each tool call
+      // and its result apart from the text of the model.
+      function step(kind, label, text) {
+        const box = document.createElement("div");
+        box.className = "step " + kind;
+
+        const name = document.createElement("span");
+        name.className = "kind";
+        name.textContent = label;
+
+        box.appendChild(name);
+        box.appendChild(document.createTextNode(text));
+        trace.appendChild(box);
+      }
+
+      worker.onmessage = (event) => {
+        const { kind, text } = event.data || {};
+        switch (kind) {
+          case "ready":
+            document.getElementById("backend").textContent = text;
+            status.textContent = "ready";
+            break;
+          case "loaded":
+            status.textContent = "model loaded: " + text;
+            askButton.disabled = false;
+            break;
+          case "token":
+            output.textContent += text;
+            break;
+          case "tool":
+            step("tool", "the model calls", text);
+            output.textContent = "";
+            break;
+          case "result":
+            step("result", "the tool answers", text);
+            break;
+          case "answer":
+            output.textContent = text;
+            break;
+          case "done":
+            status.textContent = text;
+            askButton.disabled = false;
+            break;
+          case "error":
+            status.textContent = "error: " + text;
+            askButton.disabled = false;
+            break;
+          default:
+            status.textContent = kind + ": " + text;
+        }
+      };
+
+      document.getElementById("load").onclick = () => {
+        status.textContent = "loading";
+        askButton.disabled = true;
+        worker.postMessage({ kind: "load", url: document.getElementById("model").value });
+      };
+
+      askButton.onclick = () => {
+        output.textContent = "";
+        trace.textContent = "";
+        status.textContent = "asking";
+        askButton.disabled = true;
+
+        worker.postMessage({
+          kind: "ask",
+          question: document.getElementById("question").value,
+          maxTokens: 256,
+        });
+      };
+    </script>
+  </body>
+</html>

--- a/wasm/worker.js
+++ b/wasm/worker.js
@@ -7,9 +7,10 @@
 //
 //   { kind: "load", url: "<model URL>" }
 //   { kind: "generate", prompt: "<text>", maxTokens: 128 }
+//   { kind: "ask", question: "<text>", maxTokens: 256 }
 //
 // The worker sends back { kind, text } messages, where kind is one of ready,
-// status, progress, loaded, token, done, or error.
+// status, progress, loaded, token, tool, result, answer, done, or error.
 
 // Emscripten starts each thread with new Worker(_scriptName), which in a
 // classic worker is this file. A thread must only load llama.cpp.
@@ -99,6 +100,11 @@ function run() {
           break;
         case "generate":
           self.yzmaGenerate(message.prompt, message.maxTokens || 128);
+          break;
+        case "ask":
+          // The tools page sends a question, not a prompt. The Go program
+          // renders the chat template of the model itself.
+          self.yzmaAsk(message.question, message.maxTokens || 256);
           break;
         case "describe":
           // The image comes as RGBA from a canvas of the page.


### PR DESCRIPTION
## What this does

Chat templates and tool calling now work in the browser. The model renders its
own chat template, gets the tool definitions, calls a tool, and answers with the
result.

## Why

The `message` and `template` packages are pure Go, but they could not build for
WebAssembly. `pkg/message/stopmarkers.go` imported `pkg/llama`, which imports
`jupiterrider/ffi`, and that has no build for `js/wasm`.

```
GOOS=js GOARCH=wasm go build ./pkg/template
github.com/jupiterrider/ffi: build constraints exclude all Go files
```

Thus a browser could only send one message at a time through
`llamawasm.ChatApplyTemplate`, and it had no way to parse a tool call.

## The change

**Break the import.** `StopMarkersFor(eot []string, format Format)` holds the
format switch and has no import. A build tag selects the wrapper:
`stopmarkers_llama.go` keeps the native signature as it was, and
`stopmarkers_wasm.go` gives the same call shape for `llamawasm.Vocab`.

The shim has no `yzma_vocab_eot` and no `yzma_vocab_get_text`, thus the
WebAssembly wrapper takes the text of the end of sequence token and probes the
usual markers with `Tokenize`. This needs no ABI change.
hybridgroup/llama-cpp-builder#38 asks for the two calls, and the code detects
them, thus it can drop the approximation later.

**Offer the tools to the template.** `Options.Tools` and `ApplyWithTools` put a
`tools` variable in the render context, which is what the templates of Qwen,
Hermes and Llama 3.1 expect. The variable stays undefined when there are no
tools, thus every existing render is byte identical. This also makes the
`{%- if tools %}` branch of the bundled `qwen2.5-instruct.jinja` work, which was
dead code until now.

**A new example.** `examples/wasm/tools` with `wasm/tools.html`, a Node harness,
Makefile targets, and CI.

## Verified

The round trip with Qwen3-0.6B in Node, on TinyGo and on the standard toolchain,
with the same output from both:

```
[tool]   get_weather {"location":"Paris"}
[result] The weather in Paris is 22 degrees Celsius and sunny.
[answer] The weather in Paris is 22 degrees Celsius and sunny.
```

`make test-wasm-tools` runs SmolLM-135M, which has no template of its own and
makes no tool call. It takes the chatml fallback and answers in plain text, which
checks that a small model does not stop the program.

`make test-wasm` gives the same result as before.

## Notes

`yzma-tools.wasm` is 3.36 MB against 818 KB for the chat example, because
`regexp` and `encoding/json` reach a TinyGo binary here for the first time.
`-no-debug -opt=z` brings it to 1.52 MB. The target stays the same as the others
for now.
