### PR TITLE
wasm: bind the batch and memory calls of ABI 6

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -27,6 +27,8 @@ jobs:
           go-version: '1.26'
       - name: Check the WebAssembly code
         run: make vet-wasm
+      - name: Test the WebAssembly code
+        run: make test-wasm-unit
       - name: Install TinyGo
         run: |
           set -e

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,11 @@ vet-wasm:
 	GOOS=js GOARCH=wasm go vet ./pkg/llamawasm ./pkg/message ./pkg/template \
 		./examples/wasm/chat ./examples/wasm/vlm ./examples/wasm/tools
 
+# make test-wasm-unit to run the tests of pkg/llamawasm in Node. They cover the
+# part of the package that needs no llama.cpp module, such as a batch of tokens.
+test-wasm-unit:
+	PATH="$(PATH):$(shell go env GOROOT)/lib/wasm" GOOS=js GOARCH=wasm go test ./pkg/llamawasm
+
 # make test-wasm to run the WebAssembly build in Node, with no browser.
 test-wasm:
 	node wasm/node/run.js --dir $(WASM_DIR) --model $(MODELS_DIR)/SmolLM-135M.Q2_K.gguf --tokens 12

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -124,14 +124,14 @@ section at the end explains.
 | `llama_get_logits` | yes | no |
 | `llama_get_memory` | yes | no |
 | `llama_get_model` | yes | no |
-| `llama_n_batch` | yes | no |
-| `llama_n_ctx_seq` | yes | no |
+| `llama_n_batch` | yes | yes |
+| `llama_n_ctx_seq` | yes | yes |
 | `llama_n_ctx` | yes | yes |
 | `llama_n_rs_seq` | yes | no |
-| `llama_n_seq_max` | yes | no |
+| `llama_n_seq_max` | yes | yes |
 | `llama_n_threads_batch` | yes | no |
 | `llama_n_threads` | yes | no |
-| `llama_n_ubatch` | yes | no |
+| `llama_n_ubatch` | yes | yes |
 | `llama_pooling_type` | yes | no |
 | `llama_set_abort_callback` | yes | no |
 | `llama_set_adapter_cvec` | yes | no |
@@ -157,23 +157,23 @@ section at the end explains.
 
 | Function | `yzma` | WebAssembly |
 | --- | :-: | :-: |
-| `llama_memory_can_shift` | yes | no |
+| `llama_memory_can_shift` | yes | yes |
 | `llama_memory_clear` | yes | yes |
-| `llama_memory_seq_add` | yes | no |
-| `llama_memory_seq_cp` | yes | no |
-| `llama_memory_seq_div` | yes | no |
-| `llama_memory_seq_keep` | yes | no |
-| `llama_memory_seq_pos_max` | yes | no |
-| `llama_memory_seq_pos_min` | yes | no |
-| `llama_memory_seq_rm` | yes | no |
+| `llama_memory_seq_add` | yes | yes |
+| `llama_memory_seq_cp` | yes | yes |
+| `llama_memory_seq_div` | yes | yes |
+| `llama_memory_seq_keep` | yes | yes |
+| `llama_memory_seq_pos_max` | yes | yes |
+| `llama_memory_seq_pos_min` | yes | yes |
+| `llama_memory_seq_rm` | yes | yes |
 
 ### Batch Functions
 
 | Function | `yzma` | WebAssembly |
 | --- | :-: | :-: |
-| `llama_batch_free` | yes | no |
+| `llama_batch_free` | yes | yes |
 | `llama_batch_get_one` | yes | yes |
-| `llama_batch_init` | yes | no |
+| `llama_batch_init` | yes | partial |
 
 ### Sampling Functions
 
@@ -366,7 +366,7 @@ Note that these functions are considered by `llama.cpp` to be experimental, and 
 The `pkg/llamawasm` package drives a build of `llama.cpp` for WebAssembly. It
 does not use the C API directly. A C shim in the
 [llama-cpp-builder](https://github.com/hybridgroup/llama-cpp-builder) repository
-gives it a small set of calls with a version, which is ABI 5 now. Thus a function
+gives it a small set of calls with a version, which is ABI 6 now. Thus a function
 of `llama.cpp` reaches the browser only after the shim exports it.
 
 The WebAssembly column of each table above gives the state of the wrapper.
@@ -377,10 +377,11 @@ The WebAssembly column of each table above gives the state of the wrapper.
 | partial | The WebAssembly build has it with fewer options. See the notes. |
 | no | The shim does not export it. |
 
-93 functions reach WebAssembly, 87 complete and 6 partial, all of them among the
-253 that have a wrapper on a host. That is sufficient for text generation,
-embeddings, images, chat templates, tool calling with a grammar, and every
-sampler that a host has.
+107 functions reach WebAssembly, 100 complete and 7 partial, all of them among
+the 253 that have a wrapper on a host. That is sufficient for text generation,
+embeddings, images, chat templates, tool calling with a grammar, every sampler
+that a host has, batches that carry more than one sequence, and a context that
+shifts when it becomes full.
 
 ### Notes on the partial wrappers
 
@@ -395,21 +396,19 @@ sampler that a host has.
   and not a pointer to an array of `LogitBias`. A struct cannot cross the
   boundary of the module.
 - `llama_model_default_params` has `NGpuLayers` only.
-- `llama_context_default_params` has `NCtx`, `NBatch`, `NUbatch`, `NThreads`,
-  `PoolingType`, and `Embeddings`.
+- `llama_context_default_params` has `NCtx`, `NBatch`, `NUbatch`, `NSeqMax`,
+  `NThreads`, `PoolingType`, and `Embeddings`.
+- `llama_batch_init` takes no `embd`. The shim has no call that puts an
+  embedding in a batch, thus a batch carries tokens only. `llama_batch_free`
+  does nothing, because the arrays of a batch belong to Go here.
 
 ### What WebAssembly still needs
 
 In order of the value that each one adds.
 
-1. **Batches with positions.** `llama_batch_init` and `llama_batch_free`. Only
-   `llama_batch_get_one` is available, thus a program cannot put more than one
-   sequence in a batch.
-2. **The metadata of a model.** The `llama_model_meta_*` calls and the counts of
+1. **The metadata of a model.** The `llama_model_meta_*` calls and the counts of
    layers, heads, and parameters.
-3. **Memory with sequences.** The `llama_memory_seq_*` calls and
-   `llama_memory_can_shift`. Only `llama_memory_clear` is available.
-4. **The parts of `mtmd`.** The shim does the whole pipeline of an image in two
+2. **The parts of `mtmd`.** The shim does the whole pipeline of an image in two
    coarse calls, `mtmd_tokenize` and `mtmd_helper_eval_chunks`. Thus the calls
    that build or examine one piece are absent: the getters of a bitmap, the
    accessors of a chunk and of the tokens of an image, `mtmd_encode`,

--- a/pkg/llamawasm/batch.go
+++ b/pkg/llamawasm/batch.go
@@ -2,8 +2,42 @@
 
 package llamawasm
 
+import (
+	"errors"
+	"fmt"
+)
+
+// Errors of [Batch.Add] and [Batch.SetLogit]. They agree with the errors of the
+// llama package, thus the same code builds for a native platform and for a
+// browser.
+var (
+	// ErrBatchFull means that the batch already holds the tokens that
+	// BatchInit gave it room for.
+	ErrBatchFull = errors.New("batch is full")
+
+	// ErrTooManySeqIDs means that the call gave more sequence identifiers
+	// than the nSeqMax of the batch.
+	ErrTooManySeqIDs = errors.New("too many sequence IDs for batch")
+
+	// ErrBatchNotWritable means that the batch holds no arrays to write. A
+	// batch of the zero value and a batch from BatchGetOne do not.
+	ErrBatchNotWritable = errors.New("batch owns no writable token arrays")
+
+	// ErrBatchIndexRange means that the index does not address a token of the
+	// batch.
+	ErrBatchIndexRange = errors.New("batch index out of range")
+
+	// ErrNoBatch says that the module is from a release before the calls that
+	// take a batch with positions, which are in ABI version 6 and later.
+	ErrNoBatch = errors.New("llamawasm: this llama.cpp module has no batch calls, install a newer build")
+)
+
 // BatchGetOne makes a batch that holds the given tokens. The positions of the
-// tokens continue from the state of the context that decodes the batch.
+// tokens continue from the state of the context that decodes the batch, and
+// every token goes to sequence 0.
+//
+// The batch holds no arrays of its own, thus [Batch.Add] and [Batch.SetLogit]
+// report [ErrBatchNotWritable] on it. Use [BatchInit] for a batch to fill in.
 func BatchGetOne(tokens []Token) Batch {
 	return Batch{
 		NTokens: int32(len(tokens)),
@@ -11,7 +45,107 @@ func BatchGetOne(tokens []Token) Batch {
 	}
 }
 
+// BatchInit makes a batch with room for nTokens tokens, each one with a
+// maximum of nSeqMax sequence identifiers. Fill it with [Batch.Add].
+//
+// The embd argument is always 0 here. A WebAssembly module cannot take an
+// embedding as the input of a batch, because the shim has no call for it.
+//
+// The batch is an ordinary Go value, thus [BatchFree] is not necessary. It
+// exists so that the same code builds for a native platform.
+func BatchInit(nTokens int32, embd int32, nSeqMax int32) Batch {
+	if nTokens < 1 || nSeqMax < 1 || embd != 0 {
+		return Batch{}
+	}
+
+	n := int(nTokens)
+	return Batch{
+		NTokens:   0,
+		tokens:    make([]Token, n),
+		pos:       make([]Pos, n),
+		nSeqID:    make([]int32, n),
+		seqIDs:    make([]SeqId, n*int(nSeqMax)),
+		logits:    make([]int8, n),
+		capTokens: nTokens,
+		capSeq:    nSeqMax,
+	}
+}
+
+// BatchFree does nothing. The memory of a batch belongs to Go here, thus the
+// garbage collector takes it.
+func BatchFree(batch Batch) error {
+	return nil
+}
+
 // Tokens gives the tokens of the batch.
 func (b Batch) Tokens() []Token {
-	return b.tokens
+	return b.tokens[:b.NTokens]
+}
+
+// Clear sets the number of tokens of the batch to zero.
+func (b *Batch) Clear() error {
+	b.NTokens = 0
+
+	return nil
+}
+
+// writable tells if the batch holds the arrays that Add and SetLogit write.
+func (b *Batch) writable() bool {
+	return b.capTokens > 0 && b.pos != nil && b.nSeqID != nil && b.seqIDs != nil && b.logits != nil
+}
+
+// SetLogit sets if the model computes the logits of the token at index idx.
+//
+// The index must address a token that the batch already holds, thus it must be
+// below NTokens. llama.cpp reads a flag only inside that range.
+func (b *Batch) SetLogit(idx int32, logits bool) error {
+	if !b.writable() {
+		return ErrBatchNotWritable
+	}
+	if idx < 0 || idx >= b.NTokens {
+		return fmt.Errorf("%w: index %d not in [0,%d)", ErrBatchIndexRange, idx, b.NTokens)
+	}
+
+	if logits {
+		b.logits[idx] = 1
+	} else {
+		b.logits[idx] = 0
+	}
+
+	return nil
+}
+
+// Add puts a token in the batch with its position, its sequences, and its
+// logit flag.
+//
+// It writes nothing and gives an error if the batch is full ([ErrBatchFull]),
+// if seqIDs holds more identifiers than the nSeqMax of the batch
+// ([ErrTooManySeqIDs]), or if the batch holds no arrays to write
+// ([ErrBatchNotWritable]).
+func (b *Batch) Add(token Token, pos Pos, seqIDs []SeqId, logits bool) error {
+	if !b.writable() {
+		return ErrBatchNotWritable
+	}
+
+	i := b.NTokens
+
+	if i < 0 || i >= b.capTokens {
+		return fmt.Errorf("%w: index %d, capacity %d", ErrBatchFull, i, b.capTokens)
+	}
+	if int32(len(seqIDs)) > b.capSeq {
+		return fmt.Errorf("%w: %d sequence IDs for a batch with n_seq_max %d", ErrTooManySeqIDs, len(seqIDs), b.capSeq)
+	}
+
+	b.tokens[i] = token
+	b.pos[i] = pos
+	b.nSeqID[i] = int32(len(seqIDs))
+
+	start := int(i) * int(b.capSeq)
+	copy(b.seqIDs[start:start+int(b.capSeq)], seqIDs)
+
+	// SetLogit measures the index against NTokens, thus the count must hold
+	// the new token before the flag of it can change.
+	b.NTokens++
+
+	return b.SetLogit(i, logits)
 }

--- a/pkg/llamawasm/batch_test.go
+++ b/pkg/llamawasm/batch_test.go
@@ -1,0 +1,180 @@
+//go:build js && wasm
+
+package llamawasm
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestBatchGetOne(t *testing.T) {
+	batch := BatchGetOne([]Token{1, 2, 3})
+
+	if batch.NTokens != 3 {
+		t.Errorf("NTokens = %d, want 3", batch.NTokens)
+	}
+	if len(batch.Tokens()) != 3 {
+		t.Errorf("len(Tokens()) = %d, want 3", len(batch.Tokens()))
+	}
+	if batch.writable() {
+		t.Error("a batch from BatchGetOne must not be writable")
+	}
+	if err := batch.Add(1, 0, []SeqId{0}, true); !errors.Is(err, ErrBatchNotWritable) {
+		t.Errorf("Add gave %v, want ErrBatchNotWritable", err)
+	}
+	if err := batch.SetLogit(0, true); !errors.Is(err, ErrBatchNotWritable) {
+		t.Errorf("SetLogit gave %v, want ErrBatchNotWritable", err)
+	}
+}
+
+func TestBatchInit(t *testing.T) {
+	batch := BatchInit(4, 0, 2)
+	defer BatchFree(batch)
+
+	if !batch.writable() {
+		t.Fatal("a batch from BatchInit must be writable")
+	}
+	if batch.NTokens != 0 {
+		t.Errorf("NTokens = %d, want 0", batch.NTokens)
+	}
+}
+
+// An embedding cannot be the input of a batch here, and a size below one has no
+// meaning. Each one gives a batch that holds nothing.
+func TestBatchInitBadArguments(t *testing.T) {
+	tests := []struct {
+		name                   string
+		nTokens, embd, nSeqMax int32
+	}{
+		{"no tokens", 0, 0, 1},
+		{"no sequences", 4, 0, 0},
+		{"an embedding", 4, 64, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			batch := BatchInit(tt.nTokens, tt.embd, tt.nSeqMax)
+			if batch.writable() {
+				t.Error("the batch must not be writable")
+			}
+		})
+	}
+}
+
+func TestBatchAdd(t *testing.T) {
+	batch := BatchInit(3, 0, 2)
+	defer BatchFree(batch)
+
+	if err := batch.Add(11, 0, []SeqId{0, 1}, false); err != nil {
+		t.Fatalf("Add gave %v", err)
+	}
+	if err := batch.Add(22, 1, []SeqId{1}, true); err != nil {
+		t.Fatalf("Add gave %v", err)
+	}
+
+	if batch.NTokens != 2 {
+		t.Errorf("NTokens = %d, want 2", batch.NTokens)
+	}
+
+	want := []Token{11, 22}
+	got := batch.Tokens()
+	if len(got) != len(want) {
+		t.Fatalf("len(Tokens()) = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Tokens()[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+
+	if batch.pos[1] != 1 {
+		t.Errorf("pos[1] = %d, want 1", batch.pos[1])
+	}
+	if batch.nSeqID[0] != 2 || batch.nSeqID[1] != 1 {
+		t.Errorf("nSeqID = %v, want [2 1]", batch.nSeqID[:2])
+	}
+
+	// The identifiers of each token take capSeq places, one token after the
+	// other, which is the shape that the shim takes.
+	if batch.seqIDs[0] != 0 || batch.seqIDs[1] != 1 || batch.seqIDs[2] != 1 {
+		t.Errorf("seqIDs = %v, want [0 1 1 ...]", batch.seqIDs)
+	}
+
+	if batch.logits[0] != 0 || batch.logits[1] != 1 {
+		t.Errorf("logits = %v, want [0 1]", batch.logits[:2])
+	}
+}
+
+func TestBatchAddFull(t *testing.T) {
+	batch := BatchInit(1, 0, 1)
+	defer BatchFree(batch)
+
+	if err := batch.Add(1, 0, []SeqId{0}, true); err != nil {
+		t.Fatalf("Add gave %v", err)
+	}
+	if err := batch.Add(2, 1, []SeqId{0}, true); !errors.Is(err, ErrBatchFull) {
+		t.Errorf("Add gave %v, want ErrBatchFull", err)
+	}
+	if batch.NTokens != 1 {
+		t.Errorf("NTokens = %d, want 1", batch.NTokens)
+	}
+}
+
+func TestBatchAddTooManySeqIDs(t *testing.T) {
+	batch := BatchInit(2, 0, 1)
+	defer BatchFree(batch)
+
+	if err := batch.Add(1, 0, []SeqId{0, 1}, true); !errors.Is(err, ErrTooManySeqIDs) {
+		t.Errorf("Add gave %v, want ErrTooManySeqIDs", err)
+	}
+	if batch.NTokens != 0 {
+		t.Errorf("NTokens = %d, want 0", batch.NTokens)
+	}
+}
+
+func TestBatchSetLogitOutOfRange(t *testing.T) {
+	batch := BatchInit(4, 0, 1)
+	defer BatchFree(batch)
+
+	if err := batch.Add(1, 0, []SeqId{0}, false); err != nil {
+		t.Fatalf("Add gave %v", err)
+	}
+
+	// Index 1 has room in the arrays, but the batch does not hold a token
+	// there yet, and llama.cpp reads no flag beyond NTokens.
+	for _, idx := range []int32{-1, 1, 4} {
+		if err := batch.SetLogit(idx, true); !errors.Is(err, ErrBatchIndexRange) {
+			t.Errorf("SetLogit(%d) gave %v, want ErrBatchIndexRange", idx, err)
+		}
+	}
+
+	if err := batch.SetLogit(0, true); err != nil {
+		t.Errorf("SetLogit(0) gave %v", err)
+	}
+	if batch.logits[0] != 1 {
+		t.Errorf("logits[0] = %d, want 1", batch.logits[0])
+	}
+}
+
+func TestBatchClear(t *testing.T) {
+	batch := BatchInit(2, 0, 1)
+	defer BatchFree(batch)
+
+	if err := batch.Add(1, 0, []SeqId{0}, true); err != nil {
+		t.Fatalf("Add gave %v", err)
+	}
+	if err := batch.Clear(); err != nil {
+		t.Fatalf("Clear gave %v", err)
+	}
+	if batch.NTokens != 0 {
+		t.Errorf("NTokens = %d, want 0", batch.NTokens)
+	}
+
+	// A batch that is clear takes tokens again from the start.
+	if err := batch.Add(2, 0, []SeqId{0}, true); err != nil {
+		t.Fatalf("Add gave %v", err)
+	}
+	if batch.tokens[0] != 2 {
+		t.Errorf("tokens[0] = %d, want 2", batch.tokens[0])
+	}
+}

--- a/pkg/llamawasm/context.go
+++ b/pkg/llamawasm/context.go
@@ -8,7 +8,12 @@ func InitFromModel(model Model, params ContextParams) (Context, error) {
 		return 0, ErrNotLoaded
 	}
 
-	handle, err := callErr("_yzma_context_new",
+	// A module before ABI version 6 makes a context of one sequence only.
+	if params.NSeqMax > 1 && !has("_yzma_context_new_seq") {
+		return 0, ErrNoBatch
+	}
+
+	args := []any{
 		int(model),
 		int(params.NCtx),
 		int(params.NBatch),
@@ -16,7 +21,15 @@ func InitFromModel(model Model, params ContextParams) (Context, error) {
 		int(params.NThreads),
 		int(params.Embeddings),
 		int(params.PoolingType),
-	)
+	}
+
+	name := "_yzma_context_new"
+	if has("_yzma_context_new_seq") {
+		name = "_yzma_context_new_seq"
+		args = append(args, int(params.NSeqMax))
+	}
+
+	handle, err := callErr(name, args...)
 	if err != nil {
 		return 0, err
 	}
@@ -44,28 +57,58 @@ func NCtx(ctx Context) uint32 {
 	return uint32(n)
 }
 
-// Decode runs a batch of tokens through the model. The positions of the tokens
-// continue from the state of the context, the same as llama.BatchGetOne with
-// llama.Decode.
+// NBatch gives the largest logical batch of the context. A module before ABI
+// version 6 gives 0.
+func NBatch(ctx Context) uint32 {
+	return contextSize(ctx, "_yzma_context_n_batch")
+}
+
+// NUBatch gives the largest physical batch of the context.
+func NUBatch(ctx Context) uint32 {
+	return contextSize(ctx, "_yzma_context_n_ubatch")
+}
+
+// NSeqMax gives the largest number of sequences that the context holds.
+func NSeqMax(ctx Context) uint32 {
+	return contextSize(ctx, "_yzma_context_n_seq_max")
+}
+
+// NCtxSeq gives the size of the context of one sequence.
+func NCtxSeq(ctx Context) uint32 {
+	return contextSize(ctx, "_yzma_context_n_ctx_seq")
+}
+
+// contextSize reads a size of the context. It gives 0 if the module has no
+// such call and if the call fails.
+func contextSize(ctx Context, name string) uint32 {
+	if !has(name) {
+		return 0
+	}
+	n := call(name, int(ctx))
+	if n < 0 {
+		return 0
+	}
+	return uint32(n)
+}
+
+// Decode runs a batch of tokens through the model.
+//
+// A batch from [BatchGetOne] takes its positions from the state of the
+// context, the same as llama.BatchGetOne with llama.Decode. A batch from
+// [BatchInit] carries the position, the sequences, and the logit flag of each
+// token, and the module must be of ABI version 6 or later for it.
 func Decode(ctx Context, batch Batch) (int32, error) {
-	if !Loaded() {
-		return 0, ErrNotLoaded
-	}
-	if batch.NTokens == 0 {
-		return 0, nil
-	}
-
-	ptr, err := tokenScratch.reserve(len(batch.tokens) * 4)
-	if err != nil {
-		return 0, err
-	}
-	writeTokens(ptr, batch.tokens)
-
-	return callErr("_yzma_decode", int(ctx), ptr, len(batch.tokens))
+	return run(ctx, batch, "_yzma_decode")
 }
 
 // Encode runs a batch of tokens through an encoder model.
 func Encode(ctx Context, batch Batch) (int32, error) {
+	return run(ctx, batch, "_yzma_encode")
+}
+
+// run sends a batch to the shim. The name is the call for a batch of tokens
+// only, and the call for a batch with positions is the same name with _batch.
+func run(ctx Context, batch Batch, name string) (int32, error) {
 	if !Loaded() {
 		return 0, ErrNotLoaded
 	}
@@ -73,13 +116,50 @@ func Encode(ctx Context, batch Batch) (int32, error) {
 		return 0, nil
 	}
 
-	ptr, err := tokenScratch.reserve(len(batch.tokens) * 4)
+	n := int(batch.NTokens)
+
+	ptr, err := tokenScratch.reserve(n * 4)
 	if err != nil {
 		return 0, err
 	}
-	writeTokens(ptr, batch.tokens)
+	writeTokens(ptr, batch.tokens[:n])
 
-	return callErr("_yzma_encode", int(ctx), ptr, len(batch.tokens))
+	if !batch.writable() {
+		return callErr(name, int(ctx), ptr, n)
+	}
+
+	if !has(name + "_batch") {
+		return 0, ErrNoBatch
+	}
+
+	posPtr, err := posScratch.reserve(n * 4)
+	if err != nil {
+		return 0, err
+	}
+	writeInt32s(posPtr, batch.pos[:n])
+
+	nSeqPtr, err := nSeqScratch.reserve(n * 4)
+	if err != nil {
+		return 0, err
+	}
+	writeInt32s(nSeqPtr, batch.nSeqID[:n])
+
+	// The identifiers of every token go in one array, thus the shim makes the
+	// array of pointers that llama_batch needs.
+	seqCount := n * int(batch.capSeq)
+	seqPtr, err := seqScratch.reserve(seqCount * 4)
+	if err != nil {
+		return 0, err
+	}
+	writeInt32s(seqPtr, batch.seqIDs[:seqCount])
+
+	logitPtr, err := logitScratch.reserve(n)
+	if err != nil {
+		return 0, err
+	}
+	writeInt8s(logitPtr, batch.logits[:n])
+
+	return callErr(name+"_batch", int(ctx), ptr, posPtr, nSeqPtr, seqPtr, int(batch.capSeq), logitPtr, n)
 }
 
 // GetEmbeddingsSeq gives the embedding of a sequence. The n argument is the
@@ -101,22 +181,4 @@ func GetEmbeddingsSeq(ctx Context, seqID SeqId, n int32) ([]float32, error) {
 		return nil, err
 	}
 	return readFloats(ptr, int(n)), nil
-}
-
-// MemoryClear removes everything from the memory of the context, which starts
-// the generation again from an empty state.
-//
-// On a native platform this takes a llama.Memory that comes from
-// llama.GetMemory. Here it takes the context, because the shim holds the
-// memory itself.
-func MemoryClear(ctx Context, data bool) error {
-	if !Loaded() {
-		return ErrNotLoaded
-	}
-	clear := 0
-	if data {
-		clear = 1
-	}
-	_, err := callErr("_yzma_memory_clear", int(ctx), clear)
-	return err
 }

--- a/pkg/llamawasm/fs.go
+++ b/pkg/llamawasm/fs.go
@@ -177,7 +177,10 @@ func ReleaseScratch() {
 	if !Loaded() {
 		return
 	}
-	for _, s := range []*scratch{&tokenScratch, &textScratch, &pieceScratch, &embdScratch, &errScratch} {
+	for _, s := range []*scratch{
+		&tokenScratch, &textScratch, &pieceScratch, &embdScratch, &errScratch,
+		&posScratch, &nSeqScratch, &seqScratch, &logitScratch,
+	} {
 		s.release()
 	}
 }

--- a/pkg/llamawasm/memory.go
+++ b/pkg/llamawasm/memory.go
@@ -1,0 +1,122 @@
+//go:build js && wasm
+
+package llamawasm
+
+import "errors"
+
+// ErrNoMemorySeq says that the module is from a release before the calls for
+// the memory of one sequence, which are in ABI version 6 and later.
+var ErrNoMemorySeq = errors.New("llamawasm: this llama.cpp module has no calls for the memory of a sequence, install a newer build")
+
+// The calls of this file take a context and not a llama.Memory, because the
+// shim holds the memory itself. This is the same as [MemoryClear].
+
+// MemoryClear removes everything from the memory of the context, which starts
+// the generation again from an empty state.
+//
+// On a native platform this takes a llama.Memory that comes from
+// llama.GetMemory. Here it takes the context, because the shim holds the
+// memory itself.
+func MemoryClear(ctx Context, data bool) error {
+	if !Loaded() {
+		return ErrNotLoaded
+	}
+	_, err := callErr("_yzma_memory_clear", int(ctx), boolInt(data))
+	return err
+}
+
+// MemorySeqRm removes the tokens of a sequence between the positions p0 and
+// p1. A p0 below zero is the start of the sequence and a p1 below zero is the
+// end of it. A seqID below zero matches every sequence.
+//
+// The result is false if the memory cannot remove the tokens, which happens
+// when it keeps whole sequences only. The sequence stays as it was then.
+func MemorySeqRm(ctx Context, seqID SeqId, p0, p1 Pos) (bool, error) {
+	rc, err := memoryCall("_yzma_memory_seq_rm", int(ctx), int(seqID), int(p0), int(p1))
+	return rc == 1, err
+}
+
+// MemorySeqCp copies the tokens of one sequence between the positions p0 and
+// p1 into another sequence.
+func MemorySeqCp(ctx Context, seqIDSrc, seqIDDst SeqId, p0, p1 Pos) error {
+	_, err := memoryCall("_yzma_memory_seq_cp", int(ctx), int(seqIDSrc), int(seqIDDst), int(p0), int(p1))
+	return err
+}
+
+// MemorySeqKeep removes every sequence of the memory except one.
+func MemorySeqKeep(ctx Context, seqID SeqId) error {
+	_, err := memoryCall("_yzma_memory_seq_keep", int(ctx), int(seqID))
+	return err
+}
+
+// MemorySeqAdd moves the tokens of a sequence between the positions p0 and p1
+// by delta positions. A program shifts a context that is full this way.
+//
+// Examine [MemoryCanShift] first, because not every memory accepts this.
+func MemorySeqAdd(ctx Context, seqID SeqId, p0, p1, delta Pos) error {
+	_, err := memoryCall("_yzma_memory_seq_add", int(ctx), int(seqID), int(p0), int(p1), int(delta))
+	return err
+}
+
+// MemorySeqDiv divides the positions of the tokens of a sequence between p0
+// and p1 by d.
+func MemorySeqDiv(ctx Context, seqID SeqId, p0, p1 Pos, d int) error {
+	_, err := memoryCall("_yzma_memory_seq_div", int(ctx), int(seqID), int(p0), int(p1), d)
+	return err
+}
+
+// MemorySeqPosMin gives the smallest position of a sequence, and -1 if the
+// sequence holds no tokens.
+func MemorySeqPosMin(ctx Context, seqID SeqId) (Pos, error) {
+	return memoryPos("_yzma_memory_seq_pos_min", ctx, seqID)
+}
+
+// MemorySeqPosMax gives the largest position of a sequence, and -1 if the
+// sequence holds no tokens.
+func MemorySeqPosMax(ctx Context, seqID SeqId) (Pos, error) {
+	return memoryPos("_yzma_memory_seq_pos_max", ctx, seqID)
+}
+
+// MemoryCanShift tells if the memory accepts [MemorySeqAdd].
+func MemoryCanShift(ctx Context) (bool, error) {
+	rc, err := memoryCall("_yzma_memory_can_shift", int(ctx))
+	return rc == 1, err
+}
+
+// memoryCall runs a call of the memory and reports a module that is too old as
+// a clear error.
+func memoryCall(name string, args ...any) (int32, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+	if !has(name) {
+		return 0, ErrNoMemorySeq
+	}
+	return callErr(name, args...)
+}
+
+// memoryPos reads a position of a sequence. A position of -1 is normal, thus
+// the shim reports a bad handle with errBadHandle and not with a small
+// negative value.
+func memoryPos(name string, ctx Context, seqID SeqId) (Pos, error) {
+	if !Loaded() {
+		return 0, ErrNotLoaded
+	}
+	if !has(name) {
+		return 0, ErrNoMemorySeq
+	}
+
+	rc := call(name, int(ctx), int(seqID))
+	if rc <= errBadHandle {
+		return 0, shimError(name, rc)
+	}
+	return Pos(rc), nil
+}
+
+// boolInt gives the value that the shim takes for a bool.
+func boolInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/pkg/llamawasm/module.go
+++ b/pkg/llamawasm/module.go
@@ -19,9 +19,10 @@ import (
 // this package makes a test before each use.
 const (
 	abiVersionMin = 1 // 1 has the calls for text generation and embeddings
-	abiVersion    = 5 // 2 adds yzma_gpu_device, 3 the multimodal calls, 4 the
+	abiVersion    = 6 // 2 adds yzma_gpu_device, 3 the multimodal calls, 4 the
 	//                   bounds of the tokens of an image, 5 the rest of the
-	//                   vocabulary and of the samplers
+	//                   vocabulary and of the samplers, 6 batches with
+	//                   positions and the calls for the memory of a sequence
 )
 
 // Error codes that the shim returns. These agree with the values in
@@ -386,6 +387,23 @@ func writeTokens(ptr int, tokens []Token) {
 	writeBytes(ptr, b)
 }
 
+// writeInt32s writes a slice of any 32-bit type that a batch carries.
+func writeInt32s[T ~int32](ptr int, values []T) {
+	b := make([]byte, len(values)*4)
+	for i, v := range values {
+		binary.LittleEndian.PutUint32(b[i*4:], uint32(v))
+	}
+	writeBytes(ptr, b)
+}
+
+func writeInt8s(ptr int, values []int8) {
+	b := make([]byte, len(values))
+	for i, v := range values {
+		b[i] = byte(v)
+	}
+	writeBytes(ptr, b)
+}
+
 func readTokens(ptr, n int) []Token {
 	b := readBytes(ptr, n*4)
 	tokens := make([]Token, n)
@@ -548,10 +566,16 @@ func (s *scratch) release() {
 // Each purpose has its own scratch, because more than one is in use at the same
 // time. tokenScratch holds input tokens, textScratch holds an input string, and
 // pieceScratch holds output bytes.
+// posScratch, seqScratch, and logitScratch hold the other arrays of a batch,
+// which go into the module beside the tokens.
 var (
 	tokenScratch scratch
 	textScratch  scratch
 	pieceScratch scratch
 	embdScratch  scratch
 	errScratch   scratch
+	posScratch   scratch
+	nSeqScratch  scratch
+	seqScratch   scratch
+	logitScratch scratch
 )

--- a/pkg/llamawasm/types.go
+++ b/pkg/llamawasm/types.go
@@ -99,6 +99,7 @@ type ContextParams struct {
 	NCtx        uint32      // size of the text context, 0 = from the model
 	NBatch      uint32      // largest logical batch, 0 = from llama.cpp
 	NUbatch     uint32      // largest physical batch, 0 = from llama.cpp
+	NSeqMax     uint32      // largest number of sequences, 0 = one
 	NThreads    int32       // number of threads, 0 = from the module
 	PoolingType PoolingType // how to pool embeddings
 	Embeddings  uint8       // 1 to compute embeddings
@@ -115,6 +116,7 @@ func ContextDefaultParams() ContextParams {
 		NCtx:        0,
 		NBatch:      0,
 		NUbatch:     0,
+		NSeqMax:     0,
 		NThreads:    Threads(),
 		PoolingType: PoolingTypeUnspecified,
 		Embeddings:  0,
@@ -136,10 +138,25 @@ func SamplerChainDefaultParams() SamplerChainParams {
 //
 // On a native platform llama.Batch is a C struct. Here it is an ordinary Go
 // struct, because the shim makes the C batch itself.
+//
+// [BatchGetOne] gives a batch that holds tokens only, and the context gives
+// each one its position. [BatchInit] gives a batch that also holds the
+// position, the sequences, and the logit flag of each token, which is what a
+// program needs to keep more than one sequence in one context.
 type Batch struct {
 	// NTokens is the number of tokens in the batch. A generation loop reads
 	// it to move the position forward.
 	NTokens int32
 
 	tokens []Token
+
+	// These are empty in a batch from BatchGetOne. seqIDs holds capSeq
+	// identifiers for each token, one after the other, because that is the
+	// shape that the shim takes.
+	pos       []Pos
+	nSeqID    []int32
+	seqIDs    []SeqId
+	logits    []int8
+	capTokens int32
+	capSeq    int32
 }


### PR DESCRIPTION
This is the yzma half of hybridgroup/llama-cpp-builder#41, which adds the
calls to the shim. It is the first two items of "What WebAssembly still needs"
in `ROADMAP.md`, done together: `llama_batch_init` alone leaves a page no
better off, because a program that puts several sequences in one batch cannot
then remove one of them without clearing the whole memory.

## Batches

`BatchInit(nTokens, embd, nSeqMax)` gives a batch that carries the position,
the sequences, and the logit flag of each token. `Add`, `SetLogit`, `Clear`,
and `BatchFree` match the llama package, and so do the errors: `ErrBatchFull`,
`ErrTooManySeqIDs`, `ErrBatchNotWritable`, and `ErrBatchIndexRange`. Thus the
same generation loop builds for a host and for a browser.

The batch is an ordinary Go value here, so `BatchFree` does nothing and the
garbage collector takes the memory. `embd` is always 0, because the shim has
no call that puts an embedding in a batch.

`Decode` and `Encode` look at the batch: one from `BatchGetOne` goes to the
old call, and one from `BatchInit` goes to `yzma_decode_batch` with its arrays
in four more scratch areas.

## Memory

`MemorySeqRm`, `Cp`, `Keep`, `Add`, `Div`, `PosMin`, `PosMax`, and
`MemoryCanShift` join `MemoryClear` in a new `memory.go`. They take a
`Context` and not a `llama.Memory`, the same as `MemoryClear` already did,
because the shim holds the memory itself.

`MemorySeqPosMin` and `MemorySeqPosMax` give -1 for a sequence that holds no
tokens, which is a normal value, thus the shim reports a bad handle with the
`errBadHandle` sentinel that `Tokenize` already uses.

## Sizes

`NBatch`, `NUBatch`, `NSeqMax`, and `NCtxSeq`. `ContextParams` takes `NSeqMax`,
which `InitFromModel` sends to `yzma_context_new_seq`.

## An older module still works

`abiVersionMin` stays 1. Every new call tests the shim with `has` first and
gives `ErrNoBatch` or `ErrNoMemorySeq`, and `InitFromModel` falls back to
`yzma_context_new` when the module is older. A page with a module of ABI 5
behaves as it did.

## Test

`make test-wasm-unit` runs the new tests of the batch in Node, and the CI of
WebAssembly runs it. They cover the part of the package that needs no
llama.cpp module: what `Add` writes into the arrays, the shape that the shim
takes for the sequence identifiers, and each error.

The path through the module itself cannot run until llama-cpp-builder makes a
release with ABI 6, because the CI installs the published build. `make
vet-wasm` and the tests in Node pass on this branch.