### PR TITLE
Release 1.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ $ go run ./examples/hello/
 
 You can use the convenient `yzma` command line tool to download the `llama.cpp` prebuilt libraries for your platform. You can also have your application self-download them automatically at installation time, including auto-detection for CUDA and ROCm.
 
+Each file that comes down is checked against the SHA-256 digest that the release publishes, and the `yzma verify` command checks an installation later. See [Checking what comes down](./INSTALL.md#checking-what-comes-down).
+
 See [INSTALL.md](./INSTALL.md) for installation instructions for [macOS](./INSTALL.md#macos), [Linux](./INSTALL.md#linux), and [Windows](./INSTALL.md#windows).
 
 We also have specific information on running `yzma` on [Raspberry Pi](./INSTALL.md#raspberry-pi), [NVIDIA Jetson Orin](./INSTALL.md#nvidia-jetson-orin), and the [Arduino UNO Q](./INSTALL.md#arduino-uno-q).
@@ -220,6 +222,7 @@ Sometimes there are breaking changes to `llama.cpp` that require an update to `y
 | llama.cpp | yzma    |
 | ------- | --------- |
 | v0.3.0 | v1.25.0   |
+| v0.4.0 | v1.26.0   |
 
 A tagged release of `yzma` installs its own `llama.cpp` release by default, so `yzma install` without the `-version` flag gets the version in this table. Use `-version latest` to get the most recent nightly build instead. A build from the `main` branch always uses the most recent nightly build.
 

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -862,6 +862,11 @@ func TestGetWithContext_FallbackToPreviousVersion(t *testing.T) {
 		previousVersionURL = originalPrev
 	}()
 
+	// An empty version must ask the version server, as a development build does.
+	originalDefault := DefaultVersion
+	DefaultVersion = ""
+	defer func() { DefaultVersion = originalDefault }()
+
 	// Override getFunc to use our test server
 	originalGet := getFunc
 	getFunc = func(ctx context.Context, asset Asset, dest string, progress getter.ProgressTracker) error {

--- a/pkg/download/version.go
+++ b/pkg/download/version.go
@@ -11,7 +11,7 @@ package download
 //
 // Set it in the same commit that bumps version.go, then set it back to "" after the
 // release is tagged.
-var DefaultVersion = ""
+var DefaultVersion = "v0.4.0@sha256:b95e8680b4d30761492bbc2d4a6fed656f124c5756dd4387cf02c30d27c13d90"
 
 // DefaultTag gives [DefaultVersion] without its digest, which is the value to show a
 // person. It gives "" when there is no default version.

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package main
 
-const currentVersion = "1.25.0"
+const currentVersion = "1.26.0"
 
 // Version returns the current version of the yzma package.
 func Version() string {


### PR DESCRIPTION
This prepares the v1.26.0 release.

- Set the version to 1.26.0.
- Pin `download.DefaultVersion` to `v0.4.0@sha256:b95e8680...c13d90`, so an install
  with no version gets the llama.cpp release that this yzma release was tested with,
  and checks the digest of its manifest.
- Add `v0.4.0 / v1.26.0` to the table of tagged releases in the README.
- Say in the README that the installer checks the SHA-256 of each file, and that
  `yzma verify` checks an installation later.
- One test needs an empty `DefaultVersion`, because it tests what a development build
  does when no version is given.

Checks on the other documents found nothing to change:

- Hugging Face gives 201,992 GGUF models, so "over 201k" is still correct.
- The roadmap has 254 of 264 functions, which is 96.2%, so "over 96%" is still correct.
- The roadmap already shows ABI 6, and the README already describes the browser support.
- llama.cpp `v0.4.0` is nightly build `b10809`, so the row `b10780+ / v1.26.0+` in the
  table of nightly builds stays open until the next release.

Both copies of the `v0.4.0` manifest, the release asset and the copy on the pages site,
have the SHA-256 in the pin.
