### PR TITLE
wasm: run the WebGPU build in Firefox

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -228,7 +228,7 @@ yzma install --lib /path/to/lib --processor cpu --os trixie
 yzma install --lib /path/to/web --os wasm
 ```
 
-WebGPU needs Chrome or Edge 137 and later, and an adapter with f16 shaders; every other browser runs on the CPU. Every build has the multimodal library, so a model with a projector works for images. This target uses the smaller API of the [`pkg/llamawasm`](./pkg/llamawasm) package. See [wasm/README.md](./wasm/README.md).
+WebGPU needs an adapter with f16 shaders, and Chrome or Edge 137 and later, or Firefox 153 and later with `dom.webgpu.enabled` and `dom.webgpu.workers.enabled` set in `about:config`; every other browser runs on the CPU. Every build has the multimodal library, so a model with a projector works for images. This target uses the smaller API of the [`pkg/llamawasm`](./pkg/llamawasm) package. See [wasm/README.md](./wasm/README.md).
 
 ### Windows CPU
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ There are three builds of `llama.cpp`, and the JavaScript glue takes the best on
 
 | Build | What the browser needs |
 |-------|------------------------|
-| WebGPU | WebGPU with f16 shaders, and JSPI: Chrome or Edge 137 and later |
+| WebGPU | WebGPU with f16 shaders, and JSPI: Chrome or Edge 137 and later, or Firefox 153 and later with two switches in `about:config` |
 | More threads | `SharedArrayBuffer`, so a page with the COOP and COEP headers |
 | One thread | Nothing. It works everywhere. |
 

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -210,7 +210,7 @@ the browser can run.
 
 | Build | What it needs |
 | --- | --- |
-| `yzma_wasm_webgpu` | WebGPU with f16 shaders, and JSPI. Chrome and Edge 137 or later. |
+| `yzma_wasm_webgpu` | WebGPU with f16 shaders, and JSPI. Chrome and Edge 137 or later, or Firefox 153 or later with two switches. See below. |
 | `yzma_wasm_mt` | `SharedArrayBuffer`, thus a page with the COOP and COEP headers. |
 | `yzma_wasm` | Nothing. It operates in all browsers. |
 
@@ -242,6 +242,57 @@ gives two results.
   ```
 
 The fallback makes the page slow, but the page operates.
+
+### Firefox
+
+Firefox runs the WebGPU build, but WebGPU is not yet on by default. Set both of
+these in `about:config` and restart the browser.
+
+| Switch | Why |
+| --- | --- |
+| `dom.webgpu.enabled` | WebGPU on Linux is still behind this switch. |
+| `dom.webgpu.workers.enabled` | llama.cpp loads in the worker, thus WebGPU in a page is not sufficient. |
+
+JSPI came in Firefox 153, thus 153 or later gives `WebAssembly.Suspending` and
+`WebAssembly.promising` with no switch. A test in the console of the page does
+not answer the question, because the worker has its own switch. Test the worker.
+
+```js
+const w = new Worker(URL.createObjectURL(new Blob([`
+  (async () => {
+    const a = self.navigator.gpu && await navigator.gpu.requestAdapter();
+    postMessage({
+      gpu: !!self.navigator.gpu,
+      jspi: typeof WebAssembly.Suspending === "function",
+      f16: !!a && a.features.has("shader-f16"),
+      info: a && { ...a.info },
+    });
+  })();
+`], { type: "text/javascript" })));
+w.onmessage = (e) => console.log(e.data);
+```
+
+With `?mode=webgpu` the loader says which of the parts is missing, thus read the
+console of the worker first. Firefox 154 on Linux with the two switches gives
+`gpu`, `jspi`, and `f16` in the worker, and the page reports
+`backend: webgpu (WebGPU)`.
+
+Firefox gives an empty `adapter.info`, thus the loader has no name for the card
+and `globalThis.yzmaAdapter` holds the plain word `webgpu`. This is not a
+failure. `llamawasm.Backend()` still gives the true answer.
+
+Firefox uses wgpu and Chrome uses Dawn, so the two do not always give the same
+adapter or the same features on the same machine. A machine with two GPUs can
+give f16 with one and not with the other, and these variables select the card
+before Firefox starts.
+
+```
+__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia firefox
+MESA_VK_DEVICE_SELECT=<vendor>:<device> firefox
+```
+
+Firefox gives no subgroups, thus llama.cpp takes the plain f16 shaders and the
+GPU is slower than the same card in Chrome.
 
 ## More than one thread
 
@@ -298,8 +349,9 @@ markers. The host build reads the token itself.
 
 ## Limits
 
-- WebGPU needs Chrome or Edge 137 or later, and an adapter with f16 shaders. All
-  other browsers use the CPU with SIMD.
+- WebGPU needs an adapter with f16 shaders, and Chrome or Edge 137 or later, or
+  Firefox 153 or later with two switches. All other browsers use the CPU with
+  SIMD.
 - A browser does not give the matrix instructions of a subgroup, which llama.cpp
   uses only outside a browser. Thus the GPU is slower in a page than the same
   backend on a desktop.

--- a/wasm/yzma-loader.js
+++ b/wasm/yzma-loader.js
@@ -17,10 +17,11 @@
 //   globalThis.yzmaMode      "auto" (the default), "webgpu", or "cpu"
 //
 // There are three builds of llama.cpp. The WebGPU build computes on the GPU and
-// needs a browser with WebGPU and JSPI, which is Chrome and Edge 137 or later.
-// The two CPU builds operate in all browsers. The build with more than one
-// thread needs an isolated page with the Cross-Origin-Opener-Policy and
-// Cross-Origin-Embedder-Policy headers.
+// needs a browser with WebGPU and JSPI, which is Chrome and Edge 137 or later,
+// or Firefox 153 or later with dom.webgpu.enabled and dom.webgpu.workers.enabled
+// set in about:config. The two CPU builds operate in all browsers. The build
+// with more than one thread needs an isolated page with the
+// Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers.
 //
 // In "auto" mode the loader selects the best build that the browser can run.
 
@@ -33,30 +34,48 @@
   const canThread =
     typeof SharedArrayBuffer !== "undefined" && globalThis.crossOriginIsolated === true;
 
-  // webgpuAdapter gives the name of a usable GPU, or an empty string. llama.cpp
-  // needs f16 shaders and JSPI, so navigator.gpu alone is not sufficient.
+  // webgpuAdapter gives the name of a usable GPU, or an empty string, and the
+  // reason for an empty result. llama.cpp needs f16 shaders and JSPI, so
+  // navigator.gpu alone is not sufficient.
   async function webgpuAdapter() {
     if (!globalThis.navigator || !navigator.gpu) {
-      return "";
+      // A worker has its own switch in Firefox, thus name it here. This code
+      // runs in the worker that holds llama.cpp.
+      return [
+        "",
+        "this worker has no navigator.gpu, in Firefox set dom.webgpu.enabled" +
+          " and dom.webgpu.workers.enabled",
+      ];
     }
-    if (typeof WebAssembly.Suspending !== "function") {
-      // Without JSPI the WebGPU build cannot run.
-      return "";
+
+    // The glue of the WebGPU build uses both parts of JSPI.
+    if (
+      typeof WebAssembly.Suspending !== "function" ||
+      typeof WebAssembly.promising !== "function"
+    ) {
+      return ["", "no JSPI, which needs Chrome or Edge 137, or Firefox 153, or later"];
     }
 
     try {
       const adapter = await navigator.gpu.requestAdapter();
-      if (!adapter || !adapter.features.has("shader-f16")) {
-        return "";
+      if (!adapter) {
+        return ["", "requestAdapter gave no adapter"];
+      }
+      if (!adapter.features.has("shader-f16")) {
+        return [
+          "",
+          "the adapter has no shader-f16, see the note on NVIDIA in wasm/README.md",
+        ];
       }
 
       // The browser does not always give the name of the GPU.
       const info = adapter.info || {};
-      return [info.vendor, info.architecture, info.device, info.description]
+      const name = [info.vendor, info.architecture, info.device, info.description]
         .filter((part) => part)
         .join(" ") || "webgpu";
-    } catch {
-      return "";
+      return [name, ""];
+    } catch (err) {
+      return ["", "requestAdapter failed: " + err];
     }
   }
 
@@ -79,9 +98,10 @@
     let name = "yzma_wasm";
     let backend = "cpu";
     let adapter = "";
+    let reason = "";
 
     if (mode !== "cpu") {
-      adapter = await webgpuAdapter();
+      [adapter, reason] = await webgpuAdapter();
     }
 
     if (adapter) {
@@ -90,7 +110,7 @@
     } else if (mode === "webgpu") {
       // The page asked for WebGPU, but the browser cannot give it. Continue
       // with the CPU, which is the result that "auto" gives.
-      console.warn("yzma: this browser has no WebGPU that llama.cpp can use, using the CPU");
+      console.warn("yzma: no WebGPU that llama.cpp can use, using the CPU: " + reason);
       if (canThread) {
         name = "yzma_wasm_mt";
         backend = "cpu-threads";


### PR DESCRIPTION
Firefox can now run the WebGPU build of llama.cpp, but the documents said it needs Chrome or Edge. Nothing in the code looks at the name of the browser, thus only three capability tests kept Firefox on the CPU.

Firefox needs this.

| Part | State |
| --- | --- |
| JSPI | Firefox 153 and later, with no switch |
| `navigator.gpu` | Behind `dom.webgpu.enabled` on Linux |
| `navigator.gpu` in a worker | Behind `dom.webgpu.workers.enabled`. llama.cpp loads in the worker, thus a page alone is not sufficient |
| An adapter with `shader-f16` | Comes from the machine |

With the two switches, Firefox 154 on Linux reports `backend: webgpu (WebGPU)` and computes on the GPU.

## Changes

- `wasm/yzma-loader.js` looks for `WebAssembly.promising` as well as `WebAssembly.Suspending`, because the glue of the WebGPU build uses both parts of JSPI.
- `webgpuAdapter()` gives back the reason for a failure and `?mode=webgpu` logs it. Before this, four different causes gave one message and a user could not tell which switch to set.
- `README.md`, `INSTALL.md`, and `wasm/README.md` name Firefox and the two switches. `wasm/README.md` gets a Firefox part with the switches, a test for the worker, and the note that Firefox gives an empty `adapter.info`, so the name of the card is not there.

## Tests

- `make vet-wasm`, `make test-wasm`, and `make test-wasm-webgpu` pass.
- Each branch of the new code was run against a stub adapter: no `navigator.gpu`, no JSPI, no adapter, no `shader-f16`, a throw, a full adapter, and the empty `adapter.info` of Firefox. The last one still selects the WebGPU build.
- Firefox 154 on Linux with the two switches: the worker gives `gpu`, `jspi`, and `f16`, and the chat page reports `backend: webgpu (WebGPU)`.