### PR TITLE
Release 1.26.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Sometimes there are breaking changes to `llama.cpp` that require an update to `y
 | llama.cpp | yzma    |
 | ------- | --------- |
 | v0.3.0 | v1.25.0   |
-| v0.4.0 | v1.26.0   |
+| v0.4.0 | v1.26.0 - v1.26.1   |
 
 A tagged release of `yzma` installs its own `llama.cpp` release by default, so `yzma install` without the `-version` flag gets the version in this table. Use `-version latest` to get the most recent nightly build instead. A build from the `main` branch always uses the most recent nightly build.
 

--- a/pkg/download/version.go
+++ b/pkg/download/version.go
@@ -11,7 +11,7 @@ package download
 //
 // Set it in the same commit that bumps version.go, then set it back to "" after the
 // release is tagged.
-var DefaultVersion = ""
+var DefaultVersion = "v0.4.0@sha256:b95e8680b4d30761492bbc2d4a6fed656f124c5756dd4387cf02c30d27c13d90"
 
 // DefaultTag gives [DefaultVersion] without its digest, which is the value to show a
 // person. It gives "" when there is no default version.

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package main
 
-const currentVersion = "1.26.0"
+const currentVersion = "1.26.1"
 
 // Version returns the current version of the yzma package.
 func Version() string {


### PR DESCRIPTION
Keep the `llama.cpp` pin of this release at v0.4.0, with the digest of its manifest. Show the release in the version table in the README.

This release makes `yzma verify` read the manifest that the install kept, so a check needs no network.

After the tag is made, set `DefaultVersion` back to `""` so that the main branch takes the newest nightly build again.