### PR TITLE
download: support llama.cpp ROCm 10.0 asset names from b10767

### DIFF
--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -43,24 +43,47 @@ func (f ResolverFunc) Resolve(target Target) ([]string, error) { return f(target
 // release pages. [Install] uses it when no resolver is given.
 var DefaultResolver Resolver = ResolverFunc(defaultResolve)
 
-// rocmRenameBuild is the first llama.cpp nightly build that names its ROCm assets
-// after the ROCm version on both platforms. Builds before it publish
-// "ubuntu-rocm-7.2-x64.tar.gz" and "win-hip-radeon-x64.zip"; b10356 and newer
-// publish "ubuntu-rocm-7.14-x64.tar.gz" and "win-rocm-7.14-x64.zip".
-const rocmRenameBuild = 10356
+// llama.cpp renamed its ROCm assets at these two builds.
+const (
+	rocmRenameBuild = 10356
+	rocm10Build     = 10767
+)
 
-// legacyROCmNames tells whether tag is a nightly build old enough to carry the ROCm
-// asset names used before [rocmRenameBuild]. A tag that is not a nightly build, such
-// as a tagged release resolved without its upstream build, takes the current names.
-func legacyROCmNames(tag string) bool {
+// rocmVersionNames holds the ROCm asset names for one build range.
+type rocmVersionNames struct {
+	linux   string
+	windows string
+}
+
+// rocmNames reports the ROCm asset names that tag published. A tag that is not a
+// nightly build takes the newest names.
+func rocmNames(tag string) rocmVersionNames {
+	current := rocmVersionNames{
+		linux:   "llama-%s-bin-ubuntu-rocm-10.0-x64.tar.gz",
+		windows: "llama-%s-bin-win-rocm-10.0-x64.zip",
+	}
 	if !nightlyPattern.MatchString(tag) {
-		return false
+		return current
 	}
 	build, err := strconv.Atoi(tag[1:])
 	if err != nil {
-		return false
+		return current
 	}
-	return build < rocmRenameBuild
+
+	switch {
+	case build < rocmRenameBuild:
+		return rocmVersionNames{
+			linux:   "llama-%s-bin-ubuntu-rocm-7.2-x64.tar.gz",
+			windows: "llama-%s-bin-win-hip-radeon-x64.zip",
+		}
+	case build < rocm10Build:
+		return rocmVersionNames{
+			linux:   "llama-%s-bin-ubuntu-rocm-7.14-x64.tar.gz",
+			windows: "llama-%s-bin-win-rocm-7.14-x64.zip",
+		}
+	default:
+		return current
+	}
 }
 
 // defaultResolve is the built-in platform table.
@@ -109,11 +132,7 @@ func defaultResolve(target Target) ([]string, error) {
 			if arch != AMD64 {
 				return nil, errors.New("precompiled binaries for Linux ARM64 ROCm are not available")
 			}
-			if legacyROCmNames(tag) {
-				filename = fmt.Sprintf("llama-%s-bin-ubuntu-rocm-7.2-x64.tar.gz", tag)
-				break
-			}
-			filename = fmt.Sprintf("llama-%s-bin-ubuntu-rocm-7.14-x64.tar.gz", tag)
+			filename = fmt.Sprintf(rocmNames(tag).linux, tag)
 		default:
 			return nil, ErrUnknownProcessor
 		}
@@ -222,11 +241,7 @@ func defaultResolve(target Target) ([]string, error) {
 			if arch != AMD64 {
 				return nil, errors.New("precompiled binaries for Windows ARM64 ROCm are not available")
 			}
-			if legacyROCmNames(tag) {
-				filename = fmt.Sprintf("llama-%s-bin-win-hip-radeon-x64.zip", tag)
-				break
-			}
-			filename = fmt.Sprintf("llama-%s-bin-win-rocm-7.14-x64.zip", tag)
+			filename = fmt.Sprintf(rocmNames(tag).windows, tag)
 		default:
 			return nil, ErrUnknownProcessor
 		}

--- a/pkg/download/resolver_test.go
+++ b/pkg/download/resolver_test.go
@@ -335,8 +335,8 @@ func TestInstallDefaultVersionDoesNotFallBack(t *testing.T) {
 	}
 }
 
-// llama.cpp renamed its ROCm assets at build b10356, so resolution has to follow the
-// naming that the requested build actually published.
+// llama.cpp renamed its ROCm assets at builds b10356 and b10767. Resolution must
+// follow the names that the requested build published.
 func TestDefaultResolverROCmNaming(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -347,9 +347,15 @@ func TestDefaultResolverROCmNaming(t *testing.T) {
 		{"linux before the rename", Linux, "b10355", "llama-b10355-bin-ubuntu-rocm-7.2-x64.tar.gz"},
 		{"linux at the rename", Linux, "b10356", "llama-b10356-bin-ubuntu-rocm-7.14-x64.tar.gz"},
 		{"linux after the rename", Linux, "b10705", "llama-b10705-bin-ubuntu-rocm-7.14-x64.tar.gz"},
+		{"linux before the ROCm 10 rename", Linux, "b10766", "llama-b10766-bin-ubuntu-rocm-7.14-x64.tar.gz"},
+		{"linux at the ROCm 10 rename", Linux, "b10767", "llama-b10767-bin-ubuntu-rocm-10.0-x64.tar.gz"},
+		{"linux after the ROCm 10 rename", Linux, "b10800", "llama-b10800-bin-ubuntu-rocm-10.0-x64.tar.gz"},
 		{"windows before the rename", Windows, "b10355", "llama-b10355-bin-win-hip-radeon-x64.zip"},
 		{"windows at the rename", Windows, "b10356", "llama-b10356-bin-win-rocm-7.14-x64.zip"},
 		{"windows after the rename", Windows, "b10705", "llama-b10705-bin-win-rocm-7.14-x64.zip"},
+		{"windows before the ROCm 10 rename", Windows, "b10766", "llama-b10766-bin-win-rocm-7.14-x64.zip"},
+		{"windows at the ROCm 10 rename", Windows, "b10767", "llama-b10767-bin-win-rocm-10.0-x64.zip"},
+		{"windows after the ROCm 10 rename", Windows, "b10800", "llama-b10800-bin-win-rocm-10.0-x64.zip"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -367,17 +373,32 @@ func TestDefaultResolverROCmNaming(t *testing.T) {
 	}
 }
 
-// A tagged release carries its binaries under a nightly build tag, so that tag, not
-// the release name, decides the ROCm asset names.
+// A tagged release keeps its binaries under a nightly build tag. That tag decides
+// the ROCm asset names.
 func TestDefaultResolverROCmTaggedRelease(t *testing.T) {
-	urls, err := DefaultResolver.Resolve(Target{
-		Arch: AMD64, OS: Linux, Processor: ROCm, Version: "v0.3.0", UpstreamVersion: "b10355",
-	})
-	if err != nil {
-		t.Fatalf("Resolve() failed: %v", err)
+	tests := []struct {
+		name     string
+		os       OS
+		upstream string
+		want     string
+	}{
+		{"linux before the rename", Linux, "b10355", "llama-b10355-bin-ubuntu-rocm-7.2-x64.tar.gz"},
+		{"linux between the renames", Linux, "b10766", "llama-b10766-bin-ubuntu-rocm-7.14-x64.tar.gz"},
+		{"linux at the ROCm 10 rename", Linux, "b10767", "llama-b10767-bin-ubuntu-rocm-10.0-x64.tar.gz"},
+		{"windows at the ROCm 10 rename", Windows, "b10767", "llama-b10767-bin-win-rocm-10.0-x64.zip"},
 	}
-	want := "https://github.com/ggml-org/llama.cpp/releases/download/b10355/llama-b10355-bin-ubuntu-rocm-7.2-x64.tar.gz"
-	if len(urls) != 1 || urls[0] != want {
-		t.Fatalf("Resolve() = %v, want [%s]", urls, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			urls, err := DefaultResolver.Resolve(Target{
+				Arch: AMD64, OS: tt.os, Processor: ROCm, Version: "v0.3.0", UpstreamVersion: tt.upstream,
+			})
+			if err != nil {
+				t.Fatalf("Resolve() failed: %v", err)
+			}
+			want := "https://github.com/ggml-org/llama.cpp/releases/download/" + tt.upstream + "/" + tt.want
+			if len(urls) != 1 || urls[0] != want {
+				t.Fatalf("Resolve() = %v, want [%s]", urls, want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
llama.cpp release b10767 builds its ROCm artifacts with ROCm 10.0. It also renames the Linux and Windows assets. The resolver made the ROCm 7.14 names for all builds from b10356, and those URLs now give a 404 error.

This change uses the nightly build number to select the asset names.

| Build range | Linux amd64 | Windows amd64 |
| --- | --- | --- |
| Before b10356 | `ubuntu-rocm-7.2-x64.tar.gz` | `win-hip-radeon-x64.zip` |
| b10356 to b10766 | `ubuntu-rocm-7.14-x64.tar.gz` | `win-rocm-7.14-x64.zip` |
| b10767 and newer | `ubuntu-rocm-10.0-x64.tar.gz` | `win-rocm-10.0-x64.zip` |

A tagged release keeps its binaries under a nightly build tag, so `UpstreamVersion` selects the build range for those releases.

The resolver tests now cover b10766 and b10767 on both platforms. The tagged release test is a table with `UpstreamVersion` of b10355, b10766 and b10767.

The manifest test passes against b10767 and also against b10766.

Fixes #315
