### PR TITLE
download: check the digest of each asset and add a verify command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -384,3 +384,61 @@ Notes:
   including `file://` and S3/GCS.
 
 See the [resolver example code](./examples/resolver/).
+
+### Checking what comes down
+
+`Install` checks the SHA-256 of each asset before it writes anything. The expected
+digests come from the manifest that `llama-cpp-builder` publishes for each release tag,
+next to the version files:
+
+```
+https://hybridgroup.github.io/llama-cpp-builder/digests/b10783.json
+```
+
+An asset whose bytes do not agree stops the install with `download.ErrDigestMismatch`,
+and nothing is extracted.
+
+The default is `VerifyIfAvailable`. An asset that has no digest still installs, and
+`download.VerifyWarning` prints a line about it. Set that to `nil` to say nothing.
+
+A deployment that must know which libraries it loads asks for more:
+
+```go
+err := download.Install(context.Background(), target, libPath, download.ProgressTracker, nil,
+	download.WithVerify(download.VerifyRequired))
+```
+
+`VerifyRequired` makes an asset with no digest an error, `download.ErrDigestMissing`.
+`VerifyOff` checks nothing.
+
+The `yzma install` command takes the same setting from the `YZMA_VERIFY` environment
+variable, which accepts `available` (the default), `require`, and `off`.
+
+#### Digests from your own resolver
+
+A `Resolver` returns URLs only, so it reports no digests and `VerifyRequired` refuses it.
+Implement `AssetResolver` as well to give a digest for each asset:
+
+```go
+type mirrorResolver struct{}
+
+func (mirrorResolver) Resolve(t download.Target) ([]string, error) {
+	return download.DefaultResolver.Resolve(t)
+}
+
+func (r mirrorResolver) ResolveAssets(t download.Target) ([]download.Asset, error) {
+	return []download.Asset{{
+		URL:    "https://mirror.example.com/llama/" + t.Version + "-cuda12-x64.tar.gz",
+		SHA256: mirrorDigest(t.Version),
+	}}, nil
+}
+```
+
+`Install` prefers `ResolveAssets` when a resolver has both. A resolver that wraps
+`DefaultResolver` should implement `AssetResolver` and delegate to
+`download.DefaultResolver.(download.AssetResolver).ResolveAssets(t)`, or the assets it
+passes through lose their digests.
+
+The digests show that an archive is the archive that was published. They are not a
+signature, and a digest that comes from the same place as the asset does not show who
+built it.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -442,3 +442,34 @@ passes through lose their digests.
 The digests show that an archive is the archive that was published. They are not a
 signature, and a digest that comes from the same place as the asset does not show who
 built it.
+
+### Checking an installation later
+
+The archive is removed as soon as it is extracted, so a later check reads the files that
+are in place. `Install` writes `yzma-install.json` beside the libraries to say what it
+put there, and `VerifyInstall` checks them:
+
+```go
+report, err := download.VerifyInstall(context.Background(), libPath, "")
+if err != nil {
+	return err
+}
+if !report.OK() {
+	return fmt.Errorf("%d changed, %d missing", report.Changed, report.Missing)
+}
+```
+
+An empty tag takes the release from the record. Give a tag to say which release must be
+there. The record is beside the libraries, so anything that can change the libraries can
+change the record; a tag makes the check resolve the assets of that release itself
+instead of reading the tag from the record.
+
+A file that no asset of this install holds is reported as `FileUnexpected` and does not
+make `OK` false, because a directory can hold more than one install.
+
+The file digests come from the asset, so they are there only for the assets that
+`llama-cpp-builder` builds. An install from the `llama.cpp` release page gives
+`ErrNoFileDigests`.
+
+The `yzma verify` command does the same thing from a shell. See
+[the command documentation](./cmd/README.md).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -459,9 +459,9 @@ if !report.OK() {
 }
 ```
 
-An empty tag takes the release from the record. Give a tag to say which release must be
-there. The record is beside the libraries, so anything that can change the libraries can
-change the record; a tag makes the check resolve the assets of that release itself
+An empty tag takes the release from the record. Give a tag to name the release that must
+be there. The record is beside the libraries, so anything that can change the libraries
+can change the record. A tag makes the check resolve the assets of that release itself
 instead of reading the tag from the record.
 
 A file that no asset of this install holds is reported as `FileUnexpected` and does not

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -19,6 +19,7 @@ USAGE:
 
 COMMANDS:
    install  Install llama.cpp libraries used by yzma
+   verify   Check the installed llama.cpp libraries against their published digests
    system   Show llama.cpp system information
    llama    Show most recent llama.cpp version
    model    Manage models
@@ -47,6 +48,7 @@ OPTIONS:
    --processor value, -p value  processor to use (cpu, cuda, metal, vulkan) (default: "cpu")
    --upgrade, -u                upgrade existing installation (default: false)
    --quiet, -q                  suppress output during installation (default: false)
+   --verify value               how to check the digest of each download (available, require, off) (default: "available") [$YZMA_VERIFY]
    --help, -h                   show help
 ```
 
@@ -82,3 +84,55 @@ make check-ffi
 ```
 
 See [yzma-checker/README.md](./yzma-checker/README.md) for what it verifies and how.
+
+## Using the `yzma` command to check an installation
+
+`yzma install` checks the digest of each archive as it downloads it, but the archive is
+removed as soon as it is extracted. The `yzma verify` command checks the files that are
+in place, against the digests that the publisher recorded for the release.
+
+```
+NAME:
+   yzma verify - Check the installed llama.cpp libraries against their published digests
+
+USAGE:
+   yzma verify [command options]
+
+OPTIONS:
+   --lib value, -l value      path to llama.cpp compiled library files [$YZMA_LIB]
+   --version value, -v value  the llama.cpp version that must be installed (leave empty to take the installed one)
+   --strict                   also fail when a file in the directory is not part of the install (default: false)
+   --json                     write the report as JSON (default: false)
+   --help, -h                 show help
+```
+
+```
+$ yzma verify --lib /path/to/lib
+llama.cpp b10783 in /path/to/lib
+68 verified, 0 changed, 0 missing, 0 not part of this install
+ok.
+```
+
+A file that was changed or removed makes the command exit with a status of 1:
+
+```
+$ yzma verify --lib /path/to/lib
+llama.cpp b10783 in /path/to/lib
+  changed    libllama.so.0.3.0
+  missing    libggml-base.so.0.22.0
+66 verified, 1 changed, 1 missing, 0 not part of this install
+```
+
+Notes:
+
+- `yzma install` writes `yzma-install.json` beside the libraries to say what it put
+  there. `yzma verify` needs it, so an installation made by an older yzma has to be
+  installed again first.
+- The record is beside the libraries, so anything that can change the libraries can
+  change the record. Give `--version` to say which release must be there. The check then
+  resolves the assets of that release itself and does not read the tag from the record.
+- A directory can hold more than one install, so a file that is not part of this one is
+  reported but does not fail the check. Add `--strict` to fail on those too.
+- Only the assets that `llama-cpp-builder` builds carry digests for the files in them.
+  An install that came from the `llama.cpp` release page has an archive digest but no
+  file digests, so `yzma verify` says so instead of passing.

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -49,6 +49,12 @@ var InstallCmd = &cli.Command{
 			Usage:   "suppress output during installation",
 			Value:   false,
 		},
+		&cli.StringFlag{
+			Name:    "verify",
+			Usage:   "how to check the digest of each download (available, require, off)",
+			EnvVars: []string{"YZMA_VERIFY"},
+			Value:   "available",
+		},
 	},
 	Action: func(c *cli.Context) error {
 		return runInstall(c)
@@ -111,7 +117,13 @@ func runInstall(c *cli.Context) error {
 		}
 	}
 
-	if err := download.Get(runtime.GOARCH, osInstall, processor, version, libPath); err != nil {
+	verify, err := download.ParseVerifyPolicy(c.String("verify"))
+	if err != nil {
+		return err
+	}
+
+	if err := download.Get(runtime.GOARCH, osInstall, processor, version, libPath,
+		download.WithVerify(verify)); err != nil {
 		return fmt.Errorf("failed to download llama.cpp: %w", err)
 	}
 

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/hybridgroup/yzma/pkg/download"
+	"github.com/urfave/cli/v2"
+)
+
+var VerifyCmd = &cli.Command{
+	Name:  "verify",
+	Usage: "Check the installed llama.cpp libraries against their published digests",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "lib",
+			Aliases: []string{"l"},
+			Usage:   "path to llama.cpp compiled library files",
+			EnvVars: []string{"YZMA_LIB"},
+		},
+		&cli.StringFlag{
+			Name:    "version",
+			Aliases: []string{"v"},
+			Usage:   "the llama.cpp version that must be installed (leave empty to take the installed one)",
+			Value:   "",
+		},
+		&cli.BoolFlag{
+			Name:  "strict",
+			Usage: "also fail when a file in the directory is not part of the install",
+			Value: false,
+		},
+		&cli.BoolFlag{
+			Name:  "json",
+			Usage: "write the report as JSON",
+			Value: false,
+		},
+	},
+	Action: func(c *cli.Context) error {
+		return runVerify(c)
+	},
+}
+
+func runVerify(c *cli.Context) error {
+	libPath := c.String("lib")
+	if libPath == "" {
+		return fmt.Errorf("missing lib flag or YZMA_LIB env var")
+	}
+
+	report, err := download.VerifyInstall(context.Background(), libPath, c.String("version"))
+	switch {
+	case errors.Is(err, download.ErrNoInstallRecord):
+		return fmt.Errorf("%w. Install with a yzma release that writes one, then verify", err)
+	case errors.Is(err, download.ErrNoFileDigests):
+		return fmt.Errorf("%w. The publisher gives no file digests for this release", err)
+	case err != nil:
+		return err
+	}
+
+	if c.Bool("json") {
+		body, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(body))
+	} else {
+		showVerifyReport(report)
+	}
+
+	if !report.OK() || (c.Bool("strict") && report.Unexpected > 0) {
+		return cli.Exit("", 1)
+	}
+
+	return nil
+}
+
+// showVerifyReport writes the report for a person to read. Only the files that need
+// attention are named, because an install holds many files.
+func showVerifyReport(report *download.VerifyReport) {
+	out := os.Stdout
+
+	fmt.Fprintf(out, "llama.cpp %s in %s\n", report.Tag, report.LibPath)
+
+	for _, file := range report.Files {
+		if file.State == download.FileVerified {
+			continue
+		}
+		fmt.Fprintf(out, "  %-10s %s\n", file.State, file.Name)
+	}
+
+	fmt.Fprintf(out, "%d verified, %d changed, %d missing, %d not part of this install\n",
+		report.Verified, report.Changed, report.Missing, report.Unexpected)
+
+	if report.OK() {
+		fmt.Fprintln(out, "ok.")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 func buildCommands() []*cli.Command {
 	return []*cli.Command{
 		cmd.InstallCmd,
+		cmd.VerifyCmd,
 		cmd.SystemCmd,
 		cmd.LlamaCmd,
 		cmd.ModelCmd,

--- a/pkg/download/digest.go
+++ b/pkg/download/digest.go
@@ -1,0 +1,205 @@
+package download
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var (
+	// ErrDigestMismatch means a downloaded asset does not have the bytes that the
+	// publisher recorded for it.
+	ErrDigestMismatch = errors.New("digest does not match")
+
+	// ErrDigestMissing means no digest was found for an asset and the policy is
+	// [VerifyRequired].
+	ErrDigestMissing = errors.New("no digest for asset")
+)
+
+// digestsURL is the URL of the digest manifest for a llama.cpp release tag. It is on
+// the same site as the version files, so it does not use the GitHub API, which rate
+// limits. See the llama-cpp-builder repo for how the manifests are made.
+var digestsURL = "https://hybridgroup.github.io/llama-cpp-builder/digests/%s.json"
+
+// VerifyPolicy says what [Install] does about the digest of an asset.
+type VerifyPolicy int
+
+const (
+	// VerifyIfAvailable checks an asset that has a digest and permits one that does
+	// not. This is the default.
+	VerifyIfAvailable VerifyPolicy = iota
+
+	// VerifyRequired makes an asset with no digest an error. Use it where the
+	// libraries must be known, such as a deployment that is measured.
+	VerifyRequired
+
+	// VerifyOff checks nothing.
+	VerifyOff
+)
+
+// VerifyWarning is called for each asset that installs with no digest under
+// [VerifyIfAvailable]. Set it to nil to say nothing.
+var VerifyWarning = func(url string) {
+	fmt.Fprintf(os.Stderr, "yzma: no digest for %s, installed with no check\n", url)
+}
+
+// Asset is a release asset to install and, when it is known, the digest of its bytes.
+type Asset struct {
+	// URL is where the asset is downloaded from.
+	URL string
+
+	// SHA256 is the expected digest of the asset, in hexadecimal. An empty value
+	// means the digest is not known.
+	SHA256 string
+}
+
+// AssetResolver reports the assets to install for a Target with their expected
+// digests. [Install] takes it in place of [Resolver] when a resolver has both, so an
+// existing [Resolver] keeps working and gives no digests.
+type AssetResolver interface {
+	ResolveAssets(target Target) (assets []Asset, err error)
+}
+
+// manifest holds the digests that a llama.cpp release publishes. The assets come from
+// more than one repository, and an asset name can occur in more than one of them with
+// different bytes, so the assets are grouped by the repository that published them.
+type manifest struct {
+	Version     int                       `json:"version"`
+	Tag         string                    `json:"tag"`
+	UpstreamTag string                    `json:"upstream_tag"`
+	Sources     map[string]manifestSource `json:"sources"`
+}
+
+// manifestSource holds the assets of one repository.
+type manifestSource struct {
+	Tag    string                   `json:"tag"`
+	Assets map[string]manifestAsset `json:"assets"`
+}
+
+// manifestAsset holds the digest of one asset. Files and Links describe what the
+// asset holds, which only the repository that built it can report.
+type manifestAsset struct {
+	SHA256 string            `json:"sha256"`
+	Files  map[string]string `json:"files,omitempty"`
+	Links  map[string]string `json:"links,omitempty"`
+}
+
+// assetURLPattern matches a GitHub release asset URL, and gives the repository, the
+// release tag, and the asset name.
+var assetURLPattern = regexp.MustCompile(`^https://github\.com/([^/]+/[^/]+)/releases/download/([^/]+)/([^?]+)`)
+
+// digestFor gives the expected digest of an asset URL, or "" when the manifest does
+// not name it. The repository and the tag must both agree, because the same name can
+// belong to a different asset in another repository.
+func (m *manifest) digestFor(url string) string {
+	asset, ok := m.assetFor(url)
+	if !ok {
+		return ""
+	}
+	return asset.SHA256
+}
+
+// assetFor finds the manifest entry for an asset URL.
+func (m *manifest) assetFor(url string) (manifestAsset, bool) {
+	parts := assetURLPattern.FindStringSubmatch(url)
+	if parts == nil {
+		return manifestAsset{}, false
+	}
+
+	source, ok := m.Sources[parts[1]]
+	if !ok || source.Tag != parts[2] {
+		return manifestAsset{}, false
+	}
+
+	asset, ok := source.Assets[parts[3]]
+	return asset, ok
+}
+
+// fetchManifest gets the digest manifest for a llama.cpp release tag.
+func fetchManifest(ctx context.Context, tag string) (*manifest, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf(digestsURL, tag), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received status code %d for the digests of %s", resp.StatusCode, tag)
+	}
+
+	var m manifest
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return nil, err
+	}
+
+	return &m, nil
+}
+
+// verifyFile checks that a file has the expected digest. An empty digest checks
+// nothing, because [VerifyIfAvailable] permits an asset that has none.
+func verifyFile(path, want string) error {
+	if want == "" {
+		return nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open the downloaded file: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("failed to read the downloaded file: %w", err)
+	}
+
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("%w for %s: expected %s, got %s", ErrDigestMismatch, path, want, got)
+	}
+
+	return nil
+}
+
+// ParseVerifyPolicy reads a verify policy name. The names are "available" for
+// [VerifyIfAvailable], "require" for [VerifyRequired], and "off" for [VerifyOff]. An
+// empty name gives the default.
+func ParseVerifyPolicy(name string) (VerifyPolicy, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "available", "if-available":
+		return VerifyIfAvailable, nil
+	case "require", "required":
+		return VerifyRequired, nil
+	case "off", "none":
+		return VerifyOff, nil
+	default:
+		return VerifyIfAvailable, fmt.Errorf("unknown verify policy: %s", name)
+	}
+}
+
+// String gives the name of a policy.
+func (p VerifyPolicy) String() string {
+	switch p {
+	case VerifyRequired:
+		return "require"
+	case VerifyOff:
+		return "off"
+	default:
+		return "available"
+	}
+}

--- a/pkg/download/digest.go
+++ b/pkg/download/digest.go
@@ -55,11 +55,11 @@ var VerifyWarning = func(url string) {
 // Asset is a release asset to install and, when it is known, the digest of its bytes.
 type Asset struct {
 	// URL is where the asset is downloaded from.
-	URL string
+	URL string `json:"url"`
 
 	// SHA256 is the expected digest of the asset, in hexadecimal. An empty value
 	// means the digest is not known.
-	SHA256 string
+	SHA256 string `json:"sha256,omitempty"`
 }
 
 // AssetResolver reports the assets to install for a Target with their expected

--- a/pkg/download/digest_test.go
+++ b/pkg/download/digest_test.go
@@ -1,0 +1,396 @@
+package download
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	getter "github.com/hashicorp/go-getter"
+)
+
+// The same asset name is published by both repositories with different bytes, so a
+// manifest keyed only by name would be ambiguous. See llama-cpp-builder b10783.
+const collidingName = "llama-b10783-bin-ubuntu-vulkan-arm64.tar.gz"
+
+// testManifest builds a manifest that holds one asset for each source.
+func testManifest() *manifest {
+	return &manifest{
+		Version:     1,
+		Tag:         "b10783",
+		UpstreamTag: "b10783",
+		Sources: map[string]manifestSource{
+			"hybridgroup/llama-cpp-builder": {
+				Tag: "b10783",
+				Assets: map[string]manifestAsset{
+					collidingName: {SHA256: "bbbb"},
+				},
+			},
+			"ggml-org/llama.cpp": {
+				Tag: "b10783",
+				Assets: map[string]manifestAsset{
+					collidingName: {SHA256: "gggg"},
+				},
+			},
+		},
+	}
+}
+
+func TestManifestDigestForUsesTheSource(t *testing.T) {
+	m := testManifest()
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "the builder asset",
+			url:  "https://github.com/hybridgroup/llama-cpp-builder/releases/download/b10783/" + collidingName,
+			want: "bbbb",
+		},
+		{
+			name: "the upstream asset of the same name",
+			url:  "https://github.com/ggml-org/llama.cpp/releases/download/b10783/" + collidingName,
+			want: "gggg",
+		},
+		{
+			name: "a repository the manifest does not name",
+			url:  "https://github.com/someone/mirror/releases/download/b10783/" + collidingName,
+			want: "",
+		},
+		{
+			name: "a tag that does not agree",
+			url:  "https://github.com/ggml-org/llama.cpp/releases/download/b10600/" + collidingName,
+			want: "",
+		},
+		{
+			name: "an asset the manifest does not name",
+			url:  "https://github.com/ggml-org/llama.cpp/releases/download/b10783/llama-b10783-bin-macos-arm64.tar.gz",
+			want: "",
+		},
+		{
+			name: "a URL that is not a release asset",
+			url:  "https://example.com/llama.tar.gz",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := m.digestFor(tt.url); got != tt.want {
+				t.Errorf("digestFor(%s) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "asset.tar.gz")
+	content := []byte("the bytes of an asset")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(content)
+	digest := hex.EncodeToString(sum[:])
+
+	if err := verifyFile(path, digest); err != nil {
+		t.Errorf("verifyFile() with the right digest failed: %v", err)
+	}
+
+	// A digest is hexadecimal, so the case must not matter.
+	if err := verifyFile(path, strings.ToUpper(digest)); err != nil {
+		t.Errorf("verifyFile() with an upper case digest failed: %v", err)
+	}
+
+	// An empty digest checks nothing, which VerifyIfAvailable permits.
+	if err := verifyFile(path, ""); err != nil {
+		t.Errorf("verifyFile() with no digest failed: %v", err)
+	}
+
+	err := verifyFile(path, strings.Repeat("0", 64))
+	if !errors.Is(err, ErrDigestMismatch) {
+		t.Errorf("verifyFile() with a wrong digest = %v, want ErrDigestMismatch", err)
+	}
+}
+
+func TestFetchManifest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/digests/b10783.json" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fmt.Fprint(w, `{"version":1,"tag":"b10783","upstream_tag":"b10783","sources":{
+			"hybridgroup/llama-cpp-builder":{"tag":"b10783","assets":{"a.tar.gz":{"sha256":"abcd"}}}}}`)
+	}))
+	defer server.Close()
+
+	original := digestsURL
+	digestsURL = server.URL + "/digests/%s.json"
+	defer func() { digestsURL = original }()
+
+	m, err := fetchManifest(context.Background(), "b10783")
+	if err != nil {
+		t.Fatalf("fetchManifest() failed: %v", err)
+	}
+	if m.Tag != "b10783" {
+		t.Errorf("Tag = %q, want b10783", m.Tag)
+	}
+	want := "abcd"
+	url := "https://github.com/hybridgroup/llama-cpp-builder/releases/download/b10783/a.tar.gz"
+	if got := m.digestFor(url); got != want {
+		t.Errorf("digestFor() = %q, want %q", got, want)
+	}
+
+	if _, err := fetchManifest(context.Background(), "b00000"); err == nil {
+		t.Error("fetchManifest() for a tag with no manifest returned no error")
+	}
+}
+
+// serveManifest starts a server that gives a manifest naming the assets in digests,
+// and points digestsURL at it for the length of the test.
+func serveManifest(t *testing.T, tag string, digests map[string]string) {
+	t.Helper()
+
+	assets := make([]string, 0, len(digests))
+	for name, digest := range digests {
+		assets = append(assets, fmt.Sprintf("%q:{\"sha256\":%q}", name, digest))
+	}
+	body := fmt.Sprintf(`{"version":1,"tag":%q,"upstream_tag":%q,"sources":{
+		"hybridgroup/llama-cpp-builder":{"tag":%q,"assets":{%s}},
+		"ggml-org/llama.cpp":{"tag":%q,"assets":{%s}}}}`,
+		tag, tag, tag, strings.Join(assets, ","), tag, strings.Join(assets, ","))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	t.Cleanup(server.Close)
+
+	original := digestsURL
+	digestsURL = server.URL + "/digests/%s.json"
+	t.Cleanup(func() { digestsURL = original })
+}
+
+func TestDefaultResolverReportsDigests(t *testing.T) {
+	serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz": "abcd",
+	})
+
+	assets, err := defaultResolver{}.ResolveAssets(Target{
+		Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAssets() failed: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("got %d assets, want 1", len(assets))
+	}
+	if assets[0].SHA256 != "abcd" {
+		t.Errorf("SHA256 = %q, want abcd", assets[0].SHA256)
+	}
+}
+
+func TestDefaultResolverWithNoManifest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	original := digestsURL
+	digestsURL = server.URL + "/digests/%s.json"
+	defer func() { digestsURL = original }()
+
+	// A manifest that is not there must not stop the resolver. The policy decides
+	// what happens to an asset that has no digest.
+	assets, err := defaultResolver{}.ResolveAssets(Target{
+		Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAssets() failed: %v", err)
+	}
+	if len(assets) != 1 || assets[0].SHA256 != "" {
+		t.Errorf("got %v, want one asset with no digest", assets)
+	}
+}
+
+func TestResolveAssetsFromAPlainResolver(t *testing.T) {
+	resolver := ResolverFunc(func(Target) ([]string, error) {
+		return []string{"https://example.com/a.tar.gz"}, nil
+	})
+
+	assets, err := resolveAssets(Target{Version: "b10783"}, resolver, VerifyIfAvailable)
+	if err != nil {
+		t.Fatalf("resolveAssets() failed: %v", err)
+	}
+	if len(assets) != 1 || assets[0].URL != "https://example.com/a.tar.gz" || assets[0].SHA256 != "" {
+		t.Errorf("got %v, want one asset with no digest", assets)
+	}
+}
+
+func TestInstallStopsOnADigestThatDoesNotAgree(t *testing.T) {
+	body := createMockTarGz(t, "b10783")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Write(body)
+	}))
+	defer server.Close()
+
+	dest := t.TempDir()
+	asset := Asset{
+		URL:    server.URL + "/llama-b10783-bin-ubuntu-cpu-arm64.tar.gz",
+		SHA256: strings.Repeat("0", 64),
+	}
+
+	err := get(context.Background(), asset, dest, nil)
+	if !errors.Is(err, ErrDigestMismatch) {
+		t.Fatalf("get() = %v, want ErrDigestMismatch", err)
+	}
+
+	// Nothing may be extracted, and the archive must not stay behind.
+	entries, err := os.ReadDir(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("the destination holds %v, want it empty", names)
+	}
+}
+
+func TestInstallAcceptsADigestThatAgrees(t *testing.T) {
+	body := createMockTarGz(t, "b10783")
+	sum := sha256.Sum256(body)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Write(body)
+	}))
+	defer server.Close()
+
+	dest := t.TempDir()
+	asset := Asset{
+		URL:    server.URL + "/llama-b10783-bin-ubuntu-cpu-arm64.tar.gz",
+		SHA256: hex.EncodeToString(sum[:]),
+	}
+
+	if err := get(context.Background(), asset, dest, nil); err != nil {
+		t.Fatalf("get() failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "libllama.so")); err != nil {
+		t.Errorf("the library was not extracted: %v", err)
+	}
+}
+
+func TestInstallRequiresADigest(t *testing.T) {
+	originalGet := getFunc
+	getFunc = func(context.Context, Asset, string, getter.ProgressTracker) error {
+		t.Error("nothing may be downloaded when a digest is required and missing")
+		return nil
+	}
+	defer func() { getFunc = originalGet }()
+
+	resolver := ResolverFunc(func(Target) ([]string, error) {
+		return []string{"https://example.com/a.tar.gz"}, nil
+	})
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783",
+	}, t.TempDir(), nil, resolver, WithVerify(VerifyRequired))
+
+	if !errors.Is(err, ErrDigestMissing) {
+		t.Errorf("Install() = %v, want ErrDigestMissing", err)
+	}
+}
+
+func TestInstallWarnsWhenAnAssetHasNoDigest(t *testing.T) {
+	originalGet := getFunc
+	getFunc = func(context.Context, Asset, string, getter.ProgressTracker) error { return nil }
+	defer func() { getFunc = originalGet }()
+
+	var warned []string
+	originalWarning := VerifyWarning
+	VerifyWarning = func(url string) { warned = append(warned, url) }
+	defer func() { VerifyWarning = originalWarning }()
+
+	resolver := ResolverFunc(func(Target) ([]string, error) {
+		return []string{"https://example.com/a.tar.gz"}, nil
+	})
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783",
+	}, t.TempDir(), nil, resolver)
+	if err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+
+	if len(warned) != 1 || warned[0] != "https://example.com/a.tar.gz" {
+		t.Errorf("warned about %v, want the one asset", warned)
+	}
+}
+
+func TestVerifyOffSkipsTheCheck(t *testing.T) {
+	var got []Asset
+	originalGet := getFunc
+	getFunc = func(_ context.Context, asset Asset, _ string, _ getter.ProgressTracker) error {
+		got = append(got, asset)
+		return nil
+	}
+	defer func() { getFunc = originalGet }()
+
+	serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz": "abcd",
+	})
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783",
+	}, t.TempDir(), nil, nil, WithVerify(VerifyOff))
+	if err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+
+	if len(got) != 1 || got[0].SHA256 != "" {
+		t.Errorf("got %v, want the asset with no digest to check", got)
+	}
+}
+
+func TestVerifyOffDoesNotFetchAManifest(t *testing.T) {
+	originalGet := getFunc
+	getFunc = func(context.Context, Asset, string, getter.ProgressTracker) error { return nil }
+	defer func() { getFunc = originalGet }()
+
+	var fetched int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetched++
+		fmt.Fprint(w, `{"version":1,"sources":{}}`)
+	}))
+	defer server.Close()
+
+	original := digestsURL
+	digestsURL = server.URL + "/digests/%s.json"
+	defer func() { digestsURL = original }()
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783",
+	}, t.TempDir(), nil, nil, WithVerify(VerifyOff))
+	if err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+
+	// An air-gapped install that checks nothing must not wait on a manifest.
+	if fetched != 0 {
+		t.Errorf("fetched the manifest %d times, want 0", fetched)
+	}
+}

--- a/pkg/download/doc.go
+++ b/pkg/download/doc.go
@@ -18,5 +18,21 @@
 // An empty [Target.Version] takes [DefaultVersion], the llama.cpp release this yzma
 // release was tested with. "latest" always gets the most recent nightly build.
 //
+// # Checking what comes down
+//
+// [Install] checks the SHA-256 of each asset before it writes anything, against the
+// digest manifest that llama-cpp-builder publishes for the release. An asset whose
+// bytes do not agree stops the install with [ErrDigestMismatch], and nothing is
+// extracted.
+//
+// The default policy is [VerifyIfAvailable]: an asset with no digest installs and
+// [VerifyWarning] says so. A deployment that must know what it loads asks for more:
+//
+//	err := download.Install(ctx, target, libPath, download.ProgressTracker, nil,
+//		download.WithVerify(download.VerifyRequired))
+//
+// A [Resolver] reports no digests, so [VerifyRequired] refuses one. Implement
+// [AssetResolver] to give a digest for each asset.
+//
 // See INSTALL.md for the longer version.
 package download

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -170,7 +170,7 @@ func getDownloadLocationAndFilename(arch Arch, os OS, prcssr Processor, version 
 		return "", "", err
 	}
 	for _, url := range urls[:len(urls)-1] {
-		if err := get(context.Background(), url, dest, ProgressTracker); err != nil {
+		if err := get(context.Background(), Asset{URL: url}, dest, ProgressTracker); err != nil {
 			return "", "", err
 		}
 	}
@@ -191,8 +191,8 @@ var getFunc = get
 // string ("") or "latest" is provided, the latest release will be downloaded,
 // with an automatic fallback to the previous version if the latest is still building.
 // dest in the destination directory for the downloaded binaries.
-func Get(architecture string, operatingSystem string, processor string, version string, dest string) error {
-	return GetWithProgress(architecture, operatingSystem, processor, version, dest, ProgressTracker)
+func Get(architecture string, operatingSystem string, processor string, version string, dest string, opts ...InstallOption) error {
+	return GetWithProgress(architecture, operatingSystem, processor, version, dest, ProgressTracker, opts...)
 }
 
 // GetWithProgress downloads the llama.cpp precompiled binaries for the desired arch/OS/processor
@@ -205,8 +205,8 @@ func Get(architecture string, operatingSystem string, processor string, version 
 // string ("") or "latest" is provided, the latest release will be downloaded,
 // with an automatic fallback to the previous version if the latest is still building.
 // dest in the destination directory for the downloaded binaries.
-func GetWithProgress(architecture string, operatingSystem string, processor string, version string, dest string, progress getter.ProgressTracker) error {
-	return GetWithContext(context.Background(), architecture, operatingSystem, processor, version, dest, progress)
+func GetWithProgress(architecture string, operatingSystem string, processor string, version string, dest string, progress getter.ProgressTracker, opts ...InstallOption) error {
+	return GetWithContext(context.Background(), architecture, operatingSystem, processor, version, dest, progress, opts...)
 }
 
 // GetWithContext downloads the llama.cpp precompiled binaries for the desired arch/OS/processor
@@ -219,7 +219,7 @@ func GetWithProgress(architecture string, operatingSystem string, processor stri
 // string ("") or "latest" is provided, the latest release will be downloaded,
 // with an automatic fallback to the previous version if the latest is still building.
 // dest in the destination directory for the downloaded binaries.
-func GetWithContext(ctx context.Context, architecture string, operatingSystem string, processor string, version string, dest string, progress getter.ProgressTracker) error {
+func GetWithContext(ctx context.Context, architecture string, operatingSystem string, processor string, version string, dest string, progress getter.ProgressTracker, opts ...InstallOption) error {
 	arch, err := ParseArch(architecture)
 	if err != nil {
 		return ErrUnknownArch
@@ -235,23 +235,31 @@ func GetWithContext(ctx context.Context, architecture string, operatingSystem st
 		return ErrUnknownProcessor
 	}
 
-	return Install(ctx, Target{Arch: arch, OS: os, Processor: prcssr, Version: version}, dest, progress, nil)
+	return Install(ctx, Target{Arch: arch, OS: os, Processor: prcssr, Version: version}, dest, progress, nil, opts...)
 }
 
-func get(ctx context.Context, url, dest string, progress getter.ProgressTracker) error {
+func get(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
+	url := asset.URL
+
 	// Check if it's a .tar.gz file
 	if strings.HasSuffix(url, ".tar.gz") {
-		err := downloadAndExtractTarGz(url, dest, progress)
+		err := downloadAndExtractTarGz(asset, dest, progress)
 		if err != nil && strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("%w: %s", ErrFileNotFound, url)
 		}
 		return err
 	}
 
-	// Use go-getter for other file types (e.g., .zip)
+	// Use go-getter for other file types (e.g., .zip). go-getter checks the digest
+	// itself and does not unpack an archive that does not agree.
+	src := url
+	if asset.SHA256 != "" {
+		src += "?checksum=sha256:" + asset.SHA256
+	}
+
 	client := &getter.Client{
 		Ctx:  ctx,
-		Src:  url,
+		Src:  src,
 		Dst:  dest,
 		Mode: getter.ClientModeAny,
 	}
@@ -271,7 +279,8 @@ func get(ctx context.Context, url, dest string, progress getter.ProgressTracker)
 }
 
 // downloadAndExtractTarGz downloads a .tar.gz file and extracts it to the destination directory.
-func downloadAndExtractTarGz(url, dest string, progress getter.ProgressTracker) error {
+func downloadAndExtractTarGz(asset Asset, dest string, progress getter.ProgressTracker) error {
+	url := asset.URL
 	downloadFile := filepath.Join(dest, filepath.Base(url))
 
 	client := &getter.Client{
@@ -293,6 +302,10 @@ func downloadAndExtractTarGz(url, dest string, progress getter.ProgressTracker) 
 		return err
 	}
 	defer os.Remove(downloadFile)
+
+	if err := verifyFile(downloadFile, asset.SHA256); err != nil {
+		return err
+	}
 
 	resp, err := os.Open(downloadFile)
 	if err != nil {

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -181,10 +181,10 @@ func TestGetLinuxCPU(t *testing.T) {
 
 	// Override the get function to use our mock server
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
 		// Replace the real URL with our mock server URL
 		mockURL := server.URL + "/b7974/llama-b7974-bin-ubuntu-x64.tar.gz"
-		return downloadAndExtractTarGz(mockURL, dest, nil)
+		return downloadAndExtractTarGz(Asset{URL: mockURL}, dest, nil)
 	}
 	defer func() { getFunc = originalGet }()
 
@@ -810,9 +810,9 @@ func TestGet404Error(t *testing.T) {
 
 	// Override the get function to use our mock server
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
 		mockURL := server.URL + "/mock.tar.gz"
-		return get(ctx, mockURL, dest, nil)
+		return get(ctx, Asset{URL: mockURL}, dest, nil)
 	}
 	defer func() { getFunc = originalGet }()
 
@@ -864,14 +864,15 @@ func TestGetWithContext_FallbackToPreviousVersion(t *testing.T) {
 
 	// Override getFunc to use our test server
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
+		url := asset.URL
 		// Mock url rewriting to point to our test server
 		parts := strings.Split(url, "/")
 		filename := parts[len(parts)-1]
 		versionPart := parts[len(parts)-2]
 
 		mockURL := server.URL + "/" + versionPart + "/" + filename
-		err := downloadAndExtractTarGz(mockURL, dest, nil)
+		err := downloadAndExtractTarGz(Asset{URL: mockURL}, dest, nil)
 		if err != nil && strings.Contains(err.Error(), "404") {
 			return fmt.Errorf("%w: %s", ErrFileNotFound, url)
 		}
@@ -970,7 +971,7 @@ func TestExtractTarGzUpgradeRepointsSymlink(t *testing.T) {
 	}))
 	defer server.Close()
 
-	if err := downloadAndExtractTarGz(server.URL+"/b10375/llama-b10375-bin-ubuntu-x64.tar.gz", dest, nil); err != nil {
+	if err := downloadAndExtractTarGz(Asset{URL: server.URL + "/b10375/llama-b10375-bin-ubuntu-x64.tar.gz"}, dest, nil); err != nil {
 		t.Fatalf("downloadAndExtractTarGz() failed: %v", err)
 	}
 

--- a/pkg/download/main_test.go
+++ b/pkg/download/main_test.go
@@ -1,0 +1,17 @@
+//go:build !manifest
+
+package download
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain points the digest manifests at an address that answers nothing, so an
+// ordinary test run does not reach the network. A test that needs a manifest sets
+// digestsURL to its own server. The tests behind the "manifest" build tag talk to the
+// real site on purpose, so this does not apply to them.
+func TestMain(m *testing.M) {
+	digestsURL = "http://127.0.0.1:0/digests/%s.json"
+	os.Exit(m.Run())
+}

--- a/pkg/download/manifest_test.go
+++ b/pkg/download/manifest_test.go
@@ -10,6 +10,7 @@
 package download
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -124,4 +125,72 @@ func TestDefaultResolverMatchesRelease(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDigestManifestCoversResolvedAssets checks that the published digest manifest
+// names every asset the built-in table can ask for. An asset the manifest misses
+// installs with no check under the default policy, so this catches a manifest that
+// falls behind the table.
+func TestDigestManifestCoversResolvedAssets(t *testing.T) {
+	tag := os.Getenv("YZMA_TEST_LLAMA_TAG")
+	if tag == "" {
+		latest, err := LlamaLatestVersion()
+		if err != nil {
+			t.Fatalf("LlamaLatestVersion() failed: %v", err)
+		}
+		tag = latest
+	}
+
+	target := Target{Version: tag}
+	if IsTaggedRelease(tag) {
+		upstream, err := LlamaNightlyTag(tag)
+		if err != nil {
+			t.Fatalf("LlamaNightlyTag(%s) failed: %v", tag, err)
+		}
+		target.UpstreamVersion = upstream
+	}
+
+	m, err := fetchManifest(context.Background(), tag)
+	if err != nil {
+		t.Fatalf("fetching the digests of %s failed: %v", tag, err)
+	}
+
+	// Every combination the table accepts, so a new platform is covered as soon as
+	// the table names it.
+	oses := []OS{Linux, Bookworm, Trixie, Darwin, Windows, Wasm}
+	arches := []Arch{AMD64, ARM64}
+	processors := []Processor{CPU, CUDA, Metal, ROCm, Vulkan, WebGPU}
+
+	seen := make(map[string]bool)
+	for _, os := range oses {
+		for _, arch := range arches {
+			for _, processor := range processors {
+				candidate := target
+				candidate.Arch, candidate.OS, candidate.Processor = arch, os, processor
+
+				urls, err := DefaultResolver.Resolve(candidate)
+				if err != nil {
+					// The table does not build this combination.
+					continue
+				}
+
+				for _, url := range urls {
+					if seen[url] {
+						continue
+					}
+					seen[url] = true
+
+					if m.digestFor(url) == "" {
+						t.Errorf("the digests of %s do not name %s (%s/%s/%s)",
+							tag, url, os, arch, processor)
+					}
+				}
+			}
+		}
+	}
+
+	if len(seen) == 0 {
+		t.Fatal("no assets resolved")
+	}
+	t.Logf("checked %d assets for %s", len(seen), tag)
 }

--- a/pkg/download/record.go
+++ b/pkg/download/record.go
@@ -15,9 +15,8 @@ const InstallRecordName = "yzma-install.json"
 // InstallRecord says which llama.cpp release is installed in a library directory, and
 // which assets it came from.
 //
-// The record is beside the libraries, so anything that can change the libraries can
-// change the record. It says what an install believed it did. It is not evidence on
-// its own, which is why [VerifyInstall] takes a tag to check against.
+// The record is beside the libraries, so anything that can change them can change it.
+// Give [VerifyInstall] a tag to check against instead.
 type InstallRecord struct {
 	Version int `json:"version"`
 

--- a/pkg/download/record.go
+++ b/pkg/download/record.go
@@ -1,0 +1,103 @@
+package download
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// InstallRecordName is the file that [Install] writes in the library directory to say
+// what it put there. [VerifyInstall] reads it.
+const InstallRecordName = "yzma-install.json"
+
+// InstallRecord says which llama.cpp release is installed in a library directory, and
+// which assets it came from.
+//
+// The record is beside the libraries, so anything that can change the libraries can
+// change the record. It says what an install believed it did. It is not evidence on
+// its own, which is why [VerifyInstall] takes a tag to check against.
+type InstallRecord struct {
+	Version int `json:"version"`
+
+	// Tag is the llama.cpp release that was installed.
+	Tag string `json:"tag"`
+
+	// UpstreamTag is the nightly build tag that held the binaries for a tagged
+	// release. It is empty for a nightly tag, which names its own assets.
+	UpstreamTag string `json:"upstream_tag,omitempty"`
+
+	// Arch, OS and Processor name the build, so a check can resolve the assets
+	// again for a different tag.
+	Arch      string `json:"arch"`
+	OS        string `json:"os"`
+	Processor string `json:"processor"`
+
+	Installed time.Time `json:"installed"`
+
+	// Assets are the assets that were downloaded, in the order they installed.
+	Assets []Asset `json:"assets"`
+}
+
+// recordVersion is the format of the records this release writes.
+const recordVersion = 1
+
+// WriteInstallRecord writes the record of an install into libPath.
+func WriteInstallRecord(libPath string, record InstallRecord) error {
+	record.Version = recordVersion
+
+	body, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+
+	path := filepath.Join(libPath, InstallRecordName)
+	if err := os.WriteFile(path, body, 0644); err != nil {
+		return fmt.Errorf("failed to write the install record: %w", err)
+	}
+
+	return nil
+}
+
+// ReadInstallRecord reads the record that [Install] left in libPath.
+func ReadInstallRecord(libPath string) (*InstallRecord, error) {
+	body, err := os.ReadFile(filepath.Join(libPath, InstallRecordName))
+	if err != nil {
+		return nil, err
+	}
+
+	var record InstallRecord
+	if err := json.Unmarshal(body, &record); err != nil {
+		return nil, fmt.Errorf("failed to read the install record: %w", err)
+	}
+
+	return &record, nil
+}
+
+// target rebuilds the [Target] that made an install.
+func (r *InstallRecord) target() (Target, error) {
+	arch, err := ParseArch(r.Arch)
+	if err != nil {
+		return Target{}, ErrUnknownArch
+	}
+
+	operatingSystem, err := ParseOS(r.OS)
+	if err != nil {
+		return Target{}, ErrUnknownOS
+	}
+
+	processor, err := ParseProcessor(r.Processor)
+	if err != nil {
+		return Target{}, ErrUnknownProcessor
+	}
+
+	return Target{
+		Arch:            arch,
+		OS:              operatingSystem,
+		Processor:       processor,
+		Version:         r.Tag,
+		UpstreamVersion: r.UpstreamTag,
+	}, nil
+}

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -40,8 +40,44 @@ type ResolverFunc func(target Target) ([]string, error)
 func (f ResolverFunc) Resolve(target Target) ([]string, error) { return f(target) }
 
 // DefaultResolver resolves the assets published on the llama.cpp and llama-cpp-builder
-// release pages. [Install] uses it when no resolver is given.
-var DefaultResolver Resolver = ResolverFunc(defaultResolve)
+// release pages. [Install] uses it when no resolver is given. It satisfies
+// [AssetResolver] as well, so it reports the expected digest of each asset.
+var DefaultResolver Resolver = defaultResolver{}
+
+// defaultResolver is the built-in resolver. It reads the digest manifest that
+// llama-cpp-builder publishes for each release tag.
+type defaultResolver struct{}
+
+// Resolve reports the assets to install as URLs.
+func (defaultResolver) Resolve(target Target) ([]string, error) {
+	return defaultResolve(target)
+}
+
+// ResolveAssets reports the assets to install with their expected digests. A manifest
+// that cannot be read gives assets with no digest, which [VerifyIfAvailable] permits
+// and [VerifyRequired] refuses.
+func (r defaultResolver) ResolveAssets(target Target) ([]Asset, error) {
+	urls, err := defaultResolve(target)
+	if err != nil {
+		return nil, err
+	}
+
+	assets := make([]Asset, len(urls))
+	for i, url := range urls {
+		assets[i] = Asset{URL: url}
+	}
+
+	m, err := fetchManifest(context.Background(), target.Version)
+	if err != nil {
+		return assets, nil
+	}
+
+	for i := range assets {
+		assets[i].SHA256 = m.digestFor(assets[i].URL)
+	}
+
+	return assets, nil
+}
 
 // llama.cpp renamed its ROCm assets at these two builds.
 const (
@@ -270,11 +306,33 @@ func defaultResolve(target Target) ([]string, error) {
 	return append(extra, fmt.Sprintf("%s/%s", location, filename)), nil
 }
 
+// InstallOption changes what [Install] does.
+type InstallOption func(*installOptions)
+
+// installOptions holds the settings that an [InstallOption] changes.
+type installOptions struct {
+	verify VerifyPolicy
+}
+
+// WithVerify sets what [Install] does about the digest of an asset. The default is
+// [VerifyIfAvailable].
+func WithVerify(policy VerifyPolicy) InstallOption {
+	return func(o *installOptions) { o.verify = policy }
+}
+
 // Install downloads the llama.cpp binaries for target into dest. A nil resolver means
 // [DefaultResolver]. An empty [Target.Version] takes [DefaultVersion].
-func Install(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver) error {
+//
+// Install checks the digest of each asset that has one, and stops before it writes
+// anything if the bytes do not agree. Use [WithVerify] to change that.
+func Install(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver, opts ...InstallOption) error {
 	if resolver == nil {
 		resolver = DefaultResolver
+	}
+
+	var options installOptions
+	for _, opt := range opts {
+		opt(&options)
 	}
 
 	// An empty version takes the release pinned by this yzma release. "latest" always
@@ -306,7 +364,7 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 		target.UpstreamVersion = upstream
 	}
 
-	err := installAssets(ctx, target, dest, progress, resolver)
+	err := installAssets(ctx, target, dest, progress, resolver, options)
 
 	// The newest release may still be building for this platform.
 	if err != nil && autoVersion && errors.Is(err, ErrFileNotFound) {
@@ -322,21 +380,54 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 				return err
 			}
 		}
-		return installAssets(ctx, target, dest, progress, resolver)
+		return installAssets(ctx, target, dest, progress, resolver, options)
 	}
 
 	return err
 }
 
-func installAssets(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver) error {
-	urls, err := resolver.Resolve(target)
+func installAssets(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver, options installOptions) error {
+	assets, err := resolveAssets(target, resolver, options.verify)
 	if err != nil {
 		return err
 	}
-	for _, url := range urls {
-		if err := getFunc(ctx, url, dest, progress); err != nil {
+
+	for _, asset := range assets {
+		switch {
+		case options.verify == VerifyOff, asset.SHA256 != "":
+			// Nothing to say. A digest that is there is checked as it downloads.
+		case options.verify == VerifyRequired:
+			return fmt.Errorf("%w: %s", ErrDigestMissing, asset.URL)
+		case VerifyWarning != nil:
+			VerifyWarning(asset.URL)
+		}
+
+		if err := getFunc(ctx, asset, dest, progress); err != nil {
 			return err
 		}
 	}
+
 	return nil
+}
+
+// resolveAssets asks a resolver for the assets to install. A resolver that reports
+// digests is preferred, so a resolver that only has [Resolver] keeps working.
+// [VerifyOff] takes the plain [Resolver], because a digest that nothing reads is not
+// worth the fetch of a manifest.
+func resolveAssets(target Target, resolver Resolver, verify VerifyPolicy) ([]Asset, error) {
+	if assetResolver, ok := resolver.(AssetResolver); ok && verify != VerifyOff {
+		return assetResolver.ResolveAssets(target)
+	}
+
+	urls, err := resolver.Resolve(target)
+	if err != nil {
+		return nil, err
+	}
+
+	assets := make([]Asset, len(urls))
+	for i, url := range urls {
+		assets[i] = Asset{URL: url}
+	}
+
+	return assets, nil
 }

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	getter "github.com/hashicorp/go-getter"
 )
@@ -364,10 +365,13 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 		target.UpstreamVersion = upstream
 	}
 
-	err := installAssets(ctx, target, dest, progress, resolver, options)
+	assets, err := installAssets(ctx, target, dest, progress, resolver, options)
+	if err == nil {
+		return recordInstall(dest, target, assets)
+	}
 
 	// The newest release may still be building for this platform.
-	if err != nil && autoVersion && errors.Is(err, ErrFileNotFound) {
+	if autoVersion && errors.Is(err, ErrFileNotFound) {
 		previous, prevErr := LlamaPreviousVersion()
 		if prevErr != nil {
 			return err
@@ -380,16 +384,34 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 				return err
 			}
 		}
-		return installAssets(ctx, target, dest, progress, resolver, options)
+		assets, err := installAssets(ctx, target, dest, progress, resolver, options)
+		if err != nil {
+			return err
+		}
+		return recordInstall(dest, target, assets)
 	}
 
 	return err
 }
 
-func installAssets(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver, options installOptions) error {
+// recordInstall leaves a record of what was installed, so [VerifyInstall] can check
+// the files later.
+func recordInstall(dest string, target Target, assets []Asset) error {
+	return WriteInstallRecord(dest, InstallRecord{
+		Tag:         target.Version,
+		UpstreamTag: target.UpstreamVersion,
+		Arch:        target.Arch.String(),
+		OS:          target.OS.String(),
+		Processor:   target.Processor.String(),
+		Installed:   time.Now().UTC(),
+		Assets:      assets,
+	})
+}
+
+func installAssets(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver, options installOptions) ([]Asset, error) {
 	assets, err := resolveAssets(target, resolver, options.verify)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, asset := range assets {
@@ -397,17 +419,17 @@ func installAssets(ctx context.Context, target Target, dest string, progress get
 		case options.verify == VerifyOff, asset.SHA256 != "":
 			// Nothing to say. A digest that is there is checked as it downloads.
 		case options.verify == VerifyRequired:
-			return fmt.Errorf("%w: %s", ErrDigestMissing, asset.URL)
+			return nil, fmt.Errorf("%w: %s", ErrDigestMissing, asset.URL)
 		case VerifyWarning != nil:
 			VerifyWarning(asset.URL)
 		}
 
 		if err := getFunc(ctx, asset, dest, progress); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return assets, nil
 }
 
 // resolveAssets asks a resolver for the assets to install. A resolver that reports

--- a/pkg/download/resolver_test.go
+++ b/pkg/download/resolver_test.go
@@ -14,7 +14,8 @@ import (
 func TestInstallUsesResolver(t *testing.T) {
 	var got []string
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
+		url := asset.URL
 		got = append(got, url)
 		return nil
 	}
@@ -45,7 +46,7 @@ func TestInstallUsesResolver(t *testing.T) {
 
 func TestInstallResolverError(t *testing.T) {
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
 		t.Fatal("Install() downloaded despite a resolver error")
 		return nil
 	}
@@ -64,7 +65,8 @@ func TestInstallResolverError(t *testing.T) {
 func TestInstallNilResolverUsesDefault(t *testing.T) {
 	var got []string
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
+		url := asset.URL
 		got = append(got, url)
 		return nil
 	}
@@ -194,7 +196,7 @@ func TestInstallNightlyTagSkipsNightlyTagLookup(t *testing.T) {
 	defer func() { nightlyTagURL = originalURL }()
 
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
 		return nil
 	}
 	defer func() { getFunc = originalGet }()
@@ -223,7 +225,8 @@ func TestInstallUsesDefaultVersion(t *testing.T) {
 
 	var got []string
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
+		url := asset.URL
 		got = append(got, url)
 		return nil
 	}
@@ -248,7 +251,8 @@ func TestInstallExplicitVersionOverridesDefault(t *testing.T) {
 
 	var got []string
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
+		url := asset.URL
 		got = append(got, url)
 		return nil
 	}
@@ -283,7 +287,8 @@ func TestInstallLatestSkipsDefaultVersion(t *testing.T) {
 
 	var got []string
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
+		url := asset.URL
 		got = append(got, url)
 		return nil
 	}
@@ -323,7 +328,7 @@ func TestInstallDefaultVersionDoesNotFallBack(t *testing.T) {
 	defer func() { DefaultVersion = originalDefault }()
 
 	originalGet := getFunc
-	getFunc = func(ctx context.Context, url string, dest string, progress getter.ProgressTracker) error {
+	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {
 		return ErrFileNotFound
 	}
 	defer func() { getFunc = originalGet }()

--- a/pkg/download/verify.go
+++ b/pkg/download/verify.go
@@ -100,9 +100,8 @@ func (r *VerifyReport) OK() bool {
 // VerifyInstall checks the files in libPath against the digests that the publisher
 // recorded for the release installed there.
 //
-// An empty tag takes the tag from the install record. Give a tag to say which release
-// must be there, which does not trust the record: the record sits beside the libraries
-// and anything that can change one can change the other.
+// An empty tag takes the tag from the install record. Give a tag to name the release
+// that must be there, which does not trust the record.
 func VerifyInstall(ctx context.Context, libPath, tag string) (*VerifyReport, error) {
 	record, err := ReadInstallRecord(libPath)
 	if err != nil {

--- a/pkg/download/verify.go
+++ b/pkg/download/verify.go
@@ -1,0 +1,292 @@
+package download
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var (
+	// ErrNoInstallRecord means a library directory has no record of an install, so
+	// there is nothing to say which release should be there.
+	ErrNoInstallRecord = errors.New("no install record")
+
+	// ErrNoFileDigests means the manifest for a release gives the digest of each
+	// archive but not of the files in them, so an installation cannot be checked.
+	ErrNoFileDigests = errors.New("the digests of this release do not cover files")
+
+	// ErrRecordMismatch means the install record does not agree with the release it
+	// is checked against.
+	ErrRecordMismatch = errors.New("the install record does not agree")
+)
+
+// FileState is what [VerifyInstall] found for one name.
+type FileState int
+
+const (
+	// FileVerified means the file on disk has the bytes the publisher recorded.
+	FileVerified FileState = iota
+
+	// FileChanged means the file is there and the bytes are not the same.
+	FileChanged
+
+	// FileMissing means the install should have put the file there and it is gone.
+	FileMissing
+
+	// FileUnexpected means the file is in the directory and no asset of this
+	// install holds it. Another install in the same directory makes these.
+	FileUnexpected
+)
+
+// String gives the name of a state.
+func (s FileState) String() string {
+	switch s {
+	case FileVerified:
+		return "verified"
+	case FileChanged:
+		return "changed"
+	case FileMissing:
+		return "missing"
+	case FileUnexpected:
+		return "unexpected"
+	default:
+		return "unknown"
+	}
+}
+
+// FileReport is what [VerifyInstall] found for one name.
+type FileReport struct {
+	Name  string    `json:"name"`
+	State FileState `json:"state"`
+}
+
+// MarshalJSON writes the state as its name.
+func (s FileState) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
+}
+
+// VerifyReport is what [VerifyInstall] found in a library directory.
+type VerifyReport struct {
+	// Tag is the release the files were checked against.
+	Tag string `json:"tag"`
+
+	// LibPath is the directory that was checked.
+	LibPath string `json:"lib_path"`
+
+	// Files holds one entry for each name, sorted by name.
+	Files []FileReport `json:"files"`
+
+	// Counts of each state.
+	Verified   int `json:"verified"`
+	Changed    int `json:"changed"`
+	Missing    int `json:"missing"`
+	Unexpected int `json:"unexpected"`
+}
+
+// OK reports whether every file the install put there is still what the publisher
+// recorded. A file that belongs to something else does not make it false.
+func (r *VerifyReport) OK() bool {
+	return r.Changed == 0 && r.Missing == 0
+}
+
+// VerifyInstall checks the files in libPath against the digests that the publisher
+// recorded for the release installed there.
+//
+// An empty tag takes the tag from the install record. Give a tag to say which release
+// must be there, which does not trust the record: the record sits beside the libraries
+// and anything that can change one can change the other.
+func VerifyInstall(ctx context.Context, libPath, tag string) (*VerifyReport, error) {
+	record, err := ReadInstallRecord(libPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w in %s", ErrNoInstallRecord, libPath)
+		}
+		return nil, err
+	}
+
+	target, err := record.target()
+	if err != nil {
+		return nil, err
+	}
+
+	// A caller that names a tag gets the assets of that tag, resolved again. The
+	// recorded URLs are never used then, because a record that says the wrong tag
+	// can name the wrong assets as easily.
+	assets := record.Assets
+	if tag != "" {
+		target.Version = tag
+		target.UpstreamVersion = ""
+		if IsTaggedRelease(tag) {
+			upstream, err := LlamaNightlyTag(tag)
+			if err != nil {
+				return nil, err
+			}
+			target.UpstreamVersion = upstream
+		}
+
+		urls, err := DefaultResolver.Resolve(target)
+		if err != nil {
+			return nil, err
+		}
+		assets = make([]Asset, len(urls))
+		for i, url := range urls {
+			assets[i] = Asset{URL: url}
+		}
+	} else {
+		tag = record.Tag
+	}
+
+	m, err := fetchManifest(ctx, tag)
+	if err != nil {
+		return nil, err
+	}
+
+	// Gather what the assets of this install should have put in the directory.
+	wantFiles := make(map[string]string)
+	wantLinks := make(map[string]string)
+	found := 0
+	for _, asset := range assets {
+		entry, ok := m.assetFor(asset.URL)
+		if !ok {
+			continue
+		}
+		found++
+		for name, digest := range entry.Files {
+			wantFiles[name] = digest
+		}
+		for name, destination := range entry.Links {
+			wantLinks[name] = destination
+		}
+	}
+
+	// A record that names assets of another release cannot be checked against this
+	// one. A record that was changed by hand looks like this.
+	if found == 0 {
+		return nil, fmt.Errorf("%w: the install record names assets that %s does not publish",
+			ErrRecordMismatch, tag)
+	}
+
+	if len(wantFiles) == 0 && len(wantLinks) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrNoFileDigests, tag)
+	}
+
+	report := &VerifyReport{Tag: tag, LibPath: libPath}
+	seen := make(map[string]bool)
+
+	err = filepath.WalkDir(libPath, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		name, err := filepath.Rel(libPath, path)
+		if err != nil {
+			return err
+		}
+		name = filepath.ToSlash(name)
+
+		// The record is not part of any asset.
+		if name == InstallRecordName {
+			return nil
+		}
+
+		seen[name] = true
+
+		if entry.Type()&fs.ModeSymlink != 0 {
+			want, ok := wantLinks[name]
+			if !ok {
+				report.add(name, FileUnexpected)
+				return nil
+			}
+			got, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			if got != want {
+				report.add(name, FileChanged)
+				return nil
+			}
+			report.add(name, FileVerified)
+			return nil
+		}
+
+		want, ok := wantFiles[name]
+		if !ok {
+			report.add(name, FileUnexpected)
+			return nil
+		}
+
+		got, err := hashFile(path)
+		if err != nil {
+			return err
+		}
+		if !strings.EqualFold(got, want) {
+			report.add(name, FileChanged)
+			return nil
+		}
+		report.add(name, FileVerified)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for name := range wantFiles {
+		if !seen[name] {
+			report.add(name, FileMissing)
+		}
+	}
+	for name := range wantLinks {
+		if !seen[name] {
+			report.add(name, FileMissing)
+		}
+	}
+
+	sort.Slice(report.Files, func(i, j int) bool {
+		return report.Files[i].Name < report.Files[j].Name
+	})
+
+	return report, nil
+}
+
+// add puts one result in the report and counts it.
+func (r *VerifyReport) add(name string, state FileState) {
+	r.Files = append(r.Files, FileReport{Name: name, State: state})
+
+	switch state {
+	case FileVerified:
+		r.Verified++
+	case FileChanged:
+		r.Changed++
+	case FileMissing:
+		r.Missing++
+	case FileUnexpected:
+		r.Unexpected++
+	}
+}
+
+// hashFile gives the SHA-256 of a file, in hexadecimal.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/pkg/download/verify_test.go
+++ b/pkg/download/verify_test.go
@@ -1,0 +1,320 @@
+package download
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	getter "github.com/hashicorp/go-getter"
+)
+
+// installedBundle is a small stand-in for an extracted llama.cpp bundle: a file, a
+// file in a subdirectory, and the symbolic link chain that the real bundles have.
+type installedBundle struct {
+	libPath string
+	files   map[string]string
+	links   map[string]string
+}
+
+// writeBundle puts a bundle on disk and gives the digests that describe it.
+func writeBundle(t *testing.T) installedBundle {
+	t.Helper()
+
+	libPath := t.TempDir()
+	bundle := installedBundle{
+		libPath: libPath,
+		files:   map[string]string{},
+		links:   map[string]string{"libllama.so": "libllama.so.0", "libllama.so.0": "libllama.so.0.3.0"},
+	}
+
+	contents := map[string]string{
+		"libllama.so.0.3.0": "the library",
+		"lib/libggml.so":    "a backend",
+	}
+	for name, body := range contents {
+		path := filepath.Join(libPath, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+		sum := sha256.Sum256([]byte(body))
+		bundle.files[name] = hex.EncodeToString(sum[:])
+	}
+
+	for name, destination := range bundle.links {
+		if err := os.Symlink(destination, filepath.Join(libPath, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return bundle
+}
+
+// serveBundleManifest publishes a manifest that describes a bundle, and writes the
+// install record that points at it.
+func serveBundleManifest(t *testing.T, bundle installedBundle, tag string) {
+	t.Helper()
+
+	const assetName = "llama-%s-bin-ubuntu-cpu-arm64.tar.gz"
+	name := fmt.Sprintf(assetName, tag)
+
+	body, err := json.Marshal(manifest{
+		Version: 1,
+		Tag:     tag,
+		Sources: map[string]manifestSource{
+			"hybridgroup/llama-cpp-builder": {
+				Tag: tag,
+				Assets: map[string]manifestAsset{
+					name: {SHA256: "aaaa", Files: bundle.files, Links: bundle.links},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+
+	original := digestsURL
+	digestsURL = server.URL + "/digests/%s.json"
+	t.Cleanup(func() { digestsURL = original })
+
+	record := InstallRecord{
+		Tag: tag, Arch: "arm64", OS: "linux", Processor: "cpu",
+		Assets: []Asset{{
+			URL: fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s/%s", tag, name),
+		}},
+	}
+	if err := WriteInstallRecord(bundle.libPath, record); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyInstallOnAnUntouchedInstall(t *testing.T) {
+	bundle := writeBundle(t)
+	serveBundleManifest(t, bundle, "b10783")
+
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "")
+	if err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+
+	if !report.OK() {
+		t.Errorf("report is not OK: %+v", report)
+	}
+	// Two files and two links, and the record itself is not counted.
+	if report.Verified != 4 || report.Changed != 0 || report.Missing != 0 || report.Unexpected != 0 {
+		t.Errorf("got %d verified, %d changed, %d missing, %d unexpected; want 4/0/0/0",
+			report.Verified, report.Changed, report.Missing, report.Unexpected)
+	}
+	if report.Tag != "b10783" {
+		t.Errorf("Tag = %q, want b10783", report.Tag)
+	}
+}
+
+func TestVerifyInstallFindsAChangedFile(t *testing.T) {
+	bundle := writeBundle(t)
+	serveBundleManifest(t, bundle, "b10783")
+
+	path := filepath.Join(bundle.libPath, "libllama.so.0.3.0")
+	if err := os.WriteFile(path, []byte("something else"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "")
+	if err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+	if report.OK() {
+		t.Error("a changed library must not be OK")
+	}
+	if report.Changed != 1 {
+		t.Errorf("Changed = %d, want 1", report.Changed)
+	}
+	if state := stateOf(report, "libllama.so.0.3.0"); state != FileChanged {
+		t.Errorf("state = %v, want changed", state)
+	}
+}
+
+func TestVerifyInstallFindsAMissingFile(t *testing.T) {
+	bundle := writeBundle(t)
+	serveBundleManifest(t, bundle, "b10783")
+
+	if err := os.Remove(filepath.Join(bundle.libPath, "lib", "libggml.so")); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "")
+	if err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+	if report.OK() {
+		t.Error("a missing library must not be OK")
+	}
+	if state := stateOf(report, "lib/libggml.so"); state != FileMissing {
+		t.Errorf("state = %v, want missing", state)
+	}
+}
+
+func TestVerifyInstallFindsARepointedLink(t *testing.T) {
+	bundle := writeBundle(t)
+	serveBundleManifest(t, bundle, "b10783")
+
+	path := filepath.Join(bundle.libPath, "libllama.so")
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("libevil.so", path); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "")
+	if err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+	if report.OK() {
+		t.Error("a link that points somewhere else must not be OK")
+	}
+	if state := stateOf(report, "libllama.so"); state != FileChanged {
+		t.Errorf("state = %v, want changed", state)
+	}
+}
+
+func TestVerifyInstallReportsAFileThatIsNotPartOfTheInstall(t *testing.T) {
+	bundle := writeBundle(t)
+	serveBundleManifest(t, bundle, "b10783")
+
+	if err := os.WriteFile(filepath.Join(bundle.libPath, "libextra.so"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "")
+	if err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+	// A directory can hold more than one install, so this alone is not a failure.
+	if !report.OK() {
+		t.Error("a file that belongs to something else must not fail the check")
+	}
+	if report.Unexpected != 1 {
+		t.Errorf("Unexpected = %d, want 1", report.Unexpected)
+	}
+	if state := stateOf(report, "libextra.so"); state != FileUnexpected {
+		t.Errorf("state = %v, want unexpected", state)
+	}
+}
+
+func TestVerifyInstallDoesNotTrustTheRecordTag(t *testing.T) {
+	bundle := writeBundle(t)
+	serveBundleManifest(t, bundle, "b10783")
+
+	// Rewrite the record the way something that changed the libraries would.
+	record, err := ReadInstallRecord(bundle.libPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record.Tag = "b10780"
+	if err := WriteInstallRecord(bundle.libPath, *record); err != nil {
+		t.Fatal(err)
+	}
+
+	// The operator says which release must be there, so the assets are resolved
+	// again for that release instead of taken from the record.
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "b10783")
+	if err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+	if !report.OK() {
+		t.Errorf("report is not OK: %+v", report)
+	}
+	if report.Tag != "b10783" {
+		t.Errorf("Tag = %q, want the tag the caller asked for", report.Tag)
+	}
+}
+
+func TestVerifyInstallWithNoRecord(t *testing.T) {
+	_, err := VerifyInstall(context.Background(), t.TempDir(), "")
+	if !errors.Is(err, ErrNoInstallRecord) {
+		t.Errorf("VerifyInstall() = %v, want ErrNoInstallRecord", err)
+	}
+}
+
+func TestVerifyInstallWithNoFileDigests(t *testing.T) {
+	bundle := writeBundle(t)
+	bundle.files = nil
+	bundle.links = nil
+	serveBundleManifest(t, bundle, "b10783")
+
+	_, err := VerifyInstall(context.Background(), bundle.libPath, "")
+	if !errors.Is(err, ErrNoFileDigests) {
+		t.Errorf("VerifyInstall() = %v, want ErrNoFileDigests", err)
+	}
+}
+
+func TestVerifyInstallWithARecordForAnotherRelease(t *testing.T) {
+	bundle := writeBundle(t)
+	serveBundleManifest(t, bundle, "b10783")
+
+	record, err := ReadInstallRecord(bundle.libPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record.Assets = []Asset{{
+		URL: "https://github.com/hybridgroup/llama-cpp-builder/releases/download/b10000/llama-b10000-bin-ubuntu-cpu-arm64.tar.gz",
+	}}
+	if err := WriteInstallRecord(bundle.libPath, *record); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = VerifyInstall(context.Background(), bundle.libPath, "")
+	if !errors.Is(err, ErrRecordMismatch) {
+		t.Errorf("VerifyInstall() = %v, want ErrRecordMismatch", err)
+	}
+}
+
+func TestInstallWritesARecord(t *testing.T) {
+	originalGet := getFunc
+	getFunc = func(context.Context, Asset, string, getter.ProgressTracker) error { return nil }
+	defer func() { getFunc = originalGet }()
+
+	dest := t.TempDir()
+	target := Target{Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783"}
+	if err := Install(context.Background(), target, dest, nil, nil, WithVerify(VerifyOff)); err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+
+	record, err := ReadInstallRecord(dest)
+	if err != nil {
+		t.Fatalf("reading the record failed: %v", err)
+	}
+	if record.Tag != "b10783" || record.Arch != "arm64" || record.OS != "linux" || record.Processor != "cpu" {
+		t.Errorf("record = %+v, want the target that was installed", record)
+	}
+	if len(record.Assets) != 1 {
+		t.Errorf("record names %d assets, want 1", len(record.Assets))
+	}
+}
+
+// stateOf gives the state a report holds for a name.
+func stateOf(report *VerifyReport, name string) FileState {
+	for _, file := range report.Files {
+		if file.Name == name {
+			return file.State
+		}
+	}
+	return -1
+}

--- a/pkg/download/verify_test.go
+++ b/pkg/download/verify_test.go
@@ -16,8 +16,8 @@ import (
 	getter "github.com/hashicorp/go-getter"
 )
 
-// installedBundle is a small stand-in for an extracted llama.cpp bundle: a file, a
-// file in a subdirectory, and the symbolic link chain that the real bundles have.
+// installedBundle is a small stand-in for an extracted llama.cpp bundle. It has a
+// file, a file in a subdirectory, and the symbolic link chain the real bundles have.
 type installedBundle struct {
 	libPath string
 	files   map[string]string


### PR DESCRIPTION
This change checks the llama.cpp bundles that yzma installs. It also adds a command to
check an installation later.

This is the yzma part of #322. The report came from ardanlabs/kronk#921. The builder part
is hybridgroup/llama-cpp-builder#39 and #40.

## What it does

`Install` reads the expected SHA-256 of each asset. The digests come from the manifest
that `llama-cpp-builder` publishes for the release. If the bytes do not agree, `Install`
stops before it writes anything.

A `.tar.gz` file is hashed after it downloads and before the gzip reader opens it. A
`.zip` file goes to go-getter with `?checksum=sha256:`, which go-getter already supports.

The manifest is on the same site as `version.json`. Thus the check does not use the
GitHub API, which has a rate limit. The current code avoids that API on purpose.

`yzma verify` checks the files that are in place.

```
$ yzma verify --lib /path/to/lib
llama.cpp b10783 in /path/to/lib
68 verified, 0 changed, 0 missing, 0 not part of this install
ok.
```

## The Resolver contract stays the same

`Resolver` returns `[]string`, so it cannot carry a digest. That method is exported and
the `examples/resolver` code shows it. This change adds a second interface instead.

```go
type Asset struct {
	URL    string `json:"url"`
	SHA256 string `json:"sha256,omitempty"`
}

type AssetResolver interface {
	ResolveAssets(target Target) ([]Asset, error)
}
```

`Install` uses `ResolveAssets` when a resolver has both methods. An existing `Resolver`
continues to work and reports no digest. `DefaultResolver` has both methods, so
`download.DefaultResolver.Resolve(t)` still compiles.

`Install`, `Get`, `GetWithProgress` and `GetWithContext` now take a variadic
`...InstallOption`. This is source compatible, so no caller must change.

## The policy

`VerifyIfAvailable` is the default. It checks an asset that has a digest. It installs an
asset that has no digest and writes a warning through `download.VerifyWarning`. A custom
resolver, an air-gapped mirror, and a release older than the first manifest continue to
work.

`VerifyRequired` makes a missing digest an error. Use it where the libraries must be
known. `VerifyOff` checks nothing and does not fetch a manifest, so an air-gapped install
does not wait on one.

The `yzma install --verify` flag and the `YZMA_VERIFY` environment variable accept
`available`, `require` and `off`.

## Why the manifest groups the assets by source

yzma installs from two repositories. An asset name can occur in both with different
bytes. At `b10783`, `llama-b10783-bin-ubuntu-vulkan-arm64.tar.gz` is `8b05657e5833...` on
the `llama.cpp` release page. It is `b7458bd4a30c...` on the `llama-cpp-builder` page.
The built-in table takes the second one. Thus `digestFor` matches the repository and the
tag as well as the name.

## The verify command and the install record

yzma removes an archive as soon as it extracts it. A later check must therefore read the
files. `Install` writes `yzma-install.json` beside the libraries. The record names the
release and the assets that it installed.

The record is beside the libraries. Anything that can change the libraries can also
change the record. Give `--version` to name the release that must be there. The check
then resolves the assets of that release again. It does not read the tag from the record.

A directory can hold more than one install. Thus a file that no asset of this install
holds is reported but does not fail the check. Add `--strict` to fail on those too.

## Checks

I used real published bundles and the real manifest, not only fixtures.

The install path:

- I installed the real `llama-b10783-bin-ubuntu-cpu-arm64.tar.gz` with
  `--verify require` against the real manifest. It verified and installed.
- I then changed the expected digest. The install stopped with `ErrDigestMismatch` and
  the destination stayed empty. Nothing was extracted.

The verify command:

| Case | Result |
|---|---|
| An install that nothing touched | 68 verified, exit 0 |
| A library is modified | `changed`, exit 1 |
| A file is deleted | `missing`, exit 1 |
| A link points at `libevil.so` | `changed`, exit 1 |
| An extra `.so` is put in the directory | `unexpected`, exit 0, and exit 1 with `--strict` |
| The record tag is changed and `--version` names the real one | 68 verified, exit 0 |
| `--version` names a release with different digests | 58 changed, exit 1 |

There are 21 new unit tests. `TestDigestManifestCoversResolvedAssets` sits behind the
existing `manifest` build tag. It checks that the published manifest names every asset
that the built-in table can ask for. Against the real `b10783` it checks 20 of 20 assets.
I also ran it against `v0.3.0`. It correctly reported the three WebAssembly assets that
this release never published.

`go test ./pkg/download/` passes. The failures in `pkg/llama` and `pkg/mtmd` need
`YZMA_LIB`. They also occur on `main`.

## What this does not give

A digest from the same publisher as the asset shows that an archive is the archive that
was published. It is not a signature. It does not show who built the asset.

Two later steps would close that gap. Build provenance through
`actions/attest-build-provenance` in `llama-cpp-builder` gives authenticity. Pinned
digests for `DefaultVersion` in a tagged yzma release put the expected value where the
release host cannot change it. This PR has neither.

File digests exist only for the assets that `llama-cpp-builder` builds. An install from
the `llama.cpp` release page has an archive digest and no file digests. In that case
`yzma verify` reports that fact and does not pass.

## Before this merges

The manifests are on `main` in `llama-cpp-builder`. The site has not deployed them yet,
because `publish-version` runs at the end of a release. Until the next llama.cpp release,
`digests/<tag>.json` gives a 404. The default policy then writes a warning and installs.
I checked that path against the live 404.
