### PR TITLE
llamawasm: do not put the model in the browser cache

### DIFF
--- a/pkg/llamawasm/fs.go
+++ b/pkg/llamawasm/fs.go
@@ -109,7 +109,14 @@ func FetchModelFile(name, url string, progress func(done, total int64)) error {
 		return err
 	}
 
-	response, err := await(js.Global().Call("fetch", url))
+	// Firefox writes the response to its cache while the program reads the
+	// stream. A model is larger than the maximum size of a cache entry, thus the
+	// browser stops the stream with an error. no-store keeps the model out of
+	// the cache.
+	options := js.Global().Get("Object").New()
+	options.Set("cache", "no-store")
+
+	response, err := await(js.Global().Call("fetch", url, options))
 	if err != nil {
 		return fmt.Errorf("llamawasm: cannot fetch %s: %w", url, err)
 	}


### PR DESCRIPTION
Firefox writes a response to its cache while the program reads the stream. A model is much larger than the maximum size of a cache entry, thus the browser stops the stream part way and the read fails:

```
llamawasm: cannot read https://huggingface.co/bartowski/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf: TypeError: Error in input stream
```

`FetchModelFile` now sends `cache: "no-store"` with the fetch, thus the model does not go to the cache. Chrome does not have this behavior, which is why the error was only in Firefox.