### PR TITLE
download: keep the manifest of an install, so a check needs no network

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -566,7 +566,8 @@ llama.cpp release that is newer than the one this yzma release pins.
 
 The archive is removed as soon as it is extracted, so a later check reads the files that
 are in place. `Install` writes `yzma-install.json` beside the libraries to say what it
-put there, and `VerifyInstall` checks them:
+put there, and `yzma-manifest.json` to keep the digests of the release. `VerifyInstall`
+checks the files against them:
 
 ```go
 report, err := download.VerifyInstall(context.Background(), libPath, "")
@@ -584,7 +585,15 @@ can change the record. A tag makes the check resolve the assets of that release 
 instead of reading the tag from the record.
 
 A file that no asset of this install holds is reported as `FileUnexpected` and does not
-make `OK` false, because a directory can hold more than one install.
+make `OK` false, because a directory can hold more than one install. The record and the
+manifest belong to the install, so neither is counted.
+
+The check reads the manifest that the install kept, so it needs no network. The bytes are
+checked against the pin that the operator gives, or against the digest in the record when
+there is no pin, the same as at install time. A manifest that is not there, or that does
+not agree, makes the check fetch the manifest and keep what comes back. So an installation
+that an earlier release of yzma made needs one check with a network, and no check after
+that.
 
 The file digests come from the asset, so they are there only for the assets that
 `llama-cpp-builder` builds. An install from the `llama.cpp` release page gives

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -148,6 +148,9 @@ Notes:
 - `yzma install` writes `yzma-install.json` beside the libraries to say what it put
   there. `yzma verify` needs it, so an installation made by an older yzma has to be
   installed again first.
+- `yzma install` also writes `yzma-manifest.json`, which holds the digests of the
+  release, so `yzma verify` needs no network. An installation that has no manifest beside
+  it makes the command fetch one and keep it, so only the first check needs a network.
 - The record is beside the libraries, so anything that can change the libraries can
   change the record. Give `--version` to say which release must be there. The check then
   resolves the assets of that release itself and does not read the tag from the record.

--- a/pkg/download/digest.go
+++ b/pkg/download/digest.go
@@ -203,6 +203,13 @@ const maxManifestSize = 8 << 20
 // the version files. Both copies hold the same bytes, so a pin checks either one, and
 // a location that does not answer only costs the try.
 func fetchManifest(ctx context.Context, tag string, want string) (*manifest, error) {
+	m, _, err := fetchManifestBody(ctx, tag, want)
+	return m, err
+}
+
+// fetchManifestBody does the work of [fetchManifest] and gives the raw bytes as well, so
+// a caller can keep them for a later check.
+func fetchManifestBody(ctx context.Context, tag string, want string) (*manifest, []byte, error) {
 	var body []byte
 	var errs []error
 	for _, url := range []string{fmt.Sprintf(manifestAssetURL, tag), fmt.Sprintf(digestsURL, tag)} {
@@ -215,9 +222,21 @@ func fetchManifest(ctx context.Context, tag string, want string) (*manifest, err
 		break
 	}
 	if body == nil {
-		return nil, errors.Join(errs...)
+		return nil, nil, errors.Join(errs...)
 	}
 
+	m, err := parseManifest(body, tag, want)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return m, body, nil
+}
+
+// parseManifest checks the bytes of a manifest against a digest and then decodes them. A
+// want that is not empty is the expected SHA-256, in hexadecimal. The check is on the
+// bytes as they came, because that is what a pin names.
+func parseManifest(body []byte, tag string, want string) (*manifest, error) {
 	if want != "" {
 		sum := sha256.Sum256(body)
 		got := hex.EncodeToString(sum[:])
@@ -232,6 +251,27 @@ func fetchManifest(ctx context.Context, tag string, want string) (*manifest, err
 	}
 
 	return &m, nil
+}
+
+// loadCachedManifest reads the manifest that an install left in libPath. It gives false
+// when there is no manifest there, when the bytes do not agree with want, or when the
+// manifest is for another release. A caller then fetches the manifest instead.
+func loadCachedManifest(libPath string, tag string, want string) (*manifest, []byte, bool) {
+	body, err := ReadInstallManifest(libPath)
+	if err != nil {
+		return nil, nil, false
+	}
+
+	m, err := parseManifest(body, tag, want)
+	if err != nil {
+		return nil, nil, false
+	}
+
+	if m.Tag != tag {
+		return nil, nil, false
+	}
+
+	return m, body, true
 }
 
 // fetchManifestBytes reads a manifest from one URL.

--- a/pkg/download/digest_test.go
+++ b/pkg/download/digest_test.go
@@ -233,7 +233,7 @@ func TestResolveAssetsFromAPlainResolver(t *testing.T) {
 		return []string{"https://example.com/a.tar.gz"}, nil
 	})
 
-	assets, err := resolveAssets(context.Background(), Target{Version: "b10783"}, resolver, VerifyIfAvailable)
+	assets, _, err := resolveAssets(context.Background(), Target{Version: "b10783"}, resolver, VerifyIfAvailable)
 	if err != nil {
 		t.Fatalf("resolveAssets() failed: %v", err)
 	}

--- a/pkg/download/doc.go
+++ b/pkg/download/doc.go
@@ -90,5 +90,15 @@
 // has, with whatever digests the manifest gives, under the policy above. What it does
 // not have is a value from outside the release host to check the manifest against.
 //
+// # The manifest of an install
+//
+// [Install] keeps the manifest it read in the library directory, as yzma-manifest.json,
+// and puts its digest in the install record. [VerifyInstall] reads that copy and checks
+// the bytes against the pin the operator gives, or against the recorded digest when
+// there is no pin. A check of an installed release therefore needs no network. An
+// install that has no manifest beside it, or one whose bytes do not agree, makes the
+// check fetch the manifest as before and keep what comes back.
+//
+
 // See INSTALL.md for the longer version.
 package download

--- a/pkg/download/record.go
+++ b/pkg/download/record.go
@@ -12,6 +12,10 @@ import (
 // what it put there. [VerifyInstall] reads it.
 const InstallRecordName = "yzma-install.json"
 
+// InstallManifestName is the file that [Install] writes in the library directory to keep
+// the digest manifest of the release. [VerifyInstall] reads it in place of a fetch.
+const InstallManifestName = "yzma-manifest.json"
+
 // InstallRecord says which llama.cpp release is installed in a library directory, and
 // which assets it came from.
 //
@@ -33,14 +37,20 @@ type InstallRecord struct {
 	OS        string `json:"os"`
 	Processor string `json:"processor"`
 
+	// ManifestSHA256 is the digest of the manifest kept in [InstallManifestName], in
+	// hexadecimal. It is the pin when the install was pinned.
+	ManifestSHA256 string `json:"manifest_sha256,omitempty"`
+
 	Installed time.Time `json:"installed"`
 
 	// Assets are the assets that were downloaded, in the order they installed.
 	Assets []Asset `json:"assets"`
 }
 
-// recordVersion is the format of the records this release writes.
-const recordVersion = 1
+// recordVersion is the format of the records this release writes. Version 2 added the
+// manifest digest. A version 1 record has no digest and no manifest beside it, which
+// makes [VerifyInstall] fetch the manifest as before.
+const recordVersion = 2
 
 // WriteInstallRecord writes the record of an install into libPath.
 func WriteInstallRecord(libPath string, record InstallRecord) error {
@@ -73,6 +83,22 @@ func ReadInstallRecord(libPath string) (*InstallRecord, error) {
 	}
 
 	return &record, nil
+}
+
+// WriteInstallManifest keeps the raw digest manifest of a release in libPath. The bytes
+// are kept as they came, because a pin is the digest of those bytes.
+func WriteInstallManifest(libPath string, body []byte) error {
+	path := filepath.Join(libPath, InstallManifestName)
+	if err := os.WriteFile(path, body, 0644); err != nil {
+		return fmt.Errorf("failed to write the install manifest: %w", err)
+	}
+
+	return nil
+}
+
+// ReadInstallManifest reads the manifest that [Install] left in libPath.
+func ReadInstallManifest(libPath string) ([]byte, error) {
+	return os.ReadFile(filepath.Join(libPath, InstallManifestName))
 }
 
 // target rebuilds the [Target] that made an install.

--- a/pkg/download/resolver.go
+++ b/pkg/download/resolver.go
@@ -2,6 +2,8 @@ package download
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
@@ -72,15 +74,17 @@ func (defaultResolver) Resolve(target Target) ([]string, error) {
 // have that digest, and a manifest that cannot be read is an error rather than an
 // install with no check.
 func (r defaultResolver) ResolveAssets(target Target) ([]Asset, error) {
-	return r.resolveAssets(context.Background(), target)
+	assets, _, err := r.resolveAssets(context.Background(), target)
+	return assets, err
 }
 
 // resolveAssets does the work of [defaultResolver.ResolveAssets] under a context.
-// [AssetResolver] takes no context, so [Install] calls this to pass its own.
-func (r defaultResolver) resolveAssets(ctx context.Context, target Target) ([]Asset, error) {
+// [AssetResolver] takes no context, so [Install] calls this to pass its own. It also
+// gives the raw manifest bytes, which the install keeps for a later check.
+func (r defaultResolver) resolveAssets(ctx context.Context, target Target) ([]Asset, []byte, error) {
 	urls, err := defaultResolve(target)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	assets := make([]Asset, len(urls))
@@ -88,19 +92,19 @@ func (r defaultResolver) resolveAssets(ctx context.Context, target Target) ([]As
 		assets[i] = Asset{URL: url}
 	}
 
-	m, err := fetchManifest(ctx, target.Version, target.ManifestSHA256)
+	m, body, err := fetchManifestBody(ctx, target.Version, target.ManifestSHA256)
 	if err != nil {
 		if target.ManifestSHA256 != "" {
-			return nil, err
+			return nil, nil, err
 		}
-		return assets, nil
+		return assets, nil, nil
 	}
 
 	for i := range assets {
 		assets[i].SHA256 = m.digestFor(assets[i].URL)
 	}
 
-	return assets, nil
+	return assets, body, nil
 }
 
 // llama.cpp renamed its ROCm assets at these two builds.
@@ -420,9 +424,9 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 		target.UpstreamVersion = upstream
 	}
 
-	assets, err := installAssets(ctx, target, dest, progress, resolver, options)
+	assets, manifestBody, err := installAssets(ctx, target, dest, progress, resolver, options)
 	if err == nil {
-		return recordInstall(dest, target, assets)
+		return recordInstall(dest, target, assets, manifestBody)
 	}
 
 	// The newest release may still be building for this platform.
@@ -439,34 +443,44 @@ func Install(ctx context.Context, target Target, dest string, progress getter.Pr
 				return err
 			}
 		}
-		assets, err := installAssets(ctx, target, dest, progress, resolver, options)
+		assets, manifestBody, err := installAssets(ctx, target, dest, progress, resolver, options)
 		if err != nil {
 			return err
 		}
-		return recordInstall(dest, target, assets)
+		return recordInstall(dest, target, assets, manifestBody)
 	}
 
 	return err
 }
 
 // recordInstall leaves a record of what was installed, so [VerifyInstall] can check
-// the files later.
-func recordInstall(dest string, target Target, assets []Asset) error {
+// the files later. The manifest goes beside the record, so the check needs no network.
+func recordInstall(dest string, target Target, assets []Asset, manifestBody []byte) error {
+	var manifestDigest string
+	if len(manifestBody) > 0 {
+		if err := WriteInstallManifest(dest, manifestBody); err != nil {
+			return err
+		}
+		sum := sha256.Sum256(manifestBody)
+		manifestDigest = hex.EncodeToString(sum[:])
+	}
+
 	return WriteInstallRecord(dest, InstallRecord{
-		Tag:         target.Version,
-		UpstreamTag: target.UpstreamVersion,
-		Arch:        target.Arch.String(),
-		OS:          target.OS.String(),
-		Processor:   target.Processor.String(),
-		Installed:   time.Now().UTC(),
-		Assets:      assets,
+		Tag:            target.Version,
+		UpstreamTag:    target.UpstreamVersion,
+		Arch:           target.Arch.String(),
+		OS:             target.OS.String(),
+		Processor:      target.Processor.String(),
+		ManifestSHA256: manifestDigest,
+		Installed:      time.Now().UTC(),
+		Assets:         assets,
 	})
 }
 
-func installAssets(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver, options installOptions) ([]Asset, error) {
-	assets, err := resolveAssets(ctx, target, resolver, options.verify)
+func installAssets(ctx context.Context, target Target, dest string, progress getter.ProgressTracker, resolver Resolver, options installOptions) ([]Asset, []byte, error) {
+	assets, manifestBody, err := resolveAssets(ctx, target, resolver, options.verify)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, asset := range assets {
@@ -474,24 +488,27 @@ func installAssets(ctx context.Context, target Target, dest string, progress get
 		case options.verify == VerifyOff, asset.SHA256 != "":
 			// Nothing to say. A digest that is there is checked as it downloads.
 		case options.verify == VerifyRequired:
-			return nil, fmt.Errorf("%w: %s", ErrDigestMissing, asset.URL)
+			return nil, nil, fmt.Errorf("%w: %s", ErrDigestMissing, asset.URL)
 		case VerifyWarning != nil:
 			VerifyWarning(asset.URL)
 		}
 
 		if err := getFunc(ctx, asset, dest, progress); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return assets, nil
+	return assets, manifestBody, nil
 }
 
 // resolveAssets asks a resolver for the assets to install. A resolver that reports
 // digests is preferred, so a resolver that only has [Resolver] keeps working.
 // [VerifyOff] takes the plain [Resolver], because a digest that nothing reads is not
 // worth the fetch of a manifest.
-func resolveAssets(ctx context.Context, target Target, resolver Resolver, verify VerifyPolicy) ([]Asset, error) {
+//
+// It also gives the raw bytes of the manifest the digests came from, or none when no
+// manifest was read.
+func resolveAssets(ctx context.Context, target Target, resolver Resolver, verify VerifyPolicy) ([]Asset, []byte, error) {
 	// A pinned manifest is the authority for every asset, whichever resolver named
 	// them, so it is read here instead of in the resolver.
 	if target.ManifestSHA256 != "" {
@@ -504,13 +521,14 @@ func resolveAssets(ctx context.Context, target Target, resolver Resolver, verify
 			return d.resolveAssets(ctx, target)
 		}
 		if assetResolver, ok := resolver.(AssetResolver); ok {
-			return assetResolver.ResolveAssets(target)
+			assets, err := assetResolver.ResolveAssets(target)
+			return assets, nil, err
 		}
 	}
 
 	urls, err := resolver.Resolve(target)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	assets := make([]Asset, len(urls))
@@ -518,31 +536,31 @@ func resolveAssets(ctx context.Context, target Target, resolver Resolver, verify
 		assets[i] = Asset{URL: url}
 	}
 
-	return assets, nil
+	return assets, nil, nil
 }
 
 // pinnedAssets gives the assets to install when [Target.ManifestSHA256] pins the
 // digest manifest. The resolver names the assets and the pinned manifest gives the
 // digest of each one. An asset that the manifest does not name is an error.
-func pinnedAssets(ctx context.Context, target Target, resolver Resolver) ([]Asset, error) {
+func pinnedAssets(ctx context.Context, target Target, resolver Resolver) ([]Asset, []byte, error) {
 	urls, err := resolver.Resolve(target)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	m, err := fetchManifest(ctx, target.Version, target.ManifestSHA256)
+	m, body, err := fetchManifestBody(ctx, target.Version, target.ManifestSHA256)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	assets := make([]Asset, len(urls))
 	for i, url := range urls {
 		digest := m.digestFor(url)
 		if digest == "" {
-			return nil, fmt.Errorf("%w: %s is not in the pinned digests of %s", ErrDigestMissing, url, target.Version)
+			return nil, nil, fmt.Errorf("%w: %s is not in the pinned digests of %s", ErrDigestMissing, url, target.Version)
 		}
 		assets[i] = Asset{URL: url, SHA256: digest}
 	}
 
-	return assets, nil
+	return assets, body, nil
 }

--- a/pkg/download/verify.go
+++ b/pkg/download/verify.go
@@ -104,6 +104,10 @@ func (r *VerifyReport) OK() bool {
 // that must be there, which does not trust the record. The tag may carry the expected
 // digest of the digest manifest, in the form "b10785@sha256:<digest>", which does not
 // trust the site that serves the manifest either.
+//
+// An install keeps the manifest of its release beside the record, so a check needs no
+// network. The manifest is read again against the same digest, and a manifest that is
+// not there or does not agree is fetched as before.
 func VerifyInstall(ctx context.Context, libPath, tag string) (*VerifyReport, error) {
 	tag, manifestDigest, err := ParsePinnedVersion(tag)
 	if err != nil {
@@ -123,19 +127,34 @@ func VerifyInstall(ctx context.Context, libPath, tag string) (*VerifyReport, err
 		return nil, err
 	}
 
+	named := tag != ""
+	if !named {
+		tag = record.Tag
+	}
+
+	m, err := installManifest(ctx, libPath, record, tag, manifestDigest)
+	if err != nil {
+		return nil, err
+	}
+
 	// A caller that names a tag gets the assets of that tag, resolved again. The
 	// recorded URLs are never used then, because a record that says the wrong tag
 	// can name the wrong assets as easily.
 	assets := record.Assets
-	if tag != "" {
+	if named {
 		target.Version = tag
 		target.UpstreamVersion = ""
 		if IsTaggedRelease(tag) {
-			upstream, err := LlamaNightlyTag(tag)
-			if err != nil {
-				return nil, err
+			// The manifest names the nightly build that holds the binaries of a
+			// tagged release, so the release page is not necessary.
+			target.UpstreamVersion = m.UpstreamTag
+			if target.UpstreamVersion == "" {
+				upstream, err := LlamaNightlyTag(tag)
+				if err != nil {
+					return nil, err
+				}
+				target.UpstreamVersion = upstream
 			}
-			target.UpstreamVersion = upstream
 		}
 
 		urls, err := DefaultResolver.Resolve(target)
@@ -146,13 +165,6 @@ func VerifyInstall(ctx context.Context, libPath, tag string) (*VerifyReport, err
 		for i, url := range urls {
 			assets[i] = Asset{URL: url}
 		}
-	} else {
-		tag = record.Tag
-	}
-
-	m, err := fetchManifest(ctx, tag, manifestDigest)
-	if err != nil {
-		return nil, err
 	}
 
 	// Gather what the assets of this install should have put in the directory.
@@ -201,8 +213,8 @@ func VerifyInstall(ctx context.Context, libPath, tag string) (*VerifyReport, err
 		}
 		name = filepath.ToSlash(name)
 
-		// The record is not part of any asset.
-		if name == InstallRecordName {
+		// The record and the manifest are not part of any asset.
+		if name == InstallRecordName || name == InstallManifestName {
 			return nil
 		}
 
@@ -263,6 +275,51 @@ func VerifyInstall(ctx context.Context, libPath, tag string) (*VerifyReport, err
 	})
 
 	return report, nil
+}
+
+// installManifest gives the digest manifest of a release. The copy that the install left
+// beside the record comes first, so a check needs no network. A manifest that is not
+// there or does not agree with the digest is fetched, and what comes back is kept for the
+// next check.
+func installManifest(ctx context.Context, libPath string, record *InstallRecord, tag, want string) (*manifest, error) {
+	// A caller that gives no digest gets the one the install recorded, so a manifest
+	// that changed on disk is not trusted.
+	cached := want
+	if cached == "" {
+		cached = record.ManifestSHA256
+	}
+	if m, _, ok := loadCachedManifest(libPath, tag, cached); ok {
+		return m, nil
+	}
+
+	m, body, err := fetchManifestBody(ctx, tag, want)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheManifest(libPath, record, tag, body)
+
+	return m, nil
+}
+
+// cacheManifest keeps a manifest beside the install record. It only makes the next check
+// faster, so a directory that cannot be written gives no error.
+func cacheManifest(libPath string, record *InstallRecord, tag string, body []byte) {
+	if record.Tag != tag {
+		return
+	}
+	if err := WriteInstallManifest(libPath, body); err != nil {
+		return
+	}
+
+	sum := sha256.Sum256(body)
+	digest := hex.EncodeToString(sum[:])
+	if strings.EqualFold(record.ManifestSHA256, digest) {
+		return
+	}
+
+	record.ManifestSHA256 = digest
+	_ = WriteInstallRecord(libPath, *record)
 }
 
 // add puts one result in the report and counts it.

--- a/pkg/download/verify_test.go
+++ b/pkg/download/verify_test.go
@@ -1,12 +1,12 @@
 package download
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -60,29 +60,63 @@ func writeBundle(t *testing.T) installedBundle {
 	return bundle
 }
 
-// serveBundleManifest publishes a manifest that describes a bundle, and writes the
-// install record that points at it.
-func serveBundleManifest(t *testing.T, bundle installedBundle, tag string) {
+// bundleManifest gives the manifest that describes a bundle, and the assets it covers.
+// The assets are the ones the resolver names, so a check that resolves them again finds
+// the same ones. upstream is the nightly build that holds the binaries of a tagged
+// release, and is empty for a nightly tag.
+func bundleManifest(t *testing.T, bundle installedBundle, tag, upstream string) ([]byte, []Asset) {
 	t.Helper()
 
-	const assetName = "llama-%s-bin-ubuntu-cpu-arm64.tar.gz"
-	name := fmt.Sprintf(assetName, tag)
-
-	body, err := json.Marshal(manifest{
-		Version: 1,
-		Tag:     tag,
-		Sources: map[string]manifestSource{
-			"hybridgroup/llama-cpp-builder": {
-				Tag: tag,
-				Assets: map[string]manifestAsset{
-					name: {SHA256: "aaaa", Files: bundle.files, Links: bundle.links},
-				},
-			},
-		},
+	urls, err := defaultResolve(Target{
+		Arch: ARM64, OS: Linux, Processor: CPU, Version: tag, UpstreamVersion: upstream,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	sources := map[string]manifestSource{}
+	assets := make([]Asset, len(urls))
+	for i, url := range urls {
+		parts := assetURLPattern.FindStringSubmatch(url)
+		if parts == nil {
+			t.Fatalf("cannot read the asset URL %s", url)
+		}
+
+		source := sources[parts[1]]
+		source.Tag = parts[2]
+		if source.Assets == nil {
+			source.Assets = map[string]manifestAsset{}
+		}
+
+		// Only the first asset holds the bundle.
+		entry := manifestAsset{SHA256: "aaaa"}
+		if i == 0 {
+			entry.Files, entry.Links = bundle.files, bundle.links
+		}
+		source.Assets[parts[3]] = entry
+		sources[parts[1]] = source
+
+		assets[i] = Asset{URL: url}
+	}
+
+	upstreamTag := upstream
+	if upstreamTag == "" {
+		upstreamTag = tag
+	}
+
+	body, err := json.Marshal(manifest{
+		Version: 1, Tag: tag, UpstreamTag: upstreamTag, Sources: sources,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return body, assets
+}
+
+// serveManifestBody publishes manifest bytes for the length of the test.
+func serveManifestBody(t *testing.T, body []byte) *httptest.Server {
+	t.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(body)
@@ -93,15 +127,61 @@ func serveBundleManifest(t *testing.T, bundle installedBundle, tag string) {
 	digestsURL = server.URL + "/digests/%s.json"
 	t.Cleanup(func() { digestsURL = original })
 
+	return server
+}
+
+// writeBundleRecord writes the install record of a bundle.
+func writeBundleRecord(t *testing.T, bundle installedBundle, tag, upstream string, assets []Asset, manifestDigest string) {
+	t.Helper()
+
 	record := InstallRecord{
-		Tag: tag, Arch: "arm64", OS: "linux", Processor: "cpu",
-		Assets: []Asset{{
-			URL: fmt.Sprintf("https://github.com/hybridgroup/llama-cpp-builder/releases/download/%s/%s", tag, name),
-		}},
+		Tag: tag, UpstreamTag: upstream, Arch: "arm64", OS: "linux", Processor: "cpu",
+		ManifestSHA256: manifestDigest, Assets: assets,
 	}
 	if err := WriteInstallRecord(bundle.libPath, record); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// serveBundleManifest publishes a manifest that describes a bundle, and writes the
+// install record that points at it. The record has no manifest beside it, as the records
+// that earlier releases wrote do.
+func serveBundleManifest(t *testing.T, bundle installedBundle, tag string) (*httptest.Server, []byte) {
+	t.Helper()
+
+	body, assets := bundleManifest(t, bundle, tag, "")
+	server := serveManifestBody(t, body)
+	writeBundleRecord(t, bundle, tag, "", assets, "")
+
+	return server, body
+}
+
+// installBundle writes the record and the manifest that an install leaves beside a
+// bundle, and gives the digest of the manifest to pin with. Nothing is published, so a
+// check that reaches the network fails.
+func installBundle(t *testing.T, bundle installedBundle, tag, upstream string) string {
+	t.Helper()
+
+	body, assets := bundleManifest(t, bundle, tag, upstream)
+	sum := sha256.Sum256(body)
+	digest := hex.EncodeToString(sum[:])
+
+	writeBundleRecord(t, bundle, tag, upstream, assets, digest)
+	if err := WriteInstallManifest(bundle.libPath, body); err != nil {
+		t.Fatal(err)
+	}
+
+	return digest
+}
+
+// blockNightlyTag points the nightly tag asset at a port that answers nothing, so a
+// lookup that must not happen fails the test rather than reaching GitHub.
+func blockNightlyTag(t *testing.T) {
+	t.Helper()
+
+	original := nightlyTagURL
+	nightlyTagURL = "http://127.0.0.1:0/%s/nightly-tag.txt"
+	t.Cleanup(func() { nightlyTagURL = original })
 }
 
 func TestVerifyInstallOnAnUntouchedInstall(t *testing.T) {
@@ -283,6 +363,159 @@ func TestVerifyInstallWithARecordForAnotherRelease(t *testing.T) {
 	_, err = VerifyInstall(context.Background(), bundle.libPath, "")
 	if !errors.Is(err, ErrRecordMismatch) {
 		t.Errorf("VerifyInstall() = %v, want ErrRecordMismatch", err)
+	}
+}
+
+func TestVerifyInstallReadsTheManifestBesideTheRecord(t *testing.T) {
+	bundle := writeBundle(t)
+	installBundle(t, bundle, "b10783", "")
+
+	// Nothing is published, so a fetch of the manifest fails the test.
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "")
+	if err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+	if !report.OK() {
+		t.Errorf("report is not OK: %+v", report)
+	}
+	// The manifest belongs to the install, the same as the record.
+	if report.Unexpected != 0 {
+		t.Errorf("Unexpected = %d, want 0", report.Unexpected)
+	}
+}
+
+func TestVerifyInstallOfAPinnedTaggedReleaseNeedsNoNetwork(t *testing.T) {
+	blockNightlyTag(t)
+
+	bundle := writeBundle(t)
+	digest := installBundle(t, bundle, "v0.4.0", "b10783")
+
+	// The manifest names the nightly build, so neither it nor the release page is
+	// fetched.
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "v0.4.0@sha256:"+digest)
+	if err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+	if !report.OK() {
+		t.Errorf("report is not OK: %+v", report)
+	}
+	if report.Tag != "v0.4.0" {
+		t.Errorf("Tag = %q, want v0.4.0", report.Tag)
+	}
+}
+
+func TestVerifyInstallFetchesWhenTheManifestOnDiskIsBad(t *testing.T) {
+	bundle := writeBundle(t)
+	installBundle(t, bundle, "b10783", "")
+	body, _ := bundleManifest(t, bundle, "b10783", "")
+	serveManifestBody(t, body)
+
+	if err := WriteInstallManifest(bundle.libPath, []byte("not a manifest")); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "")
+	if err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+	if !report.OK() {
+		t.Errorf("report is not OK: %+v", report)
+	}
+}
+
+func TestVerifyInstallIgnoresAManifestForAnotherRelease(t *testing.T) {
+	bundle := writeBundle(t)
+	installBundle(t, bundle, "b10783", "")
+	body, _ := bundleManifest(t, bundle, "b10783", "")
+	serveManifestBody(t, body)
+
+	// A manifest of another release does not describe this install, even when the
+	// bytes are whole.
+	other, _ := bundleManifest(t, bundle, "b10780", "")
+	if err := WriteInstallManifest(bundle.libPath, other); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "")
+	if err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+	if !report.OK() {
+		t.Errorf("report is not OK: %+v", report)
+	}
+}
+
+func TestVerifyInstallKeepsTheManifestItFetches(t *testing.T) {
+	bundle := writeBundle(t)
+	server, body := serveBundleManifest(t, bundle, "b10783")
+
+	before, err := ReadInstallRecord(bundle.libPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := VerifyInstall(context.Background(), bundle.libPath, ""); err != nil {
+		t.Fatalf("VerifyInstall() failed: %v", err)
+	}
+
+	kept, err := ReadInstallManifest(bundle.libPath)
+	if err != nil {
+		t.Fatalf("the manifest was not kept: %v", err)
+	}
+	if !bytes.Equal(kept, body) {
+		t.Error("the manifest that was kept is not the one that was fetched")
+	}
+
+	sum := sha256.Sum256(body)
+	record, err := ReadInstallRecord(bundle.libPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.ManifestSHA256 != hex.EncodeToString(sum[:]) {
+		t.Errorf("record ManifestSHA256 = %q, want the digest of the manifest", record.ManifestSHA256)
+	}
+	if !record.Installed.Equal(before.Installed) || len(record.Assets) != len(before.Assets) {
+		t.Errorf("record = %+v, want the rest of it unchanged", record)
+	}
+
+	// The next check reads what was kept.
+	server.Close()
+	report, err := VerifyInstall(context.Background(), bundle.libPath, "")
+	if err != nil {
+		t.Fatalf("VerifyInstall() after the manifest was kept failed: %v", err)
+	}
+	if !report.OK() {
+		t.Errorf("report is not OK: %+v", report)
+	}
+}
+
+func TestInstallKeepsTheManifest(t *testing.T) {
+	manifestDigest := serveManifest(t, "b10783", map[string]string{
+		"llama-b10783-bin-ubuntu-cpu-arm64.tar.gz": "abcd",
+	})
+	recordAssets(t)
+
+	dest := t.TempDir()
+	target := Target{Arch: ARM64, OS: Linux, Processor: CPU, Version: "b10783@sha256:" + manifestDigest}
+	if err := Install(context.Background(), target, dest, nil, nil); err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+
+	body, err := ReadInstallManifest(dest)
+	if err != nil {
+		t.Fatalf("the manifest was not kept: %v", err)
+	}
+	sum := sha256.Sum256(body)
+	if got := hex.EncodeToString(sum[:]); got != manifestDigest {
+		t.Errorf("the manifest that was kept has the digest %s, want %s", got, manifestDigest)
+	}
+
+	record, err := ReadInstallRecord(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.ManifestSHA256 != manifestDigest {
+		t.Errorf("record ManifestSHA256 = %q, want %s", record.ManifestSHA256, manifestDigest)
 	}
 }
 


### PR DESCRIPTION
`VerifyInstall` fetched the digest manifest every time, and looked up the nightly build tag of a tagged release as well. A check of an installed bundle therefore needed GitHub, and paid the latency on every start.

Install now keeps the manifest it read beside the install record, as `yzma-manifest.json`, and puts the digest of it in the record. `VerifyInstall` reads that copy and checks the bytes against the pin the operator gives, or against the recorded digest when there is no pin, so the trust is the same as before. The manifest also names the nightly build of a tagged release, which removes the second fetch.

A manifest that is not there, or that does not agree, makes the check fetch one as before and keep what comes back. So an installation that an earlier release made needs one check with a network, and none after that.

Fixes #334