### PR TITLE
download: do not read a digest mismatch as a file that is not there

### DIFF
--- a/pkg/download/digest_test.go
+++ b/pkg/download/digest_test.go
@@ -276,6 +276,36 @@ func TestInstallStopsOnADigestThatDoesNotAgree(t *testing.T) {
 	}
 }
 
+// A destination whose name holds "404" must not make a digest that does not agree
+// look like a file that is not there.
+func TestInstallStopsOnADigestThatDoesNotAgreeUnderA404Path(t *testing.T) {
+	body := createMockTarGz(t, "b10783")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Write(body)
+	}))
+	defer server.Close()
+
+	dest := filepath.Join(t.TempDir(), "build-404")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	asset := Asset{
+		URL:    server.URL + "/llama-b10783-bin-ubuntu-cpu-arm64.tar.gz",
+		SHA256: strings.Repeat("0", 64),
+	}
+
+	err := get(context.Background(), asset, dest, nil)
+	if !errors.Is(err, ErrDigestMismatch) {
+		t.Fatalf("get() = %v, want ErrDigestMismatch", err)
+	}
+	if errors.Is(err, ErrFileNotFound) {
+		t.Errorf("get() = %v, want no ErrFileNotFound", err)
+	}
+}
+
 func TestInstallAcceptsADigestThatAgrees(t *testing.T) {
 	body := createMockTarGz(t, "b10783")
 	sum := sha256.Sum256(body)

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -239,11 +239,7 @@ func get(ctx context.Context, asset Asset, dest string, progress getter.Progress
 
 	// Check if it's a .tar.gz file
 	if strings.HasSuffix(url, ".tar.gz") {
-		err := downloadAndExtractTarGz(asset, dest, progress)
-		if err != nil && strings.Contains(err.Error(), "404") {
-			return fmt.Errorf("%w: %s", ErrFileNotFound, url)
-		}
-		return err
+		return downloadAndExtractTarGz(asset, dest, progress)
 	}
 
 	// Use go-getter for other file types (e.g., .zip). go-getter checks the digest
@@ -265,13 +261,19 @@ func get(ctx context.Context, asset Asset, dest string, progress getter.Progress
 	}
 
 	if err := client.Get(); err != nil {
-		if strings.Contains(err.Error(), "404") {
+		if isNotFound(err) {
 			return fmt.Errorf("%w: %s", ErrFileNotFound, url)
 		}
 		return err
 	}
 
 	return nil
+}
+
+// isNotFound tells if go-getter stopped because the server answered 404. It reads the
+// message of go-getter, which gives no error value of its own.
+func isNotFound(err error) bool {
+	return strings.Contains(err.Error(), "bad response code: 404")
 }
 
 // downloadAndExtractTarGz downloads a .tar.gz file and extracts it to the destination directory.
@@ -291,9 +293,8 @@ func downloadAndExtractTarGz(asset Asset, dest string, progress getter.ProgressT
 	}
 
 	if err := client.Get(); err != nil {
-		// Check for 404 errors specifically
-		if strings.Contains(err.Error(), "404") {
-			return fmt.Errorf("404 not found: %s", url)
+		if isNotFound(err) {
+			return fmt.Errorf("%w: %s", ErrFileNotFound, url)
 		}
 		return err
 	}


### PR DESCRIPTION
The build on Windows failed in `TestInstallStopsOnADigestThatDoesNotAgree`:

```
digest_test.go:262: get() = could not download file: the requested llama.cpp version
may still be building for your platform.: http://127.0.0.1:55700/llama-b10783-bin-ubuntu-cpu-arm64.tar.gz,
want ErrDigestMismatch
```

This is not a problem of Windows. `get()` decided that a download was a 404 with
`strings.Contains(err.Error(), "404")`. The message of a digest that does not agree
holds the path of the file, so any destination path with `404` in it became
`ErrFileNotFound`. The temporary directory of the runner got such a random name.

The same failure comes on Linux with a temporary directory that holds `404`:

```
TMPDIR=/tmp/t404 go test ./pkg/download/ -run TestInstallStopsOnADigestThatDoesNotAgree
```

The fix reads the message of go-getter only, `bad response code: 404`. go-getter gives
no error value of its own. The tar.gz path now returns `ErrFileNotFound` itself, instead
of a `404 not found` string that `get()` had to match a second time.

`TestInstallStopsOnADigestThatDoesNotAgreeUnderA404Path` installs into a directory named
`build-404` and keeps the fault away.
