### PR TITLE
download: publish and read the digest of the version manifest

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -388,12 +388,17 @@ See the [resolver example code](./examples/resolver/).
 ### Checking what comes down
 
 `Install` checks the SHA-256 of each asset before it writes anything. The expected
-digests come from the manifest that `llama-cpp-builder` publishes for each release tag,
-next to the version files:
+digests come from the manifest that `llama-cpp-builder` publishes for each release tag.
+The manifest is an asset of the release it describes, and there is a copy next to the
+version files:
 
 ```
+https://github.com/hybridgroup/llama-cpp-builder/releases/download/b10783/b10783.json
 https://hybridgroup.github.io/llama-cpp-builder/digests/b10783.json
 ```
+
+Both hold the same bytes. yzma reads the release asset first and falls back to the
+second, so a release published before the manifest was an asset still works.
 
 An asset whose bytes do not agree stops the install with `download.ErrDigestMismatch`,
 and nothing is extracted.
@@ -500,6 +505,62 @@ is not 64 hexadecimal characters gives `download.ErrInvalidDigest` or
 
 A pin says that the manifest is the one you expected. It still is not a signature. It
 does not say who built the assets. Build provenance would.
+
+#### Where to get the manifest digest
+
+The manifest is an asset of the release it describes, and GitHub records the SHA-256 of
+every asset it stores. That recorded value is the manifest digest. It is published in
+three places:
+
+- The release notes for the tag print the complete pin.
+- `https://hybridgroup.github.io/llama-cpp-builder/version.json` carries the pin for the
+  newest build, and `previous.json` for the one before it:
+
+  ```console
+  $ curl -s https://hybridgroup.github.io/llama-cpp-builder/version.json
+  {"tag_name":"b10816","manifest_sha256":"<digest>","pin":"b10816@sha256:<digest>"}
+  ```
+
+- The release itself, under the asset named `<tag>.json`:
+
+  ```console
+  $ gh api repos/hybridgroup/llama-cpp-builder/releases/tags/b10816 \
+      --jq '.assets[] | select(.name == "b10816.json") | .digest'
+  sha256:<digest>
+  ```
+
+The digest of a platform archive is **not** the manifest digest. Those digests are what
+the manifest holds, one for each asset of the release. The pin covers the file that
+names them.
+
+`ManifestDigest` and `PinnedVersion` read the value for a tag, so a program can record
+the pin it is about to use. They read the version files first and only fall back to the
+GitHub API, which rate limits:
+
+```go
+pin, err := download.PinnedVersion(context.Background(), "b10816")
+```
+
+A tag whose release published no manifest gives `download.ErrNoManifestDigest`. That is
+an answer and not a failure: the version still installs, without a pin.
+
+`download.DefaultVersion` already holds the complete pin for the release that this yzma
+release installs, so an application that wants the same libraries can pass it straight
+to `Install`.
+
+#### A version with no digest
+
+A version with no digest is not the same as no checking:
+
+```
+yzma install --version v0.4.0 --lib /path/to/lib
+```
+
+That installs as it always has. The manifest still gives a digest for each asset, and
+the policy above still decides what happens to an asset that has none. What it does not
+have is a value from outside the release host to check the manifest against. Nothing in
+a pinned setup makes an unpinned version stop working, so an application can install a
+llama.cpp release that is newer than the one this yzma release pins.
 
 ### Checking an installation later
 

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -74,6 +74,23 @@ yzma install -l /path/to/lib -v b1234 -p cuda -u
 yzma install --lib /path/to/lib --version b1234@sha256:<digest>
 ```
 
+A version with no digest keeps working exactly as before, so `--version b1234` and a
+bare `yzma install` need nothing new.
+
+The digest to pin is the SHA-256 of the digest manifest of the release, which
+`llama-cpp-builder` publishes with the release. The release notes for the tag print the
+complete pin, and the version file carries it for the newest build:
+
+```console
+$ curl -s https://hybridgroup.github.io/llama-cpp-builder/version.json
+{"tag_name":"b10816","manifest_sha256":"<digest>","pin":"b10816@sha256:<digest>"}
+
+$ yzma install --lib /path/to/lib --version b10816@sha256:<digest>
+```
+
+The digest of a platform archive is not this value. Those digests are what the manifest
+holds, one for each asset. See [INSTALL.md](../INSTALL.md) for the whole chain.
+
 ## Other commands
 
 See the `yzma help` command for more information about the other things you can do with the `yzma` CLI tool.

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -89,11 +89,18 @@ func runInstall(c *cli.Context) error {
 		return err
 	}
 
+	// An empty version installs the release that this yzma release pins, which carries
+	// its own digest, so the messages report that pin rather than nothing.
+	if tag == "" && download.DefaultVersion != "" {
+		tag, manifestDigest, err = download.ParsePinnedVersion(download.DefaultVersion)
+		if err != nil {
+			return err
+		}
+	}
+
 	quiet := c.Bool("quiet")
 	if !quiet {
 		switch {
-		case tag == "" && download.DefaultVersion != "":
-			fmt.Println("installing llama.cpp version", download.DefaultVersion, "to", libPath)
 		case tag == "" || tag == "latest":
 			fmt.Println("installing latest llama.cpp version to", libPath)
 		default:

--- a/examples/installer/main.go
+++ b/examples/installer/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	switch {
 	case *version == "" && download.DefaultVersion != "":
-		fmt.Println("installing llama.cpp version", download.DefaultVersion, "to", *libPath)
+		fmt.Println("installing llama.cpp version", download.DefaultTag(), "to", *libPath)
 	case *version == "" || *version == "latest":
 		fmt.Println("installing latest llama.cpp version to", *libPath)
 	default:

--- a/pkg/download/digest.go
+++ b/pkg/download/digest.go
@@ -31,12 +31,28 @@ var (
 	// ErrVerifyDisabled means a pinned digest was given with [VerifyOff]. A pin asks
 	// for a check, so the two do not agree.
 	ErrVerifyDisabled = errors.New("a pinned digest needs verification, which is off")
+
+	// ErrNoManifestDigest means a release published no digest manifest, so there is no
+	// value to pin. The version still installs without a pin.
+	ErrNoManifestDigest = errors.New("no manifest digest is published")
 )
 
-// digestsURL is the URL of the digest manifest for a llama.cpp release tag. It is on
-// the same site as the version files, so it does not use the GitHub API, which rate
-// limits. See the llama-cpp-builder repo for how the manifests are made.
+// manifestAssetURL is the URL of the digest manifest for a llama.cpp release tag as an
+// asset of the release that it describes. GitHub publishes a SHA-256 for every release
+// asset, so this is the copy whose digest a caller can know before the download. The
+// tag names both the release and the asset.
+var manifestAssetURL = "https://github.com/hybridgroup/llama-cpp-builder/releases/download/%[1]s/%[1]s.json"
+
+// digestsURL is the same manifest on the site that serves the version files. It is the
+// fallback for a release that was published before the manifest was an asset, and it
+// does not use the GitHub API, which rate limits. See the llama-cpp-builder repo for
+// how the manifests are made.
 var digestsURL = "https://hybridgroup.github.io/llama-cpp-builder/digests/%s.json"
+
+// releaseAPIURL is the GitHub release for a tag. It gives the digest that GitHub
+// recorded for each asset, including the manifest. This rate limits, so it is only
+// read when the version files do not name the tag.
+var releaseAPIURL = "https://api.github.com/repos/hybridgroup/llama-cpp-builder/releases/tags/%s"
 
 // VerifyPolicy says what [Install] does about the digest of an asset.
 type VerifyPolicy int
@@ -181,29 +197,25 @@ const maxManifestSize = 8 << 20
 // fetchManifest gets the digest manifest for a llama.cpp release tag. A want that is
 // not empty is the expected SHA-256 of the raw manifest bytes, in hexadecimal. The
 // bytes are checked before they are decoded.
+//
+// The release asset comes first, because that is the copy whose digest GitHub
+// publishes. A release that has no manifest asset falls back to the site that serves
+// the version files. Both copies hold the same bytes, so a pin checks either one, and
+// a location that does not answer only costs the try.
 func fetchManifest(ctx context.Context, tag string, want string) (*manifest, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf(digestsURL, tag), nil)
-	if err != nil {
-		return nil, err
+	var body []byte
+	var errs []error
+	for _, url := range []string{fmt.Sprintf(manifestAssetURL, tag), fmt.Sprintf(digestsURL, tag)} {
+		read, err := fetchManifestBytes(ctx, url, tag)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		body = read
+		break
 	}
-
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("received status code %d for the digests of %s", resp.StatusCode, tag)
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestSize+1))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read the digests of %s: %w", tag, err)
-	}
-	if len(body) > maxManifestSize {
-		return nil, fmt.Errorf("the digests of %s are larger than %d bytes", tag, maxManifestSize)
+	if body == nil {
+		return nil, errors.Join(errs...)
 	}
 
 	if want != "" {
@@ -220,6 +232,137 @@ func fetchManifest(ctx context.Context, tag string, want string) (*manifest, err
 	}
 
 	return &m, nil
+}
+
+// fetchManifestBytes reads a manifest from one URL.
+func fetchManifestBytes(ctx context.Context, url string, tag string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received status code %d for the digests of %s at %s", resp.StatusCode, tag, url)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the digests of %s: %w", tag, err)
+	}
+	if len(body) > maxManifestSize {
+		return nil, fmt.Errorf("the digests of %s are larger than %d bytes", tag, maxManifestSize)
+	}
+
+	return body, nil
+}
+
+// ManifestDigest gives the SHA-256 of the digest manifest for a llama.cpp release tag,
+// in hexadecimal, so that a caller can pin the tag before it installs anything. See
+// [PinnedVersion] for the value that [Install] takes.
+//
+// It reads the version files first, because those are the two tags that most callers
+// ask for and they cost no GitHub API request. Any other tag comes from the release,
+// where GitHub publishes the digest of the manifest asset.
+//
+// A tag whose release published no manifest gives [ErrNoManifestDigest]. That is an
+// answer and not a failure: such a version still installs, without a pin.
+func ManifestDigest(ctx context.Context, tag string) (string, error) {
+	if err := VersionIsValid(tag); err != nil {
+		return "", fmt.Errorf("%w: %s", err, tag)
+	}
+
+	for _, url := range []string{currentVersionURL, previousVersionURL} {
+		file, err := getVersionFile(url)
+		if err != nil || file.TagName != tag {
+			continue
+		}
+		if digest := file.digest(); digest != "" {
+			return digest, nil
+		}
+	}
+
+	return releaseManifestDigest(ctx, tag)
+}
+
+// PinnedVersion gives the tag with the digest of its manifest, "<tag>@sha256:<digest>",
+// which is the form that [Target.Version] takes. It reports [ErrNoManifestDigest] when
+// the release published no manifest.
+func PinnedVersion(ctx context.Context, tag string) (string, error) {
+	digest, err := ManifestDigest(ctx, tag)
+	if err != nil {
+		return "", err
+	}
+
+	return tag + "@sha256:" + digest, nil
+}
+
+// digest gives the manifest digest that a version file names, or "" when it names
+// none. The pin is read when the digest field is absent, so either field is enough.
+func (f versionFile) digest() string {
+	if sha256Pattern.MatchString(f.ManifestSHA256) {
+		return strings.ToLower(f.ManifestSHA256)
+	}
+
+	tag, digest, err := ParsePinnedVersion(f.Pin)
+	if err != nil || tag != f.TagName {
+		return ""
+	}
+
+	return digest
+}
+
+// releaseManifestDigest reads the digest that GitHub recorded for the manifest asset of
+// a release.
+func releaseManifestDigest(ctx context.Context, tag string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf(releaseAPIURL, tag), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("received status code %d for the release %s", resp.StatusCode, tag)
+	}
+
+	var release struct {
+		Assets []struct {
+			Name   string `json:"name"`
+			Digest string `json:"digest"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxManifestSize+1)).Decode(&release); err != nil {
+		return "", err
+	}
+
+	// GitHub gives the digest as "sha256:<hex>", and leaves it out while an asset is
+	// still uploading.
+	name := tag + ".json"
+	for _, asset := range release.Assets {
+		if asset.Name != name {
+			continue
+		}
+		value, ok := strings.CutPrefix(asset.Digest, "sha256:")
+		if !ok || !sha256Pattern.MatchString(value) {
+			break
+		}
+		return strings.ToLower(value), nil
+	}
+
+	return "", fmt.Errorf("%w for %s", ErrNoManifestDigest, tag)
 }
 
 // verifyFile checks that a file has the expected digest. An empty digest checks

--- a/pkg/download/digest_test.go
+++ b/pkg/download/digest_test.go
@@ -157,9 +157,9 @@ func TestFetchManifest(t *testing.T) {
 }
 
 // serveManifest starts a server that gives a manifest naming the assets in digests,
-// and points digestsURL at it for the length of the test. It gives back the SHA-256
-// of the manifest bytes, in hexadecimal, which a test pins with
-// [Target.ManifestSHA256].
+// and points both manifest URLs at it for the length of the test, as a release that
+// publishes both copies does. It gives back the SHA-256 of the manifest bytes, in
+// hexadecimal, which a test pins with [Target.ManifestSHA256].
 func serveManifest(t *testing.T, tag string, digests map[string]string) string {
 	t.Helper()
 
@@ -177,9 +177,10 @@ func serveManifest(t *testing.T, tag string, digests map[string]string) string {
 	}))
 	t.Cleanup(server.Close)
 
-	original := digestsURL
+	originalAsset, originalPages := manifestAssetURL, digestsURL
+	manifestAssetURL = server.URL + "/releases/download/%[1]s/%[1]s.json"
 	digestsURL = server.URL + "/digests/%s.json"
-	t.Cleanup(func() { digestsURL = original })
+	t.Cleanup(func() { manifestAssetURL, digestsURL = originalAsset, originalPages })
 
 	sum := sha256.Sum256([]byte(body))
 	return hex.EncodeToString(sum[:])
@@ -397,5 +398,185 @@ func TestVerifyOffDoesNotFetchAManifest(t *testing.T) {
 	// An air-gapped install that checks nothing must not wait on a manifest.
 	if fetched != 0 {
 		t.Errorf("fetched the manifest %d times, want 0", fetched)
+	}
+}
+
+func TestFetchManifestPrefersTheReleaseAsset(t *testing.T) {
+	// The two copies hold the same bytes in a real release. They differ here only so
+	// that the manifest says which one answered.
+	asset := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"version":1,"tag":"b10783","upstream_tag":"asset"}`)
+	}))
+	defer asset.Close()
+	pages := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"version":1,"tag":"b10783","upstream_tag":"pages"}`)
+	}))
+	defer pages.Close()
+
+	originalAsset, originalPages := manifestAssetURL, digestsURL
+	manifestAssetURL = asset.URL + "/releases/download/%[1]s/%[1]s.json"
+	digestsURL = pages.URL + "/digests/%s.json"
+	defer func() { manifestAssetURL, digestsURL = originalAsset, originalPages }()
+
+	m, err := fetchManifest(context.Background(), "b10783", "")
+	if err != nil {
+		t.Fatalf("fetchManifest() failed: %v", err)
+	}
+	if m.UpstreamTag != "asset" {
+		t.Errorf("the manifest came from %q, want the release asset", m.UpstreamTag)
+	}
+}
+
+func TestFetchManifestFallsBackToTheVersionSite(t *testing.T) {
+	// A release published before the manifest was an asset has only the site copy.
+	asset := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer asset.Close()
+	pages := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"version":1,"tag":"b10783","upstream_tag":"pages"}`)
+	}))
+	defer pages.Close()
+
+	originalAsset, originalPages := manifestAssetURL, digestsURL
+	manifestAssetURL = asset.URL + "/releases/download/%[1]s/%[1]s.json"
+	digestsURL = pages.URL + "/digests/%s.json"
+	defer func() { manifestAssetURL, digestsURL = originalAsset, originalPages }()
+
+	m, err := fetchManifest(context.Background(), "b10783", "")
+	if err != nil {
+		t.Fatalf("fetchManifest() failed: %v", err)
+	}
+	if m.UpstreamTag != "pages" {
+		t.Errorf("the manifest came from %q, want the version site", m.UpstreamTag)
+	}
+
+	// A manifest in neither place is an error, and only then.
+	digestsURL = asset.URL + "/digests/%s.json"
+	if _, err := fetchManifest(context.Background(), "b10783", ""); err == nil {
+		t.Error("fetchManifest() with no manifest anywhere returned no error")
+	}
+}
+
+// serveVersionFile points currentVersionURL and previousVersionURL at a server that
+// gives the two bodies for the length of the test.
+func serveVersionFile(t *testing.T, current, previous string) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := current
+		if strings.Contains(r.URL.Path, "previous") {
+			body = previous
+		}
+		if body == "" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fmt.Fprint(w, body)
+	}))
+	t.Cleanup(server.Close)
+
+	originalCurrent, originalPrevious := currentVersionURL, previousVersionURL
+	currentVersionURL = server.URL + "/version.json"
+	previousVersionURL = server.URL + "/previous.json"
+	t.Cleanup(func() { currentVersionURL, previousVersionURL = originalCurrent, originalPrevious })
+}
+
+func TestManifestDigestFromTheVersionFiles(t *testing.T) {
+	digest := strings.Repeat("ab", 32)
+
+	tests := []struct {
+		name     string
+		current  string
+		previous string
+		tag      string
+	}{
+		{
+			name:    "the digest field of the current version",
+			current: fmt.Sprintf(`{"tag_name":"b10783","manifest_sha256":%q}`, digest),
+			tag:     "b10783",
+		},
+		{
+			name:    "the pin of the current version, for a file with no digest field",
+			current: fmt.Sprintf(`{"tag_name":"b10783","pin":"b10783@sha256:%s"}`, digest),
+			tag:     "b10783",
+		},
+		{
+			name:     "the previous version",
+			current:  `{"tag_name":"b10784"}`,
+			previous: fmt.Sprintf(`{"tag_name":"b10783","manifest_sha256":%q}`, digest),
+			tag:      "b10783",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serveVersionFile(t, tt.current, tt.previous)
+
+			got, err := ManifestDigest(context.Background(), tt.tag)
+			if err != nil {
+				t.Fatalf("ManifestDigest() failed: %v", err)
+			}
+			if got != digest {
+				t.Errorf("ManifestDigest() = %q, want %q", got, digest)
+			}
+
+			want := tt.tag + "@sha256:" + digest
+			if pin, err := PinnedVersion(context.Background(), tt.tag); err != nil || pin != want {
+				t.Errorf("PinnedVersion() = %q, %v, want %q", pin, err, want)
+			}
+		})
+	}
+}
+
+func TestManifestDigestFromTheRelease(t *testing.T) {
+	digest := strings.Repeat("cd", 32)
+
+	// The version files name another tag, so the release has the answer.
+	serveVersionFile(t, `{"tag_name":"b10784"}`, `{"tag_name":"b10782"}`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"assets":[
+			{"name":"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz","digest":"sha256:%s"},
+			{"name":"b10783.json","digest":"sha256:%s"}]}`, strings.Repeat("ef", 32), digest)
+	}))
+	defer server.Close()
+
+	original := releaseAPIURL
+	releaseAPIURL = server.URL + "/releases/tags/%s"
+	defer func() { releaseAPIURL = original }()
+
+	got, err := ManifestDigest(context.Background(), "b10783")
+	if err != nil {
+		t.Fatalf("ManifestDigest() failed: %v", err)
+	}
+	if got != digest {
+		t.Errorf("ManifestDigest() = %q, want the digest of the manifest asset %q", got, digest)
+	}
+}
+
+func TestManifestDigestWithNoManifestPublished(t *testing.T) {
+	serveVersionFile(t, `{"tag_name":"b10784"}`, `{"tag_name":"b10782"}`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// An asset that is still uploading has no digest yet, and an older release
+		// has no manifest asset at all.
+		fmt.Fprint(w, `{"assets":[
+			{"name":"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz","digest":"sha256:abcd"},
+			{"name":"b10783.json","digest":null}]}`)
+	}))
+	defer server.Close()
+
+	original := releaseAPIURL
+	releaseAPIURL = server.URL + "/releases/tags/%s"
+	defer func() { releaseAPIURL = original }()
+
+	_, err := ManifestDigest(context.Background(), "b10783")
+	if !errors.Is(err, ErrNoManifestDigest) {
+		t.Errorf("ManifestDigest() = %v, want ErrNoManifestDigest", err)
+	}
+
+	if _, err := ManifestDigest(context.Background(), "not-a-version"); !errors.Is(err, ErrInvalidVersion) {
+		t.Errorf("ManifestDigest() with a bad tag = %v, want ErrInvalidVersion", err)
 	}
 }

--- a/pkg/download/doc.go
+++ b/pkg/download/doc.go
@@ -51,6 +51,25 @@
 // build the string. [Get] and its variants take the suffix form in their version
 // argument, and so does "yzma install --version".
 //
+// # Where the manifest digest comes from
+//
+// llama-cpp-builder publishes the manifest for a release as an asset of that release,
+// named "<tag>.json". GitHub records the SHA-256 of every asset it stores, so that
+// value is the manifest digest. The release notes for the tag print the complete pin,
+// and https://hybridgroup.github.io/llama-cpp-builder/version.json carries it for the
+// newest build.
+//
+// The digest of a platform archive is not the manifest digest. Those digests are what
+// the manifest holds, one for each asset. The pin covers the file that names them.
+//
+// [ManifestDigest] and [PinnedVersion] read the value for a tag, so a program can
+// record the pin it is about to use:
+//
+//	pin, err := download.PinnedVersion(ctx, tag)
+//
+// [DefaultVersion] already holds the complete pin for the release that this yzma
+// release installs.
+//
 // What gets pinned is the manifest and not one archive. A version selects a different
 // set of assets for each target, and some targets need more than one, so no single
 // archive digest covers them all. The chain goes from the pin, to the manifest bytes,
@@ -66,6 +85,10 @@
 //
 // "latest" and an empty version name whichever release is newest at the time, so
 // neither can carry a digest.
+//
+// A version with no digest is not the same as no checking. It installs as it always
+// has, with whatever digests the manifest gives, under the policy above. What it does
+// not have is a value from outside the release host to check the manifest against.
 //
 // See INSTALL.md for the longer version.
 package download

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -75,9 +75,34 @@ func LlamaLatestVersion() (string, error) {
 }
 
 func getLatestVersion() (string, error) {
-	req, err := http.NewRequest("GET", currentVersionURL, nil)
+	file, err := getVersionFile(currentVersionURL)
 	if err != nil {
 		return "", err
+	}
+
+	return file.TagName, nil
+}
+
+// versionFile is what version.json and previous.json hold. Only the tag has always
+// been there, so a file with no digest is a file for a release that published none.
+type versionFile struct {
+	// TagName is the llama.cpp release tag.
+	TagName string `json:"tag_name"`
+
+	// ManifestSHA256 is the SHA-256 of the digest manifest for that tag, in
+	// hexadecimal. An empty value means the release published no manifest.
+	ManifestSHA256 string `json:"manifest_sha256"`
+
+	// Pin is the same thing ready to hand to [Install], "<tag>@sha256:<digest>".
+	Pin string `json:"pin"`
+}
+
+// getVersionFile reads one of the version files. The tag must be valid, because that
+// is the field every caller needs.
+func getVersionFile(url string) (versionFile, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return versionFile{}, err
 	}
 
 	client := &http.Client{
@@ -85,28 +110,25 @@ func getLatestVersion() (string, error) {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return versionFile{}, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("received status code %d from version URL: %s", resp.StatusCode, string(body))
+		return versionFile{}, fmt.Errorf("received status code %d from version URL: %s", resp.StatusCode, string(body))
 	}
 
-	var result struct {
-		TagName string `json:"tag_name"`
-	}
-
+	var result versionFile
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", err
+		return versionFile{}, err
 	}
 
 	if err := VersionIsValid(result.TagName); err != nil {
-		return "", fmt.Errorf("%w: %s", err, result.TagName)
+		return versionFile{}, fmt.Errorf("%w: %s", err, result.TagName)
 	}
 
-	return result.TagName, nil
+	return result, nil
 }
 
 // LlamaPreviousVersion fetches the previous release tag of llama.cpp from the version URL.
@@ -125,38 +147,12 @@ func LlamaPreviousVersion() (string, error) {
 }
 
 func getPreviousVersion() (string, error) {
-	req, err := http.NewRequest("GET", previousVersionURL, nil)
+	file, err := getVersionFile(previousVersionURL)
 	if err != nil {
 		return "", err
 	}
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("received status code %d from version URL: %s", resp.StatusCode, string(body))
-	}
-
-	var result struct {
-		TagName string `json:"tag_name"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", err
-	}
-
-	if err := VersionIsValid(result.TagName); err != nil {
-		return "", fmt.Errorf("%w: %s", err, result.TagName)
-	}
-
-	return result.TagName, nil
+	return file.TagName, nil
 }
 
 // getDownloadLocationAndFilename returns the download location and filename for the

--- a/pkg/download/main_test.go
+++ b/pkg/download/main_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 )
 
-// TestMain points the digest manifests at an address that answers nothing, so an
-// ordinary test run does not reach the network. A test that needs a manifest sets
-// digestsURL to its own server. The tests behind the "manifest" build tag talk to the
-// real site on purpose, so this does not apply to them.
+// TestMain points every place that a digest comes from at an address that answers
+// nothing, so an ordinary test run does not reach the network. A test that needs one
+// of them points it at its own server. The tests behind the "manifest" build tag talk
+// to the real site on purpose, so this does not apply to them.
 func TestMain(m *testing.M) {
+	manifestAssetURL = "http://127.0.0.1:0/releases/download/%[1]s/%[1]s.json"
 	digestsURL = "http://127.0.0.1:0/digests/%s.json"
+	releaseAPIURL = "http://127.0.0.1:0/releases/tags/%s"
 	os.Exit(m.Run())
 }

--- a/pkg/download/pin_test.go
+++ b/pkg/download/pin_test.go
@@ -383,3 +383,103 @@ func TestVerifyInstallRefusesABadPin(t *testing.T) {
 		t.Errorf("VerifyInstall() = %v, want ErrInvalidDigest", err)
 	}
 }
+
+func TestInstallTakesThePinOfTheDefaultVersion(t *testing.T) {
+	manifestDigest := serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz": "abcd",
+	})
+	got := recordAssets(t)
+
+	original := DefaultVersion
+	DefaultVersion = "b10783@sha256:" + manifestDigest
+	defer func() { DefaultVersion = original }()
+
+	dest := t.TempDir()
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU,
+	}, dest, nil, nil)
+	if err != nil {
+		t.Fatalf("Install() with no version and a pinned default failed: %v", err)
+	}
+
+	if len(*got) != 1 || (*got)[0].SHA256 != "abcd" {
+		t.Fatalf("got %v, want one asset with the digest from the pinned manifest", *got)
+	}
+
+	// Only the tag reaches the URLs and the record.
+	if strings.Contains((*got)[0].URL, "@") {
+		t.Errorf("the URL %q holds the pin, want only the tag", (*got)[0].URL)
+	}
+	record, err := ReadInstallRecord(dest)
+	if err != nil {
+		t.Fatalf("ReadInstallRecord() failed: %v", err)
+	}
+	if record.Tag != "b10783" {
+		t.Errorf("record Tag = %q, want b10783", record.Tag)
+	}
+}
+
+func TestInstallWithNoPinAndNoManifest(t *testing.T) {
+	// Neither manifest URL answers, per TestMain. A version with no digest still
+	// installs, because only a pin makes the manifest mandatory.
+	got := recordAssets(t)
+
+	warned := 0
+	originalWarning := VerifyWarning
+	VerifyWarning = func(string) { warned++ }
+	defer func() { VerifyWarning = originalWarning }()
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783",
+	}, t.TempDir(), nil, nil)
+	if err != nil {
+		t.Fatalf("Install() of a version with no digest failed: %v", err)
+	}
+
+	if len(*got) != 1 || (*got)[0].SHA256 != "" {
+		t.Errorf("got %v, want one asset with no digest", *got)
+	}
+	if warned != 1 {
+		t.Errorf("VerifyWarning was called %d times, want 1", warned)
+	}
+}
+
+func TestInstallWithNoPinTakesTheDigestsItFinds(t *testing.T) {
+	serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz": "abcd",
+	})
+	got := recordAssets(t)
+
+	err := Install(context.Background(), Target{
+		Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783",
+	}, t.TempDir(), nil, nil)
+	if err != nil {
+		t.Fatalf("Install() of a version with no digest failed: %v", err)
+	}
+
+	if len(*got) != 1 || (*got)[0].SHA256 != "abcd" {
+		t.Errorf("got %v, want one asset with the digest from the manifest", *got)
+	}
+}
+
+func TestDefaultTag(t *testing.T) {
+	original := DefaultVersion
+	defer func() { DefaultVersion = original }()
+
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{version: "", want: ""},
+		{version: "b10783", want: "b10783"},
+		{version: "b10783@sha256:" + aDigest, want: "b10783"},
+		{version: "b10783@sha256:nonsense", want: ""},
+	}
+
+	for _, tt := range tests {
+		DefaultVersion = tt.version
+		if got := DefaultTag(); got != tt.want {
+			t.Errorf("DefaultTag() with DefaultVersion %q = %q, want %q", tt.version, got, tt.want)
+		}
+	}
+}

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -365,6 +365,13 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 		opt(&options)
 	}
 
+	// An empty version takes the release pinned by this yzma release. That value can
+	// carry a digest of its own, so it goes in before the version is parsed. "latest"
+	// always asks for the newest build, so it skips the pin.
+	if target.Version == "" && DefaultVersion != "" {
+		target.Version = DefaultVersion
+	}
+
 	// The digest comes off the version before anything validates the version or
 	// builds a URL from it.
 	tag, digest, err := ParsePinnedVersion(target.Version)
@@ -388,12 +395,6 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 			return ErrVerifyDisabled
 		}
 		options.verify = VerifyRequired
-	}
-
-	// An empty version takes the release pinned by this yzma release. "latest" always
-	// asks for the newest build, so it skips the pin.
-	if target.Version == "" && DefaultVersion != "" {
-		target.Version = DefaultVersion
 	}
 
 	autoVersion := target.Version == "" || target.Version == "latest"

--- a/pkg/download/version.go
+++ b/pkg/download/version.go
@@ -4,6 +4,22 @@ package download
 // version is asked for. An empty value means the most recent nightly build, which
 // is the state on the main branch between yzma releases.
 //
-// Set it to the llama.cpp tag for the release in the same commit that bumps
-// version.go, then set it back to "" after the release is tagged.
+// It holds the complete pin, "<tag>@sha256:<manifest digest>", so that the default
+// install authenticates its digest manifest. The llama-cpp-builder release notes for
+// the tag print that value, and so does
+// https://hybridgroup.github.io/llama-cpp-builder/version.json for the newest build.
+//
+// Set it in the same commit that bumps version.go, then set it back to "" after the
+// release is tagged.
 var DefaultVersion = ""
+
+// DefaultTag gives [DefaultVersion] without its digest, which is the value to show a
+// person. It gives "" when there is no default version.
+func DefaultTag() string {
+	tag, _, err := ParsePinnedVersion(DefaultVersion)
+	if err != nil {
+		return ""
+	}
+
+	return tag
+}


### PR DESCRIPTION
Fixes #327. Needs hybridgroup/llama-cpp-builder#43, which publishes the values this reads.

The issue asks for a sidecar `digests/<tag>.json.sha256`. The builder PR does it with what GitHub already provides instead: the manifest is an asset of the release it describes, and GitHub records the SHA-256 of every asset it stores. This is the yzma side of that.

## Changes

- `fetchManifest` reads the manifest from the release asset first and keeps the site that serves the version files as the fallback. Both copies hold the same bytes, so a pin checks either one, and a location that does not answer only costs the try.
- `ManifestDigest` and `PinnedVersion` give a caller the value to pin. They read the version files first, which costs no GitHub API request, and fall back to the release API for any other tag. A release that published no manifest gives `ErrNoManifestDigest`, which is an answer and not a failure.
- `DefaultVersion` now holds the complete pin, `<tag>@sha256:<digest>`. That needed a fix in `Install`: the default version went in *after* the digest came off the version, so a pinned default reached `VersionIsValid` with the digest still attached and failed. `yzma install` and the installer example print the tag, not the pin.
- The version files carry two new optional fields, and one function reads both files now instead of two copies of the same code.
- `INSTALL.md`, `cmd/README.md` and the package documentation say where the manifest digest is published, and state that a platform archive digest is not it.

## A version with no digest is unaffected

`--version v0.4.0`, `--version b10816`, `--version latest` and a bare `yzma install` all behave as before. Only a pin makes the manifest mandatory; without one, a manifest that cannot be read still installs with whatever digests it has under the policy in force. There are tests for each of those paths, and `TestMain` now points every place a digest comes from at an address that answers nothing, so no test reaches the network.

## Verified against the real releases

- Pinned install of `b10816@sha256:99c247e5...` through the site fallback and, after the back-fill, through the release asset. `yzma verify --strict` reports 75 verified, 0 changed both times.
- Pinned install of `v0.4.0@sha256:b95e8680...`, which also exercises the `nightly-tag.txt` lookup for the upstream assets.
- One wrong hexadecimal character fails with `ErrDigestMismatch` before anything is extracted.
- `PinnedVersion` returns the pin for b10809, b10816 and v0.4.0, and `ErrNoManifestDigest` for v0.3.0, which has no manifest asset.