### PR TITLE
mtmd: add TokenizeFromParts and InputPart

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ Here are some of the known compatible versions for the nightly builds of `llama.
 | b10105 - b10211  | v1.20.0 - v1.21.0   |
 | b10212 - b10257  | v1.22.0   |
 | b10273 - b10544  | v1.23.0   |
-| b10545+  | v1.24.0+   |
+| b10545 - b10779  | v1.24.0 - v1.25.0   |
+| b10780+  | v1.26.0+   |
 
 ## Benchmarks
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -333,6 +333,7 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 | `mtmd_support_audio` | yes | yes |
 | `mtmd_support_vision` | yes | yes |
 | `mtmd_tokenize` | yes | yes |
+| `mtmd_tokenize_from_parts` | yes | no |
 
 ---
 

--- a/pkg/mtmd/mtmd.go
+++ b/pkg/mtmd/mtmd.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"unsafe"
 
 	"github.com/hybridgroup/yzma/pkg/llama"
@@ -28,6 +29,16 @@ type InputText struct {
 	TextLen      uint64
 	AddSpecial   bool
 	ParseSpecial bool
+}
+
+//	struct mtmd_input_part {
+//	    // only text or bitmap can be set, not both
+//	    const struct mtmd_input_text * text;
+//	    const struct mtmd_bitmap * bitmap;
+//	};
+type InputPart struct {
+	Text   *InputText
+	Bitmap Bitmap
 }
 
 // Opaque types (represented as pointers)
@@ -111,6 +122,13 @@ var (
 	//                            size_t n_bitmaps);
 	tokenizeFunc ffi.Fun
 
+	// MTMD_API int32_t mtmd_tokenize_from_parts(mtmd_context * ctx,
+	//                                           mtmd_input_chunks * output,
+	//                                           const mtmd_input_part ** parts,
+	//                                           size_t n_parts,
+	//                                           bool add_special);
+	tokenizeFromPartsFunc ffi.Fun
+
 	// MTMD_API int32_t mtmd_helper_eval_chunks(mtmd_context * ctx,
 	//                                          struct llama_context * lctx,
 	//                                          const mtmd_input_chunks * chunks,
@@ -183,6 +201,10 @@ func loadFuncs(lib loader.Lib) error {
 
 	if tokenizeFunc, err = lib.Prep("mtmd_tokenize", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize); err != nil {
 		return loadError("mtmd_tokenize", err)
+	}
+
+	if tokenizeFromPartsFunc, err = lib.Prep("mtmd_tokenize_from_parts", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffiTypeSize, &ffi.TypeUint8); err != nil {
+		return loadError("mtmd_tokenize_from_parts", err)
 	}
 
 	if helperEvalChunksFunc, err = lib.Prep("mtmd_helper_eval_chunks", &ffi.TypeSint32, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer,
@@ -370,6 +392,40 @@ func NewInputText(text string, addSpecial, parseSpecial bool) *InputText {
 		AddSpecial:   addSpecial,
 		ParseSpecial: parseSpecial,
 	}
+}
+
+// NewInputTextPart creates an InputPart that holds text.
+func NewInputTextPart(text *InputText) *InputPart {
+	return &InputPart{Text: text}
+}
+
+// NewInputBitmapPart creates an InputPart that holds a bitmap.
+func NewInputBitmapPart(bitmap Bitmap) *InputPart {
+	return &InputPart{Bitmap: bitmap}
+}
+
+// TokenizeFromParts does the same as Tokenize, but it takes an ordered list of parts.
+// Each part must have either text or a bitmap, not both and not neither.
+// Use it when the prompt must not use media markers, or when each text part needs
+// its own ParseSpecial value. The AddSpecial value of each part is ignored, the
+// addSpecial parameter applies to all of the parts.
+// return values:
+//
+//	0 on success
+//	1 if a part has both text and bitmap set, or neither
+//	2 on media preprocessing error
+func TokenizeFromParts(ctx Context, out InputChunks, parts []*InputPart, addSpecial bool) int32 {
+	if ctx == 0 {
+		return 1
+	}
+	pt := unsafe.SliceData(parts)
+	nParts := uint64(len(parts))
+
+	var result ffi.Arg
+	tokenizeFromPartsFunc.Call(unsafe.Pointer(&result), unsafe.Pointer(&ctx), unsafe.Pointer(&out), unsafe.Pointer(&pt), &nParts, &addSpecial)
+	runtime.KeepAlive(parts)
+
+	return int32(result)
 }
 
 // HelperEvalChunks is a helper function that automatically:

--- a/pkg/mtmd/mtmd_test.go
+++ b/pkg/mtmd/mtmd_test.go
@@ -146,6 +146,117 @@ func TestTokenize(t *testing.T) {
 	t.Log("Tokenize successfully tokenized the input text")
 }
 
+func TestTokenizeFromParts(t *testing.T) {
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer llama.ModelFree(model)
+
+	params := ContextParamsDefault()
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	defer Free(ctx)
+
+	chunks := InputChunksInit()
+	defer InputChunksFree(chunks)
+
+	data, x, y, err := openImageFile("../../images/domestic_llama.jpg")
+	if err != nil {
+		t.Fatal("could not open image file")
+	}
+
+	bitmap := BitmapInit(x, y, uintptr(unsafe.Pointer(&data[0])))
+	defer BitmapFree(bitmap)
+
+	// an ordered sequence of text, media, and text, each text with its own
+	// ParseSpecial value and no media marker
+	parts := []*InputPart{
+		NewInputTextPart(NewInputText("Here is an image: ", true, false)),
+		NewInputBitmapPart(bitmap),
+		NewInputTextPart(NewInputText("\ndescribe it in detail.", true, true)),
+	}
+
+	result := TokenizeFromParts(ctx, chunks, parts, true)
+	if result != 0 {
+		t.Fatalf("TokenizeFromParts failed with result: %d", result)
+	}
+
+	if size := InputChunksSize(chunks); size != 3 {
+		t.Fatalf("TokenizeFromParts expected 3 chunks, got %d", size)
+	}
+
+	want := []InputChunkType{InputChunkTypeText, InputChunkTypeImage, InputChunkTypeText}
+	for i, wantType := range want {
+		gotType := InputChunkGetType(InputChunksGet(chunks, uint64(i)))
+		if gotType != wantType {
+			t.Errorf("chunk %d has type %d, expected %d", i, gotType, wantType)
+		}
+	}
+}
+
+func TestTokenizeFromPartsInvalidParts(t *testing.T) {
+	modelFile := testModelFileName(t)
+	mmprojFile := testMMProjFileName(t)
+
+	testSetup(t)
+	defer testCleanup(t)
+
+	model, err := llama.ModelLoadFromFile(modelFile, llama.ModelDefaultParams())
+	if err != nil {
+		t.Fatalf("ModelLoadFromFile failed: %v", err)
+	}
+	defer llama.ModelFree(model)
+
+	params := ContextParamsDefault()
+	ctx, err := InitFromFile(mmprojFile, model, params)
+	if err != nil {
+		t.Fatalf("InitFromFile failed: %v", err)
+	}
+	defer Free(ctx)
+
+	data, x, y, err := openImageFile("../../images/domestic_llama.jpg")
+	if err != nil {
+		t.Fatal("could not open image file")
+	}
+
+	bitmap := BitmapInit(x, y, uintptr(unsafe.Pointer(&data[0])))
+	defer BitmapFree(bitmap)
+
+	tests := []struct {
+		name string
+		part *InputPart
+	}{
+		{"both text and bitmap", &InputPart{Text: NewInputText("hello", true, true), Bitmap: bitmap}},
+		{"neither text nor bitmap", &InputPart{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			chunks := InputChunksInit()
+			defer InputChunksFree(chunks)
+
+			if result := TokenizeFromParts(ctx, chunks, []*InputPart{tc.part}, true); result != 1 {
+				t.Fatalf("TokenizeFromParts expected result 1, got %d", result)
+			}
+		})
+	}
+}
+
+func TestTokenizeFromPartsZeroContext(t *testing.T) {
+	if result := TokenizeFromParts(0, 0, nil, true); result != 1 {
+		t.Fatalf("TokenizeFromParts expected result 1, got %d", result)
+	}
+}
+
 func TestHelperEvalChunks(t *testing.T) {
 	modelFile := testModelFileName(t)
 	mmprojFile := testMMProjFileName(t)

--- a/pkg/mtmd/mtmd_test.go
+++ b/pkg/mtmd/mtmd_test.go
@@ -190,16 +190,28 @@ func TestTokenizeFromParts(t *testing.T) {
 		t.Fatalf("TokenizeFromParts failed with result: %d", result)
 	}
 
-	if size := InputChunksSize(chunks); size != 3 {
-		t.Fatalf("TokenizeFromParts expected 3 chunks, got %d", size)
+	// A model that slices an image gives more than one image chunk, with text
+	// chunks between the slices, thus only the order of the parts is checked.
+	size := InputChunksSize(chunks)
+	if size < 3 {
+		t.Fatalf("TokenizeFromParts expected at least 3 chunks, got %d", size)
 	}
 
-	want := []InputChunkType{InputChunkTypeText, InputChunkTypeImage, InputChunkTypeText}
-	for i, wantType := range want {
-		gotType := InputChunkGetType(InputChunksGet(chunks, uint64(i)))
-		if gotType != wantType {
-			t.Errorf("chunk %d has type %d, expected %d", i, gotType, wantType)
+	if got := InputChunkGetType(InputChunksGet(chunks, 0)); got != InputChunkTypeText {
+		t.Errorf("first chunk has type %d, expected text", got)
+	}
+	if got := InputChunkGetType(InputChunksGet(chunks, size-1)); got != InputChunkTypeText {
+		t.Errorf("last chunk has type %d, expected text", got)
+	}
+
+	images := 0
+	for i := uint64(1); i < size-1; i++ {
+		if InputChunkGetType(InputChunksGet(chunks, i)) == InputChunkTypeImage {
+			images++
 		}
+	}
+	if images == 0 {
+		t.Error("TokenizeFromParts gave no image chunk between the text chunks")
 	}
 }
 


### PR DESCRIPTION
Fixes #319

`llama.cpp` added `mtmd_tokenize_from_parts` and `mtmd_input_part` in b10780. This adds the `yzma` wrapper for both.

A caller can now give an ordered list of text and bitmap parts. This makes it possible to tokenize a mixed sequence without media markers, and to set `ParseSpecial` for each text part on its own. The per part `AddSpecial` value is ignored, as upstream does.

## Changes

- `InputPart` type for the two pointer C struct, with `NewInputTextPart` and `NewInputBitmapPart` to make the "text or bitmap, not both" rule clear
- `TokenizeFromParts`, which keeps the part array and the values it points to alive for the FFI call
- Tests for the ordered text, image, text sequence with independent `ParseSpecial` values, for the error when a part has both fields set or neither, and for a zero context
- `ROADMAP.md` and the `README.md` compatibility table updated

## Compatibility

The new symbol is prepared like all the other symbols, thus this raises the minimum `llama.cpp` version to b10780. The README table has a new row for this.

Tested against a b10780 build. All of the `pkg/mtmd` tests pass.