### PR TITLE
download: accept a SHA-256 digest with a version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -443,6 +443,64 @@ The digests show that an archive is the archive that was published. They are not
 signature, and a digest that comes from the same place as the asset does not show who
 built it.
 
+#### Pinning the digests
+
+Every digest above comes from the same site that serves the asset. Anyone who can
+replace an asset can also replace the manifest that gives its digest. So the check
+finds a damaged download, but it does not find one that was put there on purpose.
+
+Keep the expected value where the release host cannot change it. Pin the digest of the
+manifest in the release that uses yzma. A version takes the digest as a suffix:
+
+```
+b10785
+b10785@sha256:<64 hexadecimal characters>
+```
+
+```go
+target := download.Target{
+	Arch: download.AMD64, OS: download.Linux, Processor: download.CUDA,
+	Version: "b10785@sha256:" + wantManifest,
+}
+err := download.Install(context.Background(), target, libPath, download.ProgressTracker, nil)
+```
+
+`Target.ManifestSHA256` holds the same value for a caller that does not want to build
+the string. `Get`, `GetWithProgress` and `GetWithContext` take the suffix form in their
+version argument, and so does the command line:
+
+```
+yzma install --version b10785@sha256:<digest> --lib /path/to/lib
+yzma verify --version b10785@sha256:<digest> --lib /path/to/lib
+```
+
+Only the tag is used for URLs, for the resolver, for the install record, and for the
+version that yzma reports. The pin is not part of any of them.
+
+What gets pinned is the manifest and not one archive. A version selects a different set
+of assets for each target, and some targets need more than one, so no single archive
+digest covers them all. The chain goes from the pin, to the manifest bytes, to the
+digest of every asset that the manifest names.
+
+A pin makes verification mandatory:
+
+- The manifest bytes are checked before they are decoded.
+- A manifest that cannot be read is an error, and not an install with no check. A
+  manifest that gives 404 can no longer turn the check off.
+- An asset that the manifest does not name stops the install with `ErrDigestMissing`.
+  So a pin also works with a plain `Resolver`, because `Install` reads the manifest
+  itself. A resolver that names assets the release does not publish, such as a mirror
+  with its own URLs, cannot be used with a pin.
+- A pin that comes with `VerifyOff` gives `download.ErrVerifyDisabled`.
+
+`latest` and an empty version name whichever release is newest at the time, so neither
+can carry a digest. An invalid tag, an algorithm that is not `sha256`, or a value that
+is not 64 hexadecimal characters gives `download.ErrInvalidDigest` or
+`download.ErrInvalidVersion` before anything comes down.
+
+A pin says that the manifest is the one you expected. It still is not a signature. It
+does not say who built the assets. Build provenance would.
+
 ### Checking an installation later
 
 The archive is removed as soon as it is extracted, so a later check reads the files that

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -43,7 +43,7 @@ USAGE:
    yzma install [command options]
 
 OPTIONS:
-   --version value, -v value    version of llama.cpp to install (leave empty for the version this yzma release uses)
+   --version value, -v value    version of llama.cpp to install, optionally as VERSION@sha256:DIGEST to pin the digests (leave empty for the version this yzma release uses)
    --lib value, -l value        path to llama.cpp compiled library files [$YZMA_LIB]
    --processor value, -p value  processor to use (cpu, cuda, metal, vulkan) (default: "cpu")
    --upgrade, -u                upgrade existing installation (default: false)
@@ -69,6 +69,9 @@ yzma install --lib /path/to/lib --upgrade
 
 # Using short flags
 yzma install -l /path/to/lib -v b1234 -p cuda -u
+
+# Install a version and pin the digests it must have
+yzma install --lib /path/to/lib --version b1234@sha256:<digest>
 ```
 
 ## Other commands
@@ -100,7 +103,7 @@ USAGE:
 
 OPTIONS:
    --lib value, -l value      path to llama.cpp compiled library files [$YZMA_LIB]
-   --version value, -v value  the llama.cpp version that must be installed (leave empty to take the installed one)
+   --version value, -v value  the llama.cpp version that must be installed, optionally as VERSION@sha256:DIGEST to pin the digests (leave empty to take the installed one)
    --strict                   also fail when a file in the directory is not part of the install (default: false)
    --json                     write the report as JSON (default: false)
    --help, -h                 show help
@@ -136,3 +139,8 @@ Notes:
 - Only the assets that `llama-cpp-builder` builds carry digests for the files in them.
   An install that came from the `llama.cpp` release page has an archive digest but no
   file digests, so `yzma verify` says so instead of passing.
+- `--version` also takes `VERSION@sha256:<digest>`, where the digest is the SHA-256 of
+  the digest manifest of the release. The expected value then comes from where you keep
+  it, and not from the site that serves the manifest. A pin makes the check mandatory,
+  so it does not go with `--verify off`. See [INSTALL.md](../INSTALL.md) for what a pin
+  does and does not show.

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -17,7 +17,7 @@ var InstallCmd = &cli.Command{
 		&cli.StringFlag{
 			Name:    "version",
 			Aliases: []string{"v"},
-			Usage:   "version of llama.cpp to install (leave empty for the version this yzma release uses)",
+			Usage:   "version of llama.cpp to install, optionally as VERSION@sha256:DIGEST to pin the digests (leave empty for the version this yzma release uses)",
 			Value:   "",
 		},
 		&cli.StringFlag{
@@ -82,15 +82,25 @@ func runInstall(c *cli.Context) error {
 		}
 	}
 
+	// The digest comes off the version here as well, so bad input fails before
+	// anything is downloaded and the message names the tag rather than the pin.
+	tag, manifestDigest, err := download.ParsePinnedVersion(version)
+	if err != nil {
+		return err
+	}
+
 	quiet := c.Bool("quiet")
 	if !quiet {
 		switch {
-		case version == "" && download.DefaultVersion != "":
+		case tag == "" && download.DefaultVersion != "":
 			fmt.Println("installing llama.cpp version", download.DefaultVersion, "to", libPath)
-		case version == "" || version == "latest":
+		case tag == "" || tag == "latest":
 			fmt.Println("installing latest llama.cpp version to", libPath)
 		default:
-			fmt.Println("installing llama.cpp version", version, "to", libPath)
+			fmt.Println("installing llama.cpp version", tag, "to", libPath)
+		}
+		if manifestDigest != "" {
+			fmt.Println("digests pinned to sha256:" + manifestDigest)
 		}
 	} else {
 		download.ProgressTracker = nil

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -24,7 +24,7 @@ var VerifyCmd = &cli.Command{
 		&cli.StringFlag{
 			Name:    "version",
 			Aliases: []string{"v"},
-			Usage:   "the llama.cpp version that must be installed (leave empty to take the installed one)",
+			Usage:   "the llama.cpp version that must be installed, optionally as VERSION@sha256:DIGEST to pin the digests (leave empty to take the installed one)",
 			Value:   "",
 		},
 		&cli.BoolFlag{

--- a/pkg/download/digest.go
+++ b/pkg/download/digest.go
@@ -23,6 +23,14 @@ var (
 	// ErrDigestMissing means no digest was found for an asset and the policy is
 	// [VerifyRequired].
 	ErrDigestMissing = errors.New("no digest for asset")
+
+	// ErrInvalidDigest means a pinned digest does not have the form
+	// "sha256:" followed by 64 hexadecimal characters.
+	ErrInvalidDigest = errors.New("invalid digest")
+
+	// ErrVerifyDisabled means a pinned digest was given with [VerifyOff]. A pin asks
+	// for a check, so the two do not agree.
+	ErrVerifyDisabled = errors.New("a pinned digest needs verification, which is off")
 )
 
 // digestsURL is the URL of the digest manifest for a llama.cpp release tag. It is on
@@ -67,6 +75,48 @@ type Asset struct {
 // existing [Resolver] keeps working and gives no digests.
 type AssetResolver interface {
 	ResolveAssets(target Target) (assets []Asset, err error)
+}
+
+// sha256Pattern matches the hexadecimal form of a SHA-256 digest.
+var sha256Pattern = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
+
+// ParsePinnedVersion splits a version that carries the expected digest of its digest
+// manifest. It takes either form.
+//
+//	b10785
+//	b10785@sha256:<64 hexadecimal characters>
+//
+// A version with no digest gives an empty digest and no error, so a caller can pass
+// any version through this. What a digest pins is the manifest that names the digest
+// of every asset of the release. One version selects a different set of assets for
+// each target, so no single archive digest covers them all.
+//
+// "latest" and an empty version name whichever release is newest at the time, so
+// neither can carry a digest.
+func ParsePinnedVersion(version string) (tag string, digest string, err error) {
+	tag, rest, found := strings.Cut(version, "@")
+	if !found {
+		return version, "", nil
+	}
+
+	algorithm, value, found := strings.Cut(rest, ":")
+	switch {
+	case !found:
+		return "", "", fmt.Errorf("%w: %q names no algorithm, want sha256:<digest>", ErrInvalidDigest, rest)
+	case strings.ToLower(algorithm) != "sha256":
+		return "", "", fmt.Errorf("%w: unknown algorithm %q, want sha256", ErrInvalidDigest, algorithm)
+	case !sha256Pattern.MatchString(value):
+		return "", "", fmt.Errorf("%w: %q is not 64 hexadecimal characters", ErrInvalidDigest, value)
+	}
+
+	if tag == "" || tag == "latest" {
+		return "", "", fmt.Errorf("%w: a digest needs an exact version, not %q", ErrInvalidVersion, tag)
+	}
+	if err := VersionIsValid(tag); err != nil {
+		return "", "", fmt.Errorf("%w: %s", err, tag)
+	}
+
+	return tag, strings.ToLower(value), nil
 }
 
 // manifest holds the digests that a llama.cpp release publishes. The assets come from
@@ -124,8 +174,14 @@ func (m *manifest) assetFor(url string) (manifestAsset, bool) {
 	return asset, ok
 }
 
-// fetchManifest gets the digest manifest for a llama.cpp release tag.
-func fetchManifest(ctx context.Context, tag string) (*manifest, error) {
+// maxManifestSize is the largest digest manifest that fetchManifest reads. A release
+// names about twenty assets, so this is far more than enough.
+const maxManifestSize = 8 << 20
+
+// fetchManifest gets the digest manifest for a llama.cpp release tag. A want that is
+// not empty is the expected SHA-256 of the raw manifest bytes, in hexadecimal. The
+// bytes are checked before they are decoded.
+func fetchManifest(ctx context.Context, tag string, want string) (*manifest, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf(digestsURL, tag), nil)
 	if err != nil {
 		return nil, err
@@ -142,8 +198,24 @@ func fetchManifest(ctx context.Context, tag string) (*manifest, error) {
 		return nil, fmt.Errorf("received status code %d for the digests of %s", resp.StatusCode, tag)
 	}
 
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the digests of %s: %w", tag, err)
+	}
+	if len(body) > maxManifestSize {
+		return nil, fmt.Errorf("the digests of %s are larger than %d bytes", tag, maxManifestSize)
+	}
+
+	if want != "" {
+		sum := sha256.Sum256(body)
+		got := hex.EncodeToString(sum[:])
+		if !strings.EqualFold(got, want) {
+			return nil, fmt.Errorf("%w for the digests of %s: expected %s, got %s", ErrDigestMismatch, tag, want, got)
+		}
+	}
+
 	var m manifest
-	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+	if err := json.Unmarshal(body, &m); err != nil {
 		return nil, err
 	}
 

--- a/pkg/download/digest_test.go
+++ b/pkg/download/digest_test.go
@@ -138,7 +138,7 @@ func TestFetchManifest(t *testing.T) {
 	digestsURL = server.URL + "/digests/%s.json"
 	defer func() { digestsURL = original }()
 
-	m, err := fetchManifest(context.Background(), "b10783")
+	m, err := fetchManifest(context.Background(), "b10783", "")
 	if err != nil {
 		t.Fatalf("fetchManifest() failed: %v", err)
 	}
@@ -151,14 +151,16 @@ func TestFetchManifest(t *testing.T) {
 		t.Errorf("digestFor() = %q, want %q", got, want)
 	}
 
-	if _, err := fetchManifest(context.Background(), "b00000"); err == nil {
+	if _, err := fetchManifest(context.Background(), "b00000", ""); err == nil {
 		t.Error("fetchManifest() for a tag with no manifest returned no error")
 	}
 }
 
 // serveManifest starts a server that gives a manifest naming the assets in digests,
-// and points digestsURL at it for the length of the test.
-func serveManifest(t *testing.T, tag string, digests map[string]string) {
+// and points digestsURL at it for the length of the test. It gives back the SHA-256
+// of the manifest bytes, in hexadecimal, which a test pins with
+// [Target.ManifestSHA256].
+func serveManifest(t *testing.T, tag string, digests map[string]string) string {
 	t.Helper()
 
 	assets := make([]string, 0, len(digests))
@@ -178,6 +180,9 @@ func serveManifest(t *testing.T, tag string, digests map[string]string) {
 	original := digestsURL
 	digestsURL = server.URL + "/digests/%s.json"
 	t.Cleanup(func() { digestsURL = original })
+
+	sum := sha256.Sum256([]byte(body))
+	return hex.EncodeToString(sum[:])
 }
 
 func TestDefaultResolverReportsDigests(t *testing.T) {
@@ -227,7 +232,7 @@ func TestResolveAssetsFromAPlainResolver(t *testing.T) {
 		return []string{"https://example.com/a.tar.gz"}, nil
 	})
 
-	assets, err := resolveAssets(Target{Version: "b10783"}, resolver, VerifyIfAvailable)
+	assets, err := resolveAssets(context.Background(), Target{Version: "b10783"}, resolver, VerifyIfAvailable)
 	if err != nil {
 		t.Fatalf("resolveAssets() failed: %v", err)
 	}

--- a/pkg/download/doc.go
+++ b/pkg/download/doc.go
@@ -34,5 +34,38 @@
 // A [Resolver] reports no digests, so [VerifyRequired] refuses one. Implement
 // [AssetResolver] to give a digest for each asset.
 //
+// # Pinning the digests
+//
+// Every digest above comes from the same site that serves the asset. Anyone who can
+// replace an asset can also replace the manifest that gives its digest. So the check
+// finds a damaged download, but it does not find one that was put there on purpose.
+//
+// Keep the expected value where the release host cannot change it. Pin the digest of
+// the manifest in the release that uses yzma. The version takes the digest as a
+// suffix:
+//
+//	target := download.Target{Version: "b10785@sha256:" + wantManifest}
+//	err := download.Install(ctx, target, libPath, download.ProgressTracker, nil)
+//
+// [Target.ManifestSHA256] holds the same value for a caller that does not want to
+// build the string. [Get] and its variants take the suffix form in their version
+// argument, and so does "yzma install --version".
+//
+// What gets pinned is the manifest and not one archive. A version selects a different
+// set of assets for each target, and some targets need more than one, so no single
+// archive digest covers them all. The chain goes from the pin, to the manifest bytes,
+// to the digest of every asset.
+//
+// A pin makes verification mandatory. The manifest bytes are checked before they are
+// decoded. A manifest that cannot be read is an error, and not an install with no
+// check. An asset that the manifest does not name stops the install with
+// [ErrDigestMissing]. So a pin also works with a plain [Resolver], because [Install]
+// reads the manifest itself. A resolver that names assets the release does not
+// publish cannot be used with a pin. A pin that comes with [VerifyOff] gives
+// [ErrVerifyDisabled], because the two ask for opposite things.
+//
+// "latest" and an empty version name whichever release is newest at the time, so
+// neither can carry a digest.
+//
 // See INSTALL.md for the longer version.
 package download

--- a/pkg/download/manifest_test.go
+++ b/pkg/download/manifest_test.go
@@ -150,7 +150,7 @@ func TestDigestManifestCoversResolvedAssets(t *testing.T) {
 		target.UpstreamVersion = upstream
 	}
 
-	m, err := fetchManifest(context.Background(), tag)
+	m, err := fetchManifest(context.Background(), tag, "")
 	if err != nil {
 		t.Fatalf("fetching the digests of %s failed: %v", tag, err)
 	}

--- a/pkg/download/pin_test.go
+++ b/pkg/download/pin_test.go
@@ -1,0 +1,385 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	getter "github.com/hashicorp/go-getter"
+)
+
+// aDigest is a well formed SHA-256 value that no test asset actually has.
+const aDigest = "0000000000000000000000000000000000000000000000000000000000000000"
+
+func TestParsePinnedVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		wantTag    string
+		wantDigest string
+		wantErr    error
+	}{
+		{
+			name:    "a version with no digest passes through",
+			version: "b10783",
+			wantTag: "b10783",
+		},
+		{
+			name:    "an empty version passes through",
+			version: "",
+			wantTag: "",
+		},
+		{
+			name:    "latest with no digest passes through",
+			version: "latest",
+			wantTag: "latest",
+		},
+		{
+			name:       "a nightly build takes a digest",
+			version:    "b10783@sha256:" + aDigest,
+			wantTag:    "b10783",
+			wantDigest: aDigest,
+		},
+		{
+			name:       "a tagged release takes a digest",
+			version:    "v0.3.0@sha256:" + aDigest,
+			wantTag:    "v0.3.0",
+			wantDigest: aDigest,
+		},
+		{
+			name:       "a digest in capitals becomes lower case",
+			version:    "b10783@SHA256:" + strings.ToUpper("abc") + aDigest[3:],
+			wantTag:    "b10783",
+			wantDigest: "abc" + aDigest[3:],
+		},
+		{
+			name:    "a digest with no algorithm is refused",
+			version: "b10783@" + aDigest,
+			wantErr: ErrInvalidDigest,
+		},
+		{
+			name:    "an algorithm that is not sha256 is refused",
+			version: "b10783@sha512:" + aDigest,
+			wantErr: ErrInvalidDigest,
+		},
+		{
+			name:    "a digest that is too short is refused",
+			version: "b10783@sha256:abcd",
+			wantErr: ErrInvalidDigest,
+		},
+		{
+			name:    "a digest that is not hexadecimal is refused",
+			version: "b10783@sha256:" + strings.Repeat("z", 64),
+			wantErr: ErrInvalidDigest,
+		},
+		{
+			name:    "an empty digest is refused",
+			version: "b10783@sha256:",
+			wantErr: ErrInvalidDigest,
+		},
+		{
+			name:    "latest cannot take a digest",
+			version: "latest@sha256:" + aDigest,
+			wantErr: ErrInvalidVersion,
+		},
+		{
+			name:    "an empty version cannot take a digest",
+			version: "@sha256:" + aDigest,
+			wantErr: ErrInvalidVersion,
+		},
+		{
+			name:    "a version that is not a release cannot take a digest",
+			version: "nightly@sha256:" + aDigest,
+			wantErr: ErrInvalidVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tag, digest, err := ParsePinnedVersion(tt.version)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("ParsePinnedVersion(%q) = %v, want %v", tt.version, err, tt.wantErr)
+				}
+				if tag != "" || digest != "" {
+					t.Errorf("got tag %q and digest %q, want both empty on an error", tag, digest)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePinnedVersion(%q) failed: %v", tt.version, err)
+			}
+			if tag != tt.wantTag {
+				t.Errorf("tag = %q, want %q", tag, tt.wantTag)
+			}
+			if digest != tt.wantDigest {
+				t.Errorf("digest = %q, want %q", digest, tt.wantDigest)
+			}
+		})
+	}
+}
+
+func TestFetchManifestChecksTheRawBytes(t *testing.T) {
+	manifestDigest := serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz": "abcd",
+	})
+
+	m, err := fetchManifest(context.Background(), "b10783", manifestDigest)
+	if err != nil {
+		t.Fatalf("fetchManifest() with the right digest failed: %v", err)
+	}
+	if m.Tag != "b10783" {
+		t.Errorf("Tag = %q, want b10783", m.Tag)
+	}
+
+	_, err = fetchManifest(context.Background(), "b10783", aDigest)
+	if !errors.Is(err, ErrDigestMismatch) {
+		t.Errorf("fetchManifest() with a digest that does not agree = %v, want ErrDigestMismatch", err)
+	}
+}
+
+// recordAssets makes getFunc collect the assets it is given rather than download
+// them, and gives back the collected slice.
+func recordAssets(t *testing.T) *[]Asset {
+	t.Helper()
+
+	var got []Asset
+	original := getFunc
+	getFunc = func(_ context.Context, asset Asset, _ string, _ getter.ProgressTracker) error {
+		got = append(got, asset)
+		return nil
+	}
+	t.Cleanup(func() { getFunc = original })
+
+	return &got
+}
+
+func TestInstallAcceptsAPinnedManifest(t *testing.T) {
+	manifestDigest := serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz": "abcd",
+	})
+	got := recordAssets(t)
+
+	dest := t.TempDir()
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU,
+		Version: "b10783@sha256:" + manifestDigest,
+	}, dest, nil, nil)
+	if err != nil {
+		t.Fatalf("Install() with a pin that agrees failed: %v", err)
+	}
+
+	if len(*got) != 1 {
+		t.Fatalf("got %d assets, want 1", len(*got))
+	}
+	if (*got)[0].SHA256 != "abcd" {
+		t.Errorf("SHA256 = %q, want abcd, so the pinned manifest gave the digest", (*got)[0].SHA256)
+	}
+
+	// Only the tag reaches the URLs and the record. The pin is not part of either.
+	if strings.Contains((*got)[0].URL, "@") {
+		t.Errorf("the URL %q holds the pin, want only the tag", (*got)[0].URL)
+	}
+	record, err := ReadInstallRecord(dest)
+	if err != nil {
+		t.Fatalf("ReadInstallRecord() failed: %v", err)
+	}
+	if record.Tag != "b10783" {
+		t.Errorf("record Tag = %q, want b10783", record.Tag)
+	}
+}
+
+func TestInstallAcceptsAPinOnTheTargetField(t *testing.T) {
+	manifestDigest := serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz": "abcd",
+	})
+	got := recordAssets(t)
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU,
+		Version:        "b10783",
+		ManifestSHA256: manifestDigest,
+	}, t.TempDir(), nil, nil)
+	if err != nil {
+		t.Fatalf("Install() with ManifestSHA256 set failed: %v", err)
+	}
+	if len(*got) != 1 || (*got)[0].SHA256 != "abcd" {
+		t.Errorf("got %v, want one asset with the digest abcd", *got)
+	}
+}
+
+func TestInstallStopsOnAPinnedManifestThatDoesNotAgree(t *testing.T) {
+	serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz": "abcd",
+	})
+
+	original := getFunc
+	getFunc = func(context.Context, Asset, string, getter.ProgressTracker) error {
+		t.Error("nothing may be downloaded when the manifest does not agree with the pin")
+		return nil
+	}
+	defer func() { getFunc = original }()
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU,
+		Version: "b10783@sha256:" + aDigest,
+	}, t.TempDir(), nil, nil)
+
+	if !errors.Is(err, ErrDigestMismatch) {
+		t.Errorf("Install() = %v, want ErrDigestMismatch", err)
+	}
+}
+
+func TestInstallRefusesAPinWhenVerificationIsOff(t *testing.T) {
+	original := getFunc
+	getFunc = func(context.Context, Asset, string, getter.ProgressTracker) error {
+		t.Error("nothing may be downloaded when a pin is given with VerifyOff")
+		return nil
+	}
+	defer func() { getFunc = original }()
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU,
+		Version: "b10783@sha256:" + aDigest,
+	}, t.TempDir(), nil, nil, WithVerify(VerifyOff))
+
+	if !errors.Is(err, ErrVerifyDisabled) {
+		t.Errorf("Install() = %v, want ErrVerifyDisabled", err)
+	}
+}
+
+func TestInstallRefusesAPinThatDisagreesWithTheTargetField(t *testing.T) {
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU,
+		Version:        "b10783@sha256:" + aDigest,
+		ManifestSHA256: strings.Repeat("a", 64),
+	}, t.TempDir(), nil, nil)
+
+	if !errors.Is(err, ErrInvalidDigest) {
+		t.Errorf("Install() = %v, want ErrInvalidDigest", err)
+	}
+}
+
+func TestInstallRefusesAnAssetThePinnedManifestDoesNotName(t *testing.T) {
+	// The manifest names another asset, so the one that resolves has no digest.
+	manifestDigest := serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-x64.tar.gz": "abcd",
+	})
+
+	original := getFunc
+	getFunc = func(context.Context, Asset, string, getter.ProgressTracker) error {
+		t.Error("nothing may be downloaded when the pinned manifest omits an asset")
+		return nil
+	}
+	defer func() { getFunc = original }()
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU,
+		Version: "b10783@sha256:" + manifestDigest,
+	}, t.TempDir(), nil, nil)
+
+	if !errors.Is(err, ErrDigestMissing) {
+		t.Errorf("Install() = %v, want ErrDigestMissing", err)
+	}
+}
+
+func TestInstallPinsEveryAssetOfATargetThatTakesMoreThanOne(t *testing.T) {
+	// A WebAssembly target takes all three browser builds.
+	manifestDigest := serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-wasm-simd.tar.gz":    "aaaa",
+		"llama-b10783-bin-wasm-simd-mt.tar.gz": "bbbb",
+		"llama-b10783-bin-wasm-webgpu.tar.gz":  "cccc",
+	})
+	got := recordAssets(t)
+
+	err := Install(context.Background(), Target{
+		Arch: AMD64, OS: Wasm, Processor: CPU,
+		Version: "b10783@sha256:" + manifestDigest,
+	}, t.TempDir(), nil, nil)
+	if err != nil {
+		t.Fatalf("Install() for a WebAssembly target failed: %v", err)
+	}
+
+	if len(*got) != 3 {
+		t.Fatalf("got %d assets, want 3", len(*got))
+	}
+	for _, asset := range *got {
+		if asset.SHA256 == "" {
+			t.Errorf("%s has no digest, want every asset of a pin checked", asset.URL)
+		}
+	}
+}
+
+func TestAPinMakesAManifestThatCannotBeReadFatal(t *testing.T) {
+	// digestsURL points at a port that nothing listens on, per TestMain.
+	original := getFunc
+	getFunc = func(context.Context, Asset, string, getter.ProgressTracker) error {
+		t.Error("nothing may be downloaded when a pinned manifest cannot be read")
+		return nil
+	}
+	defer func() { getFunc = original }()
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU,
+		Version: "b10783@sha256:" + aDigest,
+	}, t.TempDir(), nil, nil)
+
+	if err == nil {
+		t.Error("Install() with a pin and no manifest returned no error")
+	}
+}
+
+func TestAPlainVersionStillInstallsWithoutAManifest(t *testing.T) {
+	// The same conditions as the test above, but with no pin, so the install goes
+	// ahead with a warning. This is what keeps an air-gapped mirror working.
+	originalWarning := VerifyWarning
+	VerifyWarning = nil
+	defer func() { VerifyWarning = originalWarning }()
+
+	got := recordAssets(t)
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783",
+	}, t.TempDir(), nil, nil)
+	if err != nil {
+		t.Fatalf("Install() with a plain version failed: %v", err)
+	}
+	if len(*got) != 1 || (*got)[0].SHA256 != "" {
+		t.Errorf("got %v, want one asset with no digest", *got)
+	}
+}
+
+func TestAPinWorksWithACustomResolver(t *testing.T) {
+	manifestDigest := serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz": "abcd",
+	})
+	got := recordAssets(t)
+
+	// A resolver that names an asset of the release still gets the pinned digest,
+	// because the manifest is read by Install and not by the resolver.
+	resolver := ResolverFunc(func(target Target) ([]string, error) {
+		return []string{
+			"https://github.com/hybridgroup/llama-cpp-builder/releases/download/" +
+				target.Version + "/llama-" + target.Version + "-bin-ubuntu-cpu-arm64.tar.gz",
+		}, nil
+	})
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU,
+		Version: "b10783@sha256:" + manifestDigest,
+	}, t.TempDir(), nil, resolver)
+	if err != nil {
+		t.Fatalf("Install() with a custom resolver and a pin failed: %v", err)
+	}
+	if len(*got) != 1 || (*got)[0].SHA256 != "abcd" {
+		t.Errorf("got %v, want one asset with the digest abcd", *got)
+	}
+}
+
+func TestVerifyInstallRefusesABadPin(t *testing.T) {
+	_, err := VerifyInstall(context.Background(), t.TempDir(), "b10783@sha512:"+aDigest)
+	if !errors.Is(err, ErrInvalidDigest) {
+		t.Errorf("VerifyInstall() = %v, want ErrInvalidDigest", err)
+	}
+}

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	getter "github.com/hashicorp/go-getter"
@@ -25,6 +26,15 @@ type Target struct {
 	// Version. A tagged release has no binaries of its own, so [Install] fills this
 	// in with [LlamaNightlyTag]. Empty means use Version.
 	UpstreamVersion string
+
+	// ManifestSHA256 is the expected digest of the raw digest manifest of Version,
+	// in hexadecimal. Empty means the digest is not pinned, which is the usual case.
+	//
+	// A pin makes verification mandatory. The manifest bytes must agree, the
+	// manifest must name every resolved asset, and the bytes of each asset must
+	// agree with it. [Install] also takes the pin as a suffix on Version, in the
+	// form "b10785@sha256:<digest>", and moves it here.
+	ManifestSHA256 string
 }
 
 // Resolver reports the release assets to install for a Target, as URLs downloaded in
@@ -57,7 +67,17 @@ func (defaultResolver) Resolve(target Target) ([]string, error) {
 // ResolveAssets reports the assets to install with their expected digests. A manifest
 // that cannot be read gives assets with no digest, which [VerifyIfAvailable] permits
 // and [VerifyRequired] refuses.
+//
+// A [Target.ManifestSHA256] that is set makes the manifest mandatory. The bytes must
+// have that digest, and a manifest that cannot be read is an error rather than an
+// install with no check.
 func (r defaultResolver) ResolveAssets(target Target) ([]Asset, error) {
+	return r.resolveAssets(context.Background(), target)
+}
+
+// resolveAssets does the work of [defaultResolver.ResolveAssets] under a context.
+// [AssetResolver] takes no context, so [Install] calls this to pass its own.
+func (r defaultResolver) resolveAssets(ctx context.Context, target Target) ([]Asset, error) {
 	urls, err := defaultResolve(target)
 	if err != nil {
 		return nil, err
@@ -68,8 +88,11 @@ func (r defaultResolver) ResolveAssets(target Target) ([]Asset, error) {
 		assets[i] = Asset{URL: url}
 	}
 
-	m, err := fetchManifest(context.Background(), target.Version)
+	m, err := fetchManifest(ctx, target.Version, target.ManifestSHA256)
 	if err != nil {
+		if target.ManifestSHA256 != "" {
+			return nil, err
+		}
 		return assets, nil
 	}
 
@@ -326,6 +349,12 @@ func WithVerify(policy VerifyPolicy) InstallOption {
 //
 // Install checks the digest of each asset that has one, and stops before it writes
 // anything if the bytes do not agree. Use [WithVerify] to change that.
+//
+// [Target.Version] may carry the expected digest of the digest manifest of the
+// release, in the form "b10785@sha256:<digest>". Install moves it to
+// [Target.ManifestSHA256] and uses only the tag for URLs, for the resolver, for the
+// install record, and for the version it reports. A pin makes verification mandatory,
+// so it cannot be given with [VerifyOff].
 func Install(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver, opts ...InstallOption) error {
 	if resolver == nil {
 		resolver = DefaultResolver
@@ -334,6 +363,31 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 	var options installOptions
 	for _, opt := range opts {
 		opt(&options)
+	}
+
+	// The digest comes off the version before anything validates the version or
+	// builds a URL from it.
+	tag, digest, err := ParsePinnedVersion(target.Version)
+	if err != nil {
+		return err
+	}
+	target.Version = tag
+	switch {
+	case digest == "":
+		// Nothing to say. The version carried no digest.
+	case target.ManifestSHA256 == "":
+		target.ManifestSHA256 = digest
+	case !strings.EqualFold(target.ManifestSHA256, digest):
+		return fmt.Errorf("%w: the version pins %s and ManifestSHA256 is %s", ErrInvalidDigest, digest, target.ManifestSHA256)
+	}
+
+	// A pin asks for a check, so it does not agree with a policy that checks nothing,
+	// and it makes an asset with no digest an error.
+	if target.ManifestSHA256 != "" {
+		if options.verify == VerifyOff {
+			return ErrVerifyDisabled
+		}
+		options.verify = VerifyRequired
 	}
 
 	// An empty version takes the release pinned by this yzma release. "latest" always
@@ -409,7 +463,7 @@ func recordInstall(dest string, target Target, assets []Asset) error {
 }
 
 func installAssets(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver, options installOptions) ([]Asset, error) {
-	assets, err := resolveAssets(target, resolver, options.verify)
+	assets, err := resolveAssets(ctx, target, resolver, options.verify)
 	if err != nil {
 		return nil, err
 	}
@@ -436,9 +490,21 @@ func installAssets(ctx context.Context, target Target, dest string, progress get
 // digests is preferred, so a resolver that only has [Resolver] keeps working.
 // [VerifyOff] takes the plain [Resolver], because a digest that nothing reads is not
 // worth the fetch of a manifest.
-func resolveAssets(target Target, resolver Resolver, verify VerifyPolicy) ([]Asset, error) {
-	if assetResolver, ok := resolver.(AssetResolver); ok && verify != VerifyOff {
-		return assetResolver.ResolveAssets(target)
+func resolveAssets(ctx context.Context, target Target, resolver Resolver, verify VerifyPolicy) ([]Asset, error) {
+	// A pinned manifest is the authority for every asset, whichever resolver named
+	// them, so it is read here instead of in the resolver.
+	if target.ManifestSHA256 != "" {
+		return pinnedAssets(ctx, target, resolver)
+	}
+
+	if verify != VerifyOff {
+		// The built-in resolver has a form that carries the context of the install.
+		if d, ok := resolver.(defaultResolver); ok {
+			return d.resolveAssets(ctx, target)
+		}
+		if assetResolver, ok := resolver.(AssetResolver); ok {
+			return assetResolver.ResolveAssets(target)
+		}
 	}
 
 	urls, err := resolver.Resolve(target)
@@ -449,6 +515,32 @@ func resolveAssets(target Target, resolver Resolver, verify VerifyPolicy) ([]Ass
 	assets := make([]Asset, len(urls))
 	for i, url := range urls {
 		assets[i] = Asset{URL: url}
+	}
+
+	return assets, nil
+}
+
+// pinnedAssets gives the assets to install when [Target.ManifestSHA256] pins the
+// digest manifest. The resolver names the assets and the pinned manifest gives the
+// digest of each one. An asset that the manifest does not name is an error.
+func pinnedAssets(ctx context.Context, target Target, resolver Resolver) ([]Asset, error) {
+	urls, err := resolver.Resolve(target)
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := fetchManifest(ctx, target.Version, target.ManifestSHA256)
+	if err != nil {
+		return nil, err
+	}
+
+	assets := make([]Asset, len(urls))
+	for i, url := range urls {
+		digest := m.digestFor(url)
+		if digest == "" {
+			return nil, fmt.Errorf("%w: %s is not in the pinned digests of %s", ErrDigestMissing, url, target.Version)
+		}
+		assets[i] = Asset{URL: url, SHA256: digest}
 	}
 
 	return assets, nil

--- a/pkg/download/verify.go
+++ b/pkg/download/verify.go
@@ -101,8 +101,15 @@ func (r *VerifyReport) OK() bool {
 // recorded for the release installed there.
 //
 // An empty tag takes the tag from the install record. Give a tag to name the release
-// that must be there, which does not trust the record.
+// that must be there, which does not trust the record. The tag may carry the expected
+// digest of the digest manifest, in the form "b10785@sha256:<digest>", which does not
+// trust the site that serves the manifest either.
 func VerifyInstall(ctx context.Context, libPath, tag string) (*VerifyReport, error) {
+	tag, manifestDigest, err := ParsePinnedVersion(tag)
+	if err != nil {
+		return nil, err
+	}
+
 	record, err := ReadInstallRecord(libPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -143,7 +150,7 @@ func VerifyInstall(ctx context.Context, libPath, tag string) (*VerifyReport, err
 		tag = record.Tag
 	}
 
-	m, err := fetchManifest(ctx, tag)
+	m, err := fetchManifest(ctx, tag, manifestDigest)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Kronk has an expected digest for a llama.cpp library bundle and cannot check the
archive after yzma extracts and removes it. This is the rest of #322 and closes
#325.

Every digest that #323 added comes from the same site that serves the asset, so
anyone who can replace an asset can also replace the manifest that gives its
digest. This change lets the caller keep the expected value where the release
host cannot change it.

## What it does

A version takes the digest of its digest manifest as a suffix.

    b10785
    b10785@sha256:<64 hexadecimal characters>

`ParsePinnedVersion` splits the two before anything validates the version or
builds a URL from it. `Target.ManifestSHA256` holds the same value for a caller
that does not want to build the string. `Install`, `Get`, `GetWithProgress`,
`GetWithContext`, `yzma install --version` and `yzma verify --version` all take
the suffix form.

Only the tag reaches the URLs, the resolver, the install record, and the version
that yzma reports.

## Why the manifest and not one archive

One version selects a different set of assets for each target, and some targets
need more than one, so no single archive digest covers them all. The chain goes
from the pin, to the manifest bytes, to the digest of every asset. So
`fetchManifest` now reads the body, checks it, and then decodes it. It also
limits the size of what it reads.

## What a pin changes

A pin makes verification mandatory.

- A manifest that cannot be read is an error, and not an install with no check.
  A manifest that gives 404 can no longer turn the check off.
- An asset that the manifest does not name gives `ErrDigestMissing`. So a pin
  also works with a plain `Resolver`, because `Install` reads the manifest
  itself.
- A pin that comes with `VerifyOff` gives `ErrVerifyDisabled`.

`latest` and an empty version name whichever release is newest at the time, so
neither can carry a digest. A bad tag, algorithm or value gives an error before
anything comes down.

`ResolveAssets` also uses the context of the install now, in place of
`context.Background`.

## Checks

Against the real b10797 manifest on the live site.

| Case | Result |
|---|---|
| A pinned install with `--verify require` | exit 0 |
| One hex character changed in the pin | `ErrDigestMismatch`, destination empty |
| A pin with `--verify off` | `ErrVerifyDisabled` |
| `sha512`, a short value, `latest@sha256:` | refused before any download |
| A pinned install, then a pinned `VerifyInstall` | 68 verified, ok |
| A file changed, then a file deleted | 1 changed, then 1 changed 1 missing |

There are 12 new unit tests. `go test ./pkg/download/` passes, and so does
`go vet -tags manifest ./pkg/download/`. The failures in `pkg/llama` and
`pkg/mtmd` need `YZMA_LIB` and also occur on main.

## What this does not give

A pin says the manifest is the one you expected. It is not a signature and does
not say who built the assets. Items 2 and 3 of #322 stay open, which are build
provenance and file digests for the upstream assets.

Signed-off-by: deadprogram <ron@hybridgroup.com>

