### PR TITLE
download: use newest nightly llama.cpp build again

### DIFF
--- a/pkg/download/version.go
+++ b/pkg/download/version.go
@@ -11,7 +11,7 @@ package download
 //
 // Set it in the same commit that bumps version.go, then set it back to "" after the
 // release is tagged.
-var DefaultVersion = "v0.4.0@sha256:b95e8680b4d30761492bbc2d4a6fed656f124c5756dd4387cf02c30d27c13d90"
+var DefaultVersion = ""
 
 // DefaultTag gives [DefaultVersion] without its digest, which is the value to show a
 // person. It gives "" when there is no default version.


### PR DESCRIPTION
v1.26.1 is tagged, so a build from the main branch must install the most recent nightly build of `llama.cpp` again. The next release sets the pin.